### PR TITLE
pyvo.object2pos() -> SkyCoord.from_name()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@
 
 - Add support for authenticated requests. [#157]
 
+- Replace example's usage of pyvo.object2pos() with SkyCoord.from_name() [#171]
+
 0.9.3 (2019-05-30)
 ==================
 

--- a/scripts/ex_casA_image_cat.py
+++ b/scripts/ex_casA_image_cat.py
@@ -1,11 +1,12 @@
 #! /usr/bin/env python
+from astropy.coordinates import SkyCoord
 import pyvo as vo
 
 # find archives with x-ray images
 archives = vo.regsearch(servicetype='image', waveband='xray')
 
 # position of my favorite source
-pos = vo.object2pos('Cas A')
+pos = SkyCoord.from_name('Cas A')
 
 # find images and list in a file
 with open('cas-a.csv', 'w') as csv:

--- a/scripts/ex_get_cutouts.py
+++ b/scripts/ex_get_cutouts.py
@@ -1,4 +1,5 @@
 #! /usr/bin/env python
+from astropy.coordinates import SkyCoord
 import pyvo as vo
 import os
 
@@ -6,7 +7,7 @@ import os
 sourcenames = ["ngc4258", "m101", "m51"]
 mysources = {}
 for src in sourcenames:
-    mysources[src] = vo.object2pos(src)
+    mysources[src] = SkyCoord.from_name(src)
 
 # create an output directory for cutouts
 if not os.path.exists("NVSSimages"):


### PR DESCRIPTION
Running these examples I noticed that object2pos was being called,
but got deleted.  So instead, let's use astropy's way of doing
the same thing.

Fixes #165.