### PR TITLE
Fix the readthedocs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,8 @@
+python:
+  version: 3.5
+  pip_install: true
+
+# Don't build any extra formats
+# formats: []
+
+requirements_file: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,1 @@
+sphinx-astropy


### PR DESCRIPTION
Add in missing dependency for the build, sphinx-astropy.

This also tells readthedocs to install the requirements file when
building the docs, and to build with python3