### PR TITLE
Fix to regtap.ivoid2service(), small fixes for examples/notebooks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,9 @@
 
 - Fix waveband option in registry.regsearch [#175]
 
+- Fix to regtap.ivoid2service(), few decode()'s, para_format_desc
+  was moved to utils.  
+
 
 0.9.3 (2019-05-30)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,8 +19,7 @@
 
 - Fix waveband option in registry.regsearch [#175]
 
-- Fix to regtap.ivoid2service(), few decode()'s, para_format_desc
-  was moved to utils.  
+- Fix to regtap.ivoid2service(), few decode()'s, para_format_desc  was moved to utils.  [#177]
 
 
 0.9.3 (2019-05-30)

--- a/examples/notebooks/working_with_registry_results.ipynb
+++ b/examples/notebooks/working_with_registry_results.ipynb
@@ -11,11 +11,7 @@
     "have noticed that the results behave similarly to the results from the\n",
     "data access services. Like them, registry search results are returned\n",
     "as a `~pyvo.registry.regtap.RegistryResults` instance, and each\n",
-    "record is represented as a `~pyvo.registry.regtap.RegistryResource` instance. \n",
-    "\n",
-    "A `~pyvo.registry.regtap.RegistryRecord` record acts like a\n",
-    "dictionary where the keys are the column names from the results table;\n",
-    "using our NVSS example from simple_service_discovery."
+    "record is represented as a `~pyvo.registry.regtap.RegistryResource` instance. "
    ]
   },
   {
@@ -27,16 +23,7 @@
     "import pyvo as vo\n",
     "colls = vo.regsearch(keywords=[\"NVSS\"], servicetype='sia')\n",
     "nvss = colls[0]\n",
-    "print(nvss.res_title)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "nvss.keys()"
+    "nvss.res_title"
    ]
   },
   {
@@ -77,7 +64,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Registry Records can be converted to a service object"
+    "Registry Records can be converted to a service object that can be queried.  "
    ]
   },
   {
@@ -87,8 +74,7 @@
    "outputs": [],
    "source": [
     "nvss = colls[0].service  # converts record to service object\n",
-    "print(nvss.baseurl)\n",
-    "query = nvss.create_query(size=0.25, format=\"image/fits\")"
+    "nvss.search(pos=(350.85, 58.815),size=0.25,format=\"image/fits\").to_table()"
    ]
   },
   {
@@ -98,8 +84,20 @@
     "Thus, not only does this service instance contain the base URL but it\n",
     "also includes all of the metadata from the registry that desribes the\n",
     "service.  With this service object, we can either call its \n",
-    "`~pyvo.dal.sia.SIAService.search` function directly or \n",
+    "`~pyvo.dal.sia.SIAService.search` function directly as above, or \n",
     "create query objects to get cutouts for a whole list of sources."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cutouts1 = nvss.search(pos=(148.8888, 69.065), size=0.2)\n",
+    "nvssq = nvss.create_query(size=0.2)  # or create a query object\n",
+    "nvssq.pos = (350.85, 58.815)\n",
+    "cutouts2 = nvssq.execute()"
    ]
   },
   {
@@ -128,8 +126,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This identifier can be used to uniquely retrieve a service desription\n",
-    "from the registry."
+    "This identifier can be used to retrieve a specific service from the registry.  "
    ]
   },
   {
@@ -138,20 +135,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "nvss = vo.registry.ivoid2service('ivo://nasa.heasarc/skyview/nvss')\n",
-    "nvss.baseurl"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "cutouts1 = nvss.search(pos=(148.8888, 69.065), size=0.2)\n",
-    "nvssq = nvss.create_query(size=0.2)  # or create a query object\n",
-    "nvssq.pos = (350.85, 58.815)\n",
-    "cutouts2 = nvssq.execute()"
+    "nvss = vo.registry.ivoid2service('ivo://nasa.heasarc/skyview/nvss',servicetype='sia')\n",
+    "nvss.search(pos=(350.85, 58.815),size=0.25,format=\"image/fits\").to_table()"
    ]
   },
   {
@@ -171,19 +156,19 @@
    "outputs": [],
    "source": [
     "services = vo.regsearch(keywords=[\"NVSS\"],\n",
-    "                        servicetype='sia')     # RegistryResults\n",
-    "nvss = services[0]                             # RegistryResource\n",
-    "nvsss = nvss.service                           # SIAService\n",
-    "nq = nvsss.create_query(pos=(350.85, 58.815),\n",
+    "                        servicetype='sia') \n",
+    "nvss_resource = services[0]\n",
+    "nvss_service = nvss_resource.service \n",
+    "nvss_query = nvss_service.create_query(pos=(350.85, 58.815),\n",
     "                      size=0.25, \n",
-    "                      format=\"image/fits\")     # SIAQuery\n",
-    "images = nq.execute()                          # SIAResults\n",
-    "firstim = images[0]                            # SIARecord\n",
+    "                      format=\"image/fits\")\n",
+    "images = nvss_query.execute()\n",
+    "firstim = images[0]\n",
     "\n",
     "print(type(services))\n",
-    "print(type(nvss))\n",
-    "print(type(nvsss))\n",
-    "print(type(nq))\n",
+    "print(type(nvss_resource))\n",
+    "print(type(nvss_service))\n",
+    "print(type(nvss_query))\n",
     "print(type(images))\n",
     "print(type(firstim))"
    ]

--- a/examples/notebooks/working_with_registry_results.ipynb
+++ b/examples/notebooks/working_with_registry_results.ipynb
@@ -1,223 +1,221 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "As you can see from the examples in simple_service_discovery,\n",
-    "a search will often return more than one record,\n",
-    "and so sometimes you need to review some of the\n",
-    "resource metadata to determine which one or ones you want.  You may\n",
-    "have noticed that the results behave similarly to the results from the\n",
-    "data access services. Like them, registry search results are returned\n",
-    "as a `~pyvo.registry.regtap.RegistryResults` instance, and each\n",
-    "record is represented as a `~pyvo.registry.regtap.RegistryResource` instance. \n",
-    "\n",
-    "A `~pyvo.registry.regtap.RegistryRecord` record acts like a\n",
-    "dictionary where the keys are the column names from the results table;\n",
-    "using our NVSS example from simple_service_discovery."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import pyvo as vo\n",
-    "colls = vo.regsearch(keywords=[\"NVSS\"], servicetype='sia')\n",
-    "nvss = colls[0]\n",
-    "print(nvss.res_title)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "nvss.keys()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "If you are looking for a particular data collection or catalog, as we\n",
-    "did above when we looked for the NVSS archive, often simply reviewing\n",
-    "the titles is sufficient.  Other times, particularly when you are not\n",
-    "sure what you are looking for, it helps to look deeper.  \n",
-    "\n",
-    "The resource description, available via the \n",
-    "`~pyvo.registry.regtap.ResourceRecord.res_description` property,\n",
-    "tends to be the most revealing.  It contains a paragraph (or two)\n",
-    "summarizing the catalog or data collection.  It will often describe\n",
-    "the scientific intent behind the collection.  \n",
-    "\n",
-    "The `~pyvo.registry.regtap.RegistryResource.short_name` can also be\n",
-    "helpful, as well.  This name is meant to be short--16 characters or\n",
-    "fewer; consequently, the value is often includes the abbreviation for the\n",
-    "project or observatory that produced the collection or catalog.  \n",
-    "\n",
-    "A selection of the resource metadata, including the title, shortname and\n",
-    "desription, can be printed out in a summary form with\n",
-    "the `~pyvo.registry.regtap.RegistryResource.describe` function."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "nvss.describe()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Registry Records can be converted to a service object"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "nvss = colls[0].service  # converts record to service object\n",
-    "print(nvss.baseurl)\n",
-    "query = nvss.create_query(size=0.25, format=\"image/fits\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Thus, not only does this service instance contain the base URL but it\n",
-    "also includes all of the metadata from the registry that desribes the\n",
-    "service.  With this service object, we can either call its \n",
-    "`~pyvo.dal.sia.SIAService.search` function directly or \n",
-    "create query objects to get cutouts for a whole list of sources."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Our discussion of service metadata offers an opportunity to highlight\n",
-    "another important property, the service's *IVOA Identifier* (sometimes\n",
-    "referred to as its *ivoid*).  This is a globally-unique identifier\n",
-    "that takes the form of a \n",
-    "`URI <http://en.wikipedia.org/wiki/Uniform_resource_identifier>`_:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "colls = vo.regsearch(keywords=[\"NVSS\"], servicetype='sia')\n",
-    "for coll in colls:\n",
-    "    print(coll.ivoid)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "This identifier can be used to uniquely retrieve a service desription\n",
-    "from the registry."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "nvss = vo.registry.ivoid2service('ivo://nasa.heasarc/skyview/nvss')\n",
-    "nvss.baseurl"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "cutouts1 = nvss.search(pos=(148.8888, 69.065), size=0.2)\n",
-    "#nvssq = nvss.create_query(size=0.2)  # or create a query object\n",
-    "#nvssq.pos = (350.85, 58.815)\n",
-    "#cutouts2 = nvssq.execute()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "As we end this discussion of the service objects, you can hopefully\n",
-    "see that there is a straight-forward chain of discovery classes that\n",
-    "connect the registry down through to a dataset.  Spelled out in all\n",
-    "its detail, it looks like this:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "services = vo.regsearch(keywords=[\"NVSS\"],\n",
-    "                        servicetype='sia')     # RegistryResults\n",
-    "nvss = services[0]                             # RegistryResource\n",
-    "nvss = nvss.service                           # SIAService\n",
-    "nq = nvss.create_query(pos=(350.85, 58.815),\n",
-    "                      size=0.25, \n",
-    "                      format=\"image/fits\")     # SIAQuery\n",
-    "images = nq.execute()                          # SIAResults\n",
-    "firstim = images[0]                            # SIARecord\n",
-    "\n",
-    "print(type(services))\n",
-    "print(type(nvss))\n",
-    "print(type(nq))\n",
-    "print(type(images))\n",
-    "print(type(firstim))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Most of the time, it's not necessary to follow all these steps\n",
-    "yourself, so there are functions and methods that provide syntactic\n",
-    "shortcuts.  However, when you need some finer control over the\n",
-    "process, it is possible to jump off the fast track and work directly\n",
-    "with an underlying object.  "
-   ]
-  }
- ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.7"
-  }
+  "name": "",
+  "signature": "sha256:77ab35415e38567d49af91382dac230998db0223d904a781aafade553a673424"
  },
- "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat": 3,
+ "nbformat_minor": 0,
+ "worksheets": [
+  {
+   "cells": [
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "As you can see from the examples in simple_service_discovery,\n",
+      "a search will often return more than one record,\n",
+      "and so sometimes you need to review some of the\n",
+      "resource metadata to determine which one or ones you want.  You may\n",
+      "have noticed that the results behave similarly to the results from the\n",
+      "data access services. Like them, registry search results are returned\n",
+      "as a `~pyvo.registry.regtap.RegistryResults` instance, and each\n",
+      "record is represented as a `~pyvo.registry.regtap.RegistryResource` instance. \n",
+      "\n",
+      "A `~pyvo.registry.regtap.RegistryRecord` record acts like a\n",
+      "dictionary where the keys are the column names from the results table;\n",
+      "using our NVSS example from simple_service_discovery."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "import pyvo as vo\n",
+      "colls = vo.regsearch(keywords=[\"NVSS\"], servicetype='sia')\n",
+      "nvss = colls[0]\n",
+      "print(nvss.res_title)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "nvss.keys()"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "If you are looking for a particular data collection or catalog, as we\n",
+      "did above when we looked for the NVSS archive, often simply reviewing\n",
+      "the titles is sufficient.  Other times, particularly when you are not\n",
+      "sure what you are looking for, it helps to look deeper.  \n",
+      "\n",
+      "The resource description, available via the \n",
+      "`~pyvo.registry.regtap.ResourceRecord.res_description` property,\n",
+      "tends to be the most revealing.  It contains a paragraph (or two)\n",
+      "summarizing the catalog or data collection.  It will often describe\n",
+      "the scientific intent behind the collection.  \n",
+      "\n",
+      "The `~pyvo.registry.regtap.RegistryResource.short_name` can also be\n",
+      "helpful, as well.  This name is meant to be short--16 characters or\n",
+      "fewer; consequently, the value is often includes the abbreviation for the\n",
+      "project or observatory that produced the collection or catalog.  \n",
+      "\n",
+      "A selection of the resource metadata, including the title, shortname and\n",
+      "desription, can be printed out in a summary form with\n",
+      "the `~pyvo.registry.regtap.RegistryResource.describe` function."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "nvss.describe()"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Registry Records can be converted to a service object"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "nvss = colls[0].service  # converts record to service object\n",
+      "print(nvss.baseurl)\n",
+      "query = nvss.create_query(size=0.25, format=\"image/fits\")"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Thus, not only does this service instance contain the base URL but it\n",
+      "also includes all of the metadata from the registry that desribes the\n",
+      "service.  With this service object, we can either call its \n",
+      "`~pyvo.dal.sia.SIAService.search` function directly or \n",
+      "create query objects to get cutouts for a whole list of sources."
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Our discussion of service metadata offers an opportunity to highlight\n",
+      "another important property, the service's *IVOA Identifier* (sometimes\n",
+      "referred to as its *ivoid*).  This is a globally-unique identifier\n",
+      "that takes the form of a \n",
+      "`URI <http://en.wikipedia.org/wiki/Uniform_resource_identifier>`_:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "colls = vo.regsearch(keywords=[\"NVSS\"], servicetype='sia')\n",
+      "for coll in colls:\n",
+      "    print coll.ivoid"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "This identifier can be used to uniquely retrieve a service desription\n",
+      "from the registry."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "nvss = vo.registry.ivoid2service('ivo://nasa.heasarc/skyview/nvss')\n",
+      "nvss.baseurl"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "cutouts1 = nvss.search(pos=(148.8888, 69.065), size=0.2)\n",
+      "nvssq = nvss.create_query(size=0.2)  # or create a query object\n",
+      "nvssq.pos = (350.85, 58.815)\n",
+      "cutouts2 = nvssq.execute()"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "As we end this discussion of the service objects, you can hopefully\n",
+      "see that there is a straight-forward chain of discovery classes that\n",
+      "connect the registry down through to a dataset.  Spelled out in all\n",
+      "its detail, it looks like this:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "services = vo.regsearch(keywords=[\"NVSS\"],\n",
+      "                        servicetype='sia')     # RegistryResults\n",
+      "nvss = services[0]                             # RegistryResource\n",
+      "nvsss = nvss.service                           # SIAService\n",
+      "nq = nvss.create_query(pos=(350.85, 58.815),\n",
+      "                      size=0.25, \n",
+      "                      format=\"image/fits\")     # SIAQuery\n",
+      "images = nq.execute()                          # SIAResults\n",
+      "firstim = images[0]                            # SIARecord\n",
+      "\n",
+      "print(type(services))\n",
+      "print(type(nvss))\n",
+      "print(type(nq))\n",
+      "print(type(images))\n",
+      "print(type(firstim))"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Most of the time, it's not necessary to follow all these steps\n",
+      "yourself, so there are functions and methods that provide syntactic\n",
+      "shortcuts.  However, when you need some finer control over the\n",
+      "process, it is possible to jump off the fast track and work directly\n",
+      "with an underlying object.  "
+     ]
+    }
+   ],
+   "metadata": {}
+  }
+ ]
 }

--- a/examples/notebooks/working_with_registry_results.ipynb
+++ b/examples/notebooks/working_with_registry_results.ipynb
@@ -1,221 +1,223 @@
 {
- "metadata": {
-  "name": "",
-  "signature": "sha256:77ab35415e38567d49af91382dac230998db0223d904a781aafade553a673424"
- },
- "nbformat": 3,
- "nbformat_minor": 0,
- "worksheets": [
+ "cells": [
   {
-   "cells": [
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "As you can see from the examples in simple_service_discovery,\n",
-      "a search will often return more than one record,\n",
-      "and so sometimes you need to review some of the\n",
-      "resource metadata to determine which one or ones you want.  You may\n",
-      "have noticed that the results behave similarly to the results from the\n",
-      "data access services. Like them, registry search results are returned\n",
-      "as a `~pyvo.registry.regtap.RegistryResults` instance, and each\n",
-      "record is represented as a `~pyvo.registry.regtap.RegistryResource` instance. \n",
-      "\n",
-      "A `~pyvo.registry.regtap.RegistryRecord` record acts like a\n",
-      "dictionary where the keys are the column names from the results table;\n",
-      "using our NVSS example from simple_service_discovery."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "import pyvo as vo\n",
-      "colls = vo.regsearch(keywords=[\"NVSS\"], servicetype='sia')\n",
-      "nvss = colls[0]\n",
-      "print(nvss.res_title)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "nvss.keys()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "If you are looking for a particular data collection or catalog, as we\n",
-      "did above when we looked for the NVSS archive, often simply reviewing\n",
-      "the titles is sufficient.  Other times, particularly when you are not\n",
-      "sure what you are looking for, it helps to look deeper.  \n",
-      "\n",
-      "The resource description, available via the \n",
-      "`~pyvo.registry.regtap.ResourceRecord.res_description` property,\n",
-      "tends to be the most revealing.  It contains a paragraph (or two)\n",
-      "summarizing the catalog or data collection.  It will often describe\n",
-      "the scientific intent behind the collection.  \n",
-      "\n",
-      "The `~pyvo.registry.regtap.RegistryResource.short_name` can also be\n",
-      "helpful, as well.  This name is meant to be short--16 characters or\n",
-      "fewer; consequently, the value is often includes the abbreviation for the\n",
-      "project or observatory that produced the collection or catalog.  \n",
-      "\n",
-      "A selection of the resource metadata, including the title, shortname and\n",
-      "desription, can be printed out in a summary form with\n",
-      "the `~pyvo.registry.regtap.RegistryResource.describe` function."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "nvss.describe()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Registry Records can be converted to a service object"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "nvss = colls[0].service  # converts record to service object\n",
-      "print(nvss.baseurl)\n",
-      "query = nvss.create_query(size=0.25, format=\"image/fits\")"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Thus, not only does this service instance contain the base URL but it\n",
-      "also includes all of the metadata from the registry that desribes the\n",
-      "service.  With this service object, we can either call its \n",
-      "`~pyvo.dal.sia.SIAService.search` function directly or \n",
-      "create query objects to get cutouts for a whole list of sources."
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Our discussion of service metadata offers an opportunity to highlight\n",
-      "another important property, the service's *IVOA Identifier* (sometimes\n",
-      "referred to as its *ivoid*).  This is a globally-unique identifier\n",
-      "that takes the form of a \n",
-      "`URI <http://en.wikipedia.org/wiki/Uniform_resource_identifier>`_:"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "colls = vo.regsearch(keywords=[\"NVSS\"], servicetype='sia')\n",
-      "for coll in colls:\n",
-      "    print coll.ivoid"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "This identifier can be used to uniquely retrieve a service desription\n",
-      "from the registry."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "nvss = vo.registry.ivoid2service('ivo://nasa.heasarc/skyview/nvss')\n",
-      "nvss.baseurl"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "cutouts1 = nvss.search(pos=(148.8888, 69.065), size=0.2)\n",
-      "nvssq = nvss.create_query(size=0.2)  # or create a query object\n",
-      "nvssq.pos = (350.85, 58.815)\n",
-      "cutouts2 = nvssq.execute()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "As we end this discussion of the service objects, you can hopefully\n",
-      "see that there is a straight-forward chain of discovery classes that\n",
-      "connect the registry down through to a dataset.  Spelled out in all\n",
-      "its detail, it looks like this:"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "services = vo.regsearch(keywords=[\"NVSS\"],\n",
-      "                        servicetype='sia')     # RegistryResults\n",
-      "nvss = services[0]                             # RegistryResource\n",
-      "nvsss = nvss.service                           # SIAService\n",
-      "nq = nvss.create_query(pos=(350.85, 58.815),\n",
-      "                      size=0.25, \n",
-      "                      format=\"image/fits\")     # SIAQuery\n",
-      "images = nq.execute()                          # SIAResults\n",
-      "firstim = images[0]                            # SIARecord\n",
-      "\n",
-      "print(type(services))\n",
-      "print(type(nvss))\n",
-      "print(type(nq))\n",
-      "print(type(images))\n",
-      "print(type(firstim))"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Most of the time, it's not necessary to follow all these steps\n",
-      "yourself, so there are functions and methods that provide syntactic\n",
-      "shortcuts.  However, when you need some finer control over the\n",
-      "process, it is possible to jump off the fast track and work directly\n",
-      "with an underlying object.  "
-     ]
-    }
-   ],
-   "metadata": {}
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As you can see from the examples in simple_service_discovery,\n",
+    "a search will often return more than one record,\n",
+    "and so sometimes you need to review some of the\n",
+    "resource metadata to determine which one or ones you want.  You may\n",
+    "have noticed that the results behave similarly to the results from the\n",
+    "data access services. Like them, registry search results are returned\n",
+    "as a `~pyvo.registry.regtap.RegistryResults` instance, and each\n",
+    "record is represented as a `~pyvo.registry.regtap.RegistryResource` instance. \n",
+    "\n",
+    "A `~pyvo.registry.regtap.RegistryRecord` record acts like a\n",
+    "dictionary where the keys are the column names from the results table;\n",
+    "using our NVSS example from simple_service_discovery."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pyvo as vo\n",
+    "colls = vo.regsearch(keywords=[\"NVSS\"], servicetype='sia')\n",
+    "nvss = colls[0]\n",
+    "print(nvss.res_title)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nvss.keys()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you are looking for a particular data collection or catalog, as we\n",
+    "did above when we looked for the NVSS archive, often simply reviewing\n",
+    "the titles is sufficient.  Other times, particularly when you are not\n",
+    "sure what you are looking for, it helps to look deeper.  \n",
+    "\n",
+    "The resource description, available via the \n",
+    "`~pyvo.registry.regtap.ResourceRecord.res_description` property,\n",
+    "tends to be the most revealing.  It contains a paragraph (or two)\n",
+    "summarizing the catalog or data collection.  It will often describe\n",
+    "the scientific intent behind the collection.  \n",
+    "\n",
+    "The `~pyvo.registry.regtap.RegistryResource.short_name` can also be\n",
+    "helpful, as well.  This name is meant to be short--16 characters or\n",
+    "fewer; consequently, the value is often includes the abbreviation for the\n",
+    "project or observatory that produced the collection or catalog.  \n",
+    "\n",
+    "A selection of the resource metadata, including the title, shortname and\n",
+    "desription, can be printed out in a summary form with\n",
+    "the `~pyvo.registry.regtap.RegistryResource.describe` function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nvss.describe()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Registry Records can be converted to a service object"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nvss = colls[0].service  # converts record to service object\n",
+    "print(nvss.baseurl)\n",
+    "query = nvss.create_query(size=0.25, format=\"image/fits\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Thus, not only does this service instance contain the base URL but it\n",
+    "also includes all of the metadata from the registry that desribes the\n",
+    "service.  With this service object, we can either call its \n",
+    "`~pyvo.dal.sia.SIAService.search` function directly or \n",
+    "create query objects to get cutouts for a whole list of sources."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Our discussion of service metadata offers an opportunity to highlight\n",
+    "another important property, the service's *IVOA Identifier* (sometimes\n",
+    "referred to as its *ivoid*).  This is a globally-unique identifier\n",
+    "that takes the form of a \n",
+    "`URI <http://en.wikipedia.org/wiki/Uniform_resource_identifier>`_:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "colls = vo.regsearch(keywords=[\"NVSS\"], servicetype='sia')\n",
+    "for coll in colls:\n",
+    "    print(coll.ivoid)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This identifier can be used to uniquely retrieve a service desription\n",
+    "from the registry."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nvss = vo.registry.ivoid2service('ivo://nasa.heasarc/skyview/nvss')\n",
+    "nvss.baseurl"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cutouts1 = nvss.search(pos=(148.8888, 69.065), size=0.2)\n",
+    "#nvssq = nvss.create_query(size=0.2)  # or create a query object\n",
+    "#nvssq.pos = (350.85, 58.815)\n",
+    "#cutouts2 = nvssq.execute()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As we end this discussion of the service objects, you can hopefully\n",
+    "see that there is a straight-forward chain of discovery classes that\n",
+    "connect the registry down through to a dataset.  Spelled out in all\n",
+    "its detail, it looks like this:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "services = vo.regsearch(keywords=[\"NVSS\"],\n",
+    "                        servicetype='sia')     # RegistryResults\n",
+    "nvss = services[0]                             # RegistryResource\n",
+    "nvss = nvss.service                           # SIAService\n",
+    "nq = nvss.create_query(pos=(350.85, 58.815),\n",
+    "                      size=0.25, \n",
+    "                      format=\"image/fits\")     # SIAQuery\n",
+    "images = nq.execute()                          # SIAResults\n",
+    "firstim = images[0]                            # SIARecord\n",
+    "\n",
+    "print(type(services))\n",
+    "print(type(nvss))\n",
+    "print(type(nq))\n",
+    "print(type(images))\n",
+    "print(type(firstim))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Most of the time, it's not necessary to follow all these steps\n",
+    "yourself, so there are functions and methods that provide syntactic\n",
+    "shortcuts.  However, when you need some finer control over the\n",
+    "process, it is possible to jump off the fast track and work directly\n",
+    "with an underlying object.  "
+   ]
   }
- ]
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
 }

--- a/examples/notebooks/working_with_registry_results.ipynb
+++ b/examples/notebooks/working_with_registry_results.ipynb
@@ -149,9 +149,9 @@
    "outputs": [],
    "source": [
     "cutouts1 = nvss.search(pos=(148.8888, 69.065), size=0.2)\n",
-    "#nvssq = nvss.create_query(size=0.2)  # or create a query object\n",
-    "#nvssq.pos = (350.85, 58.815)\n",
-    "#cutouts2 = nvssq.execute()"
+    "nvssq = nvss.create_query(size=0.2)  # or create a query object\n",
+    "nvssq.pos = (350.85, 58.815)\n",
+    "cutouts2 = nvssq.execute()"
    ]
   },
   {
@@ -173,8 +173,8 @@
     "services = vo.regsearch(keywords=[\"NVSS\"],\n",
     "                        servicetype='sia')     # RegistryResults\n",
     "nvss = services[0]                             # RegistryResource\n",
-    "nvss = nvss.service                           # SIAService\n",
-    "nq = nvss.create_query(pos=(350.85, 58.815),\n",
+    "nvsss = nvss.service                           # SIAService\n",
+    "nq = nvsss.create_query(pos=(350.85, 58.815),\n",
     "                      size=0.25, \n",
     "                      format=\"image/fits\")     # SIAQuery\n",
     "images = nq.execute()                          # SIAResults\n",
@@ -182,6 +182,7 @@
     "\n",
     "print(type(services))\n",
     "print(type(nvss))\n",
+    "print(type(nvsss))\n",
     "print(type(nq))\n",
     "print(type(images))\n",
     "print(type(firstim))"

--- a/pyvo/registry/__init__.py
+++ b/pyvo/registry/__init__.py
@@ -7,5 +7,6 @@ The regtap module supports access to the IVOA Registries
 from . import regtap
 
 search = regtap.search
+ivoid2service = regtap.ivoid2service
 
 __all__ = ["search"]

--- a/pyvo/registry/regtap.py
+++ b/pyvo/registry/regtap.py
@@ -426,7 +426,7 @@ def ivoid2service(ivoid):
     """.format(tap.escape(ivoid)))
     services = []
     for result in results:
-        id=result["standard_id"].decode()
+        id = result["standard_id"].decode()
         for ivo, cls in {
             "ivo://ivoa.net/std/conesearch":  scs.SCSService,
             "ivo://ivoa.net/std/sia":  sia.SIAService,
@@ -435,7 +435,7 @@ def ivoid2service(ivoid):
             "ivo://ivoa.net/std/tap":  tap.TAPService,
         }.items():
             if id != '' and id in ivo:
-                services.append( cls( result["access_url"].decode() ) )
+                services.append(cls(result["access_url"].decode()))
     if len(services) > 1:
         return services
     elif len(services) == 1:

--- a/pyvo/registry/regtap.py
+++ b/pyvo/registry/regtap.py
@@ -17,6 +17,8 @@ standardized TAP-based services.
 """
 import os
 from ..dal import scs, sia, ssa, sla, tap, query as dalq
+from ..utils.formatting import para_format_desc
+
 
 __all__ = ["search", "RegistryResource", "RegistryResults", "ivoid2service"]
 
@@ -373,7 +375,6 @@ class RegistryResource(dalq.Record):
             If provided, write information to this output stream.
             Otherwise, it is written to standard out.
         """
-        from ..utils.formatting import para_format_desc
         restype = "Custom Service"
         stdid = self.get("standard_id", decode=True).lower()
         if stdid:

--- a/pyvo/registry/regtap.py
+++ b/pyvo/registry/regtap.py
@@ -424,7 +424,7 @@ def ivoid2service(ivoid):
         NATURAL JOIN rr.interface
         WHERE ivoid = '{}'
     """.format(tap.escape(ivoid)))
-    services=[]
+    services = []
     for result in results:
         id=result["standard_id"].decode()
         for ivo, cls in {
@@ -435,8 +435,7 @@ def ivoid2service(ivoid):
             "ivo://ivoa.net/std/tap":  tap.TAPService,
         }.items():
             if id != '' and id in ivo:
-                services.append( cls(result["access_url"].decode()) )
-    ## Return services as what?  
+                services.append( cls( result["access_url"].decode() ) )
     if len(services) > 1:
         return services
     elif len(services) == 1:


### PR DESCRIPTION
Some small fixes to get the examples/notebooks/working_with_registry_results.ipynb working, including some bytes decodes, the location of para_format_desc() had moved.  Most significantly, the ivoid2service() example was not working because that IVOID now has multiple services associated, one of which is not a VO service.  Firstly, I made the code safe against such entries missing the standard_id.  But secondly, this function needs to be able to handle multiple possible return services.  I don't know the best way to do this.  I made it simply return a list of services.  Is there a better way?   