### PR TITLE
Fix AstropyDeprecationWarning in SIA & SSA

### DIFF
--- a/pyvo/dal/sia.py
+++ b/pyvo/dal/sia.py
@@ -399,7 +399,7 @@ class SIAQuery(DALQuery):
         if pos:
             self.pos = pos
 
-        if size:
+        if size is not None:
             self.size = size
 
         if format:

--- a/pyvo/dal/ssa.py
+++ b/pyvo/dal/ssa.py
@@ -349,7 +349,7 @@ class SSAQuery(DALQuery):
         if pos:
             self.pos = pos
 
-        if diameter:
+        if diameter is not None:
             self.diameter = diameter
 
         if band:


### PR DESCRIPTION
Fixes #163

When running SSAService.search() and passing in an astropy Quantity,
this warning would be emitted:

WARNING: AstropyDeprecationWarning: The truth value of a Quantity is ambiguous.
In the future this will raise a ValueError. [astropy.units.quantity]

Instead of checking the truth value of the parameter, I'm just going to check
if it is None or not, not relying on what the truth value of the Quantity
may be.