### PR TITLE
bug fix: properly handle zero-results 

### DIFF
--- a/pyvo/dal/query.py
+++ b/pyvo/dal/query.py
@@ -598,11 +598,11 @@ class Record(object):
         self._fdesc = fielddesc
         if not self._fdesc: 
             self._fdesc = {}
-        if results:
-            self.rec = results.votable.array.data[index]
-            if fielddesc is None:
-                for fld in results.fieldnames():
-                    self._fdesc[fld] = results.getdesc(fld)
+
+        self.rec = results.votable.array.data[index]
+        if fielddesc is None:
+            for fld in results.fieldnames():
+                self._fdesc[fld] = results.getdesc(fld)
 
     def __len__(self):
         return len(self.rec.dtype.names)


### PR DESCRIPTION
bug was introduced when dal.query.Record was changed to rap the actual numpy recarray containing the data.  When there were no results, iterating would erroneously create a first record.  

(SIAResults.**len**() effects bool(SIAResults))
