### PR TITLE
Require docs build to pass with no warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,11 +82,10 @@ matrix:
         - os: linux
           env: MAIN_CMD='flake8 pyvo' SETUP_CMD=''
 
-    allow_failures:
         # Check for sphinx doc build warnings
-        # (allow to fail because docs aren't in the right state yet')
         - os: linux
           env: SETUP_CMD='build_docs -w'
+               PIP_DEPENDENCIES='requests mimeparse requests_mock sphinx_astropy'
 
 install:
     - git clone git://github.com/astropy/ci-helpers.git

--- a/docs/io/index.rst
+++ b/docs/io/index.rst
@@ -5,7 +5,7 @@ This module contains submodules which handle datastructures related to the
 virtual observatory.
 
 .. toctree::
-   :maxdepth: 1
+  :maxdepth: 1
 
   vosi
   uws

--- a/pyvo/dal/adhoc.py
+++ b/pyvo/dal/adhoc.py
@@ -252,7 +252,7 @@ class DatalinkService(DALService, AvailabilityMixin, CapabilityMixin):
 
 class DatalinkQuery(DALQuery):
     """
-    a class for preparing an query to an Datalink service.  Query constraints
+    A class for preparing a query to a Datalink service.  Query constraints
     are added via its service type-specific methods.  The various execute()
     functions will submit the query and return the results.
 
@@ -275,16 +275,19 @@ class DatalinkQuery(DALQuery):
 
         XML Hierarchy:
 
-        <FIELD id="ID"...>
-        <FIELD id="srcGroup">
+        .. code:: xml
 
-        <GROUP name="inputParams">
-            <PARAM name="ID" datatype="char" arraysize="*" value=""
-                ref="primaryID"/>
-            <PARAM name="CALIB" datatype="char" arraysize="*" value="FLUX"/>
-            <PARAM name="GROUP" datatype="char" arraysize="*" value=""
-                ref="srcGroup"/>
-        </GROUP>
+            <FIELD id="ID">
+            <FIELD id="srcGroup">
+
+            <GROUP name="inputParams">
+                <PARAM name="ID" datatype="char" arraysize="*" value=""
+                    ref="primaryID"/>
+                <PARAM name="CALIB" datatype="char" arraysize="*"
+                    value="FLUX"/>
+                <PARAM name="GROUP" datatype="char" arraysize="*" value=""
+                    ref="srcGroup"/>
+            </GROUP>
         """
         input_params = _get_input_params_from_resource(resource)
         # get params outside of any group

--- a/pyvo/registry/regtap.py
+++ b/pyvo/registry/regtap.py
@@ -193,17 +193,6 @@ class RegistryResource(dalq.Record):
     be accessed by name via the [] operator, and the attribute names can
     by returned via the keys() function.  For convenience, it also stores
     key values as properties; these include:
-
-    Properties
-    ----------
-    title : bytes
-       the title of the resource
-    shortname : bytes
-       the resource's short name
-    ivoid : bytes
-       the IVOA identifier for the resource (identifier will also work)
-    accessurl : str
-       when the resource is a service, the service's access URL.
     """
 
     _service = None
@@ -339,6 +328,8 @@ class RegistryResource(dalq.Record):
         """
         assuming this resource refers to a searchable service, execute a
         search against the resource.  This is equivalent to:
+
+        .. code:: python
 
            self.to_service().search(*args, **keys)
 


### PR DESCRIPTION
Travis wasn't even attempting to run the docs build, because
in Travis you need to have it in the matrix.include: part
as well as the same keys present in the matrix.allow_failures:
part.

Fixes #139.