### PR TITLE
Result for TAP service should default result to id=result

### DIFF
--- a/pyvo/dal/tap.py
+++ b/pyvo/dal/tap.py
@@ -575,6 +575,10 @@ class AsyncTAPJob(object):
         The job result if exists
         """
         try:
+            for r in self._job.results:
+                if r.id_ == 'result':
+                    return r
+
             return self._job.results[0]
         except IndexError:
             return None
@@ -589,10 +593,10 @@ class AsyncTAPJob(object):
     @property
     def result_uri(self):
         """
-        the first result uri
+        the uri of the result
         """
         try:
-            return self.result_uris[0]
+            return self.result.href
         except IndexError:
             return None
 


### PR DESCRIPTION
For a TAP service async job, it can have multiple results in one
set.  When doing a fetch_results() it has to pick which one of the
multiple results to fetch.  The TAP specification outlines that
if there is a query language that returns on result (as ADQL does),
then the result of the query should have id of result in the XML
representation of the results.

Right now pyvo picks just the first one in the list, which doesn't
play well with the CADC TAP service, which has the real result URL
listed last.  If no result with id=result is present, then we
default to our previous behavior of picking the first one.  In
these cases it is likely that the user will need to fetch all
the results through a different mechanism.

Fixes #147.