### PR TITLE
MNT: Use sphinx_astropy on conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,11 +38,8 @@ except ImportError:
         if os.path.isdir(a_h_path):
             sys.path.insert(1, a_h_path)
 
-    # If that doesn't work trying to import from astropy_helpers below will
-    # still blow up
-
 # Load all of the global Astropy configuration
-from astropy_helpers.sphinx.conf import *
+from sphinx_astropy.conf import *
 
 # Get configuration information from setup.cfg
 try:


### PR DESCRIPTION
This should get rid of import error when trying to build doc. The command to build doc should be:

```
python setup.py build_docs
```

For the record, `sphinx-astropy` is at https://github.com/astropy/sphinx-astropy