### PR TITLE
fix to registry.regsearch() waveband option

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,8 @@
 
 - Update ex_casA_image_cat example. [#172]
 
+- Fix waveband option in registry.regsearch [#175]
+
 
 0.9.3 (2019-05-30)
 ==================

--- a/pyvo/registry/regtap.py
+++ b/pyvo/registry/regtap.py
@@ -119,7 +119,7 @@ def search(keywords=None, servicetype=None, waveband=None, datamodel=None):
         """)
 
     if waveband:
-        wheres.append("1 = ivo_hashlist_has('{}', waveband)".format(
+        wheres.append("1 = ivo_hashlist_has(rr.resource.waveband, '{}')".format(
             tap.escape(waveband)))
 
     if datamodel:

--- a/pyvo/registry/tests/test_regtap.py
+++ b/pyvo/registry/tests/test_regtap.py
@@ -83,7 +83,7 @@ def waveband_fixture(mocker):
         data = dict(parse_qsl(request.body))
         query = data['QUERY']
 
-        assert "1 = ivo_hashlist_has('optical', waveband" in query
+        assert "1 = ivo_hashlist_has(rr.resource.waveband, 'optical'" in query
 
         return get_pkg_data_contents('data/regtap.xml')
 


### PR DESCRIPTION
I am not sure why this partly worked before, but it did not find matches to entries with multiple wavebands like ("optical#infrared#uv").  Try 

uv_services=vo.regsearch(servicetype='image',keywords='galex',waveband='uv')
print(uv_services.to_table()['waveband','short_name'])

and see the extra stuff picked up after I think I fixed the ivo_hashlist_has() call, which I think was backward compared to documentation in http://www.ivoa.net/documents/RegTAP/20141208/REC-RegTAP-1.0.html .  