### PR TITLE
Small style fix: s->session

### DIFF
--- a/pyvo/dal/adhoc.py
+++ b/pyvo/dal/adhoc.py
@@ -20,7 +20,7 @@ from astropy.io.votable.tree import Resource, Group
 from astropy.utils.collections import HomogeneousList
 
 from ..utils.decorators import stream_decode_content
-from ..utils.http import session as s
+from ..utils.http import session
 
 
 # monkeypatch astropy with group support in RESOURCE
@@ -182,7 +182,7 @@ class DatalinkRecordMixin(object):
     def getdataset(self, timeout=None):
         try:
             url = next(self.getdatalink().bysemantics('#this')).access_url
-            r = s.get(url, stream=True, timeout=timeout)
+            r = session.get(url, stream=True, timeout=timeout)
             r.raise_for_status()
             return r.raw
         except (DALServiceError, ValueError, StopIteration):

--- a/pyvo/dal/adhoc.py
+++ b/pyvo/dal/adhoc.py
@@ -182,9 +182,9 @@ class DatalinkRecordMixin(object):
     def getdataset(self, timeout=None):
         try:
             url = next(self.getdatalink().bysemantics('#this')).access_url
-            r = session.get(url, stream=True, timeout=timeout)
-            r.raise_for_status()
-            return r.raw
+            response = session.get(url, stream=True, timeout=timeout)
+            response.raise_for_status()
+            return response.raw
         except (DALServiceError, ValueError, StopIteration):
             # this should go to Record.getdataset()
             return super(DatalinkRecordMixin, self).getdataset(timeout=timeout)

--- a/pyvo/dal/mimetype.py
+++ b/pyvo/dal/mimetype.py
@@ -77,15 +77,15 @@ def mime_object_maker(url, mimetype):
         return session.get(url).text
 
     if mimetype[1] == 'fits' or mimetype[1] == 'x-fits':
-        r = session.get(url)
-        return HDUList.fromstring(r.content)
+        response = session.get(url)
+        return HDUList.fromstring(response.content)
 
     if mimetype[0] == 'image':
         from PIL import Image
         from io import BytesIO
-        r = session.get(url)
-        b = BytesIO(r.content)
-        return Image.open(b)
+        response = session.get(url)
+        bio = BytesIO(response.content)
+        return Image.open(bio)
 
     if mimetype[1] == 'x-votable' or mimetype[1] == 'x-votable+xml':
         # As soon as there are some kind of recursive data structures,

--- a/pyvo/dal/mimetype.py
+++ b/pyvo/dal/mimetype.py
@@ -10,7 +10,7 @@ import six
 
 from astropy.io.fits import HDUList
 
-from ..utils.http import session as s
+from ..utils.http import session
 
 
 mimetypes.add_type('application/fits', 'fits')
@@ -74,16 +74,16 @@ def mime_object_maker(url, mimetype):
     mimetype = mimeparse.parse_mime_type(mimetype)
 
     if mimetype[0] == 'text':
-        return s.get(url).text
+        return session.get(url).text
 
     if mimetype[1] == 'fits' or mimetype[1] == 'x-fits':
-        r = s.get(url)
+        r = session.get(url)
         return HDUList.fromstring(r.content)
 
     if mimetype[0] == 'image':
         from PIL import Image
         from io import BytesIO
-        r = s.get(url)
+        r = session.get(url)
         b = BytesIO(r.content)
         return Image.open(b)
 

--- a/pyvo/dal/query.py
+++ b/pyvo/dal/query.py
@@ -49,7 +49,7 @@ from .exceptions import (DALFormatError, DALServiceError, DALQueryError)
 from .. import samp
 
 from ..utils.decorators import stream_decode_content
-from ..utils.http import session as s
+from ..utils.http import session
 
 
 class DALService(object):
@@ -202,7 +202,7 @@ class DALQuery(dict):
         url = self.queryurl
         params = {k: v for k, v in self.items()}
 
-        r = s.get(url, params=params, stream=True)
+        r = session.get(url, params=params, stream=True)
         return r
 
     def execute_votable(self):
@@ -262,7 +262,7 @@ class DALResults(object):
     @classmethod
     @stream_decode_content
     def _from_result_url(cls, result_url):
-        return s.get(result_url, stream=True).raw
+        return session.get(result_url, stream=True).raw
 
     @classmethod
     def from_result_url(cls, result_url):
@@ -742,9 +742,9 @@ class Record(Mapping):
             raise KeyError("no dataset access URL recognized in record")
 
         if timeout:
-            r = s.get(url, stream=True, timeout=timeout)
+            r = session.get(url, stream=True, timeout=timeout)
         else:
-            r = s.get(url, stream=True)
+            r = session.get(url, stream=True)
 
         r.raise_for_status()
         return r.raw

--- a/pyvo/dal/query.py
+++ b/pyvo/dal/query.py
@@ -185,15 +185,15 @@ class DALQuery(dict):
         No exceptions are raised here because non-2xx responses might still
         contain payload. They can be raised later by calling ``raise_if_error``
         """
-        r = self.submit()
+        response = self.submit()
 
         try:
-            r.raise_for_status()
+            response.raise_for_status()
         except requests.RequestException as ex:
             # save for later use
             self._ex = ex
         finally:
-            return r.raw
+            return response.raw
 
     def submit(self):
         """
@@ -202,8 +202,8 @@ class DALQuery(dict):
         url = self.queryurl
         params = {k: v for k, v in self.items()}
 
-        r = session.get(url, params=params, stream=True)
-        return r
+        response = session.get(url, params=params, stream=True)
+        return response
 
     def execute_votable(self):
         """
@@ -742,12 +742,12 @@ class Record(Mapping):
             raise KeyError("no dataset access URL recognized in record")
 
         if timeout:
-            r = session.get(url, stream=True, timeout=timeout)
+            response = session.get(url, stream=True, timeout=timeout)
         else:
-            r = session.get(url, stream=True)
+            response = session.get(url, stream=True)
 
-        r.raise_for_status()
-        return r.raw
+        response.raise_for_status()
+        return response.raw
 
     def cachedataset(self, filename=None, dir=".", timeout=None, bufsize=None):
         """

--- a/pyvo/dal/tap.py
+++ b/pyvo/dal/tap.py
@@ -25,7 +25,7 @@ from ..io import vosi, uws
 from ..io.vosi import tapregext as tr
 
 from ..utils.formatting import para_format_desc
-from ..utils.http import session as s
+from ..utils.http import session
 
 __all__ = [
     "search", "escape", "TAPService", "TAPQuery", "AsyncTAPJob", "TAPResults"]
@@ -100,7 +100,7 @@ class TAPService(DALService, AvailabilityMixin, CapabilityMixin):
         if self._tables is None:
             tables_url = '{0}/tables'.format(self.baseurl)
 
-            response = s.get(tables_url, stream=True)
+            response = session.get(tables_url, stream=True)
 
             try:
                 response.raise_for_status()
@@ -397,13 +397,13 @@ class AsyncTAPJob(object):
         """
         try:
             if wait_for_statechange:
-                response = s.get(
+                response = session.get(
                     self.url, stream=True, timeout=timeout, params={
                         "WAIT": "-1"
                     }
                 )
             else:
-                response = s.get(self.url, stream=True, timeout=timeout)
+                response = session.get(self.url, stream=True, timeout=timeout)
             response.raise_for_status()
         except requests.RequestException as ex:
             raise DALServiceError.from_except(ex, self.url)
@@ -455,7 +455,7 @@ class AsyncTAPJob(object):
     @execution_duration.setter
     def execution_duration(self, value):
         try:
-            response = s.post(
+            response = session.post(
                 "{}/executionduration".format(self.url),
                 data={"EXECUTIONDURATION": str(value)})
             response.raise_for_status()
@@ -491,7 +491,7 @@ class AsyncTAPJob(object):
             pass
 
         try:
-            response = s.post(
+            response = session.post(
                 "{}/destruction".format(self.url),
                 data={"DESTRUCTION": value.strftime("%Y-%m-%dT%H:%M:%SZ")})
             response.raise_for_status()
@@ -530,7 +530,7 @@ class AsyncTAPJob(object):
     @query.setter
     def query(self, query):
         try:
-            response = s.post(
+            response = session.post(
                 '{}/parameters'.format(self.url),
                 data={"QUERY": query})
             response.raise_for_status()
@@ -551,7 +551,7 @@ class AsyncTAPJob(object):
         }
 
         try:
-            response = s.post(
+            response = session.post(
                 '{}/parameters'.format(self.url),
                 data={'UPLOAD': uploads.param()},
                 files=files
@@ -606,7 +606,7 @@ class AsyncTAPJob(object):
         starts the job / change phase to RUN
         """
         try:
-            response = s.post(
+            response = session.post(
                 '{}/phase'.format(self.url), data={"PHASE": "RUN"})
             response.raise_for_status()
         except requests.RequestException as ex:
@@ -619,7 +619,7 @@ class AsyncTAPJob(object):
         aborts the job / change phase to ABORT
         """
         try:
-            response = s.post(
+            response = session.post(
                 '{}/phase'.format(self.url), data={"PHASE": "ABORT"})
             response.raise_for_status()
         except requests.RequestException as ex:
@@ -698,7 +698,7 @@ class AsyncTAPJob(object):
         returns the result votable if query is finished
         """
         try:
-            response = s.get(self.result_uri, stream=True)
+            response = session.get(self.result_uri, stream=True)
             response.raise_for_status()
         except requests.RequestException as ex:
             self._update()
@@ -824,7 +824,7 @@ class TAPQuery(DALQuery):
             if upload.is_inline
         }
 
-        response = s.post(
+        response = session.post(
             url, data=self, stream=True, files=files)
         # requests doesn't decode the content by default
         response.raw.read = partial(response.raw.read, decode_content=True)

--- a/pyvo/dal/tap.py
+++ b/pyvo/dal/tap.py
@@ -674,7 +674,7 @@ class AsyncTAPJob(object):
         deletes the job. this object will become invalid.
         """
         try:
-            response = s.post(self.url, data={"ACTION": "DELETE"})
+            response = session.post(self.url, data={"ACTION": "DELETE"})
             response.raise_for_status()
         except requests.RequestException as ex:
             raise DALServiceError.from_except(ex, self.url)


### PR DESCRIPTION
Single-character variable names are hard to search for, so I replaced 's' with 'session' where it's used