### PR TITLE
Fixing service discovery query pattern to use RegTAP 1.1 role=std

### DIFF
--- a/pyvo/registry/regtap.py
+++ b/pyvo/registry/regtap.py
@@ -83,7 +83,7 @@ def search(keywords=None, servicetype=None, waveband=None, datamodel=None):
             "No search parameters passed to registry search")
 
     wheres = list()
-    wheres.append("intf_type = 'vs:paramhttp'")
+    wheres.append("intf_role = 'std'")
 
     if keywords:
         def _unions():


### PR DESCRIPTION
This PR updates the registry query pattern as per http://mail.ivoa.net/pipermail/apps/2019-September/001430.html.

As argued in that citing mail, there should be no functional impact.