### PR TITLE
Get auth docs building

### DIFF
--- a/docs/auth/index.rst
+++ b/docs/auth/index.rst
@@ -7,6 +7,10 @@ communicating with virtual observatory services.
 Reference/API
 =============
 
+.. automodapi:: pyvo.auth
+
 .. automodapi:: pyvo.auth.authsession
+
 .. automodapi:: pyvo.auth.authurls
+
 .. automodapi:: pyvo.auth.credentialstore

--- a/docs/auth/index.rst
+++ b/docs/auth/index.rst
@@ -1,0 +1,12 @@
+******************
+Auth (`pyvo.auth`)
+******************
+This module contains submodules which help handle auth when
+communicating with virtual observatory services.
+
+Reference/API
+=============
+
+.. automodapi:: pyvo.auth.authsession
+.. automodapi:: pyvo.auth.authurls
+.. automodapi:: pyvo.auth.credentialstore

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -121,3 +121,4 @@ Using `pyvo`
    dal/index
    registry/index
    io/index
+   auth/index

--- a/pyvo/auth/__init__.py
+++ b/pyvo/auth/__init__.py
@@ -1,1 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+__all__ = ["AuthSession", "AuthURLs", "CredentialStore"]
+
+from .authsession import AuthSession
+from .authurls import AuthURLs
+from .credentialstore import CredentialStore

--- a/pyvo/auth/authsession.py
+++ b/pyvo/auth/authsession.py
@@ -3,6 +3,8 @@ import logging
 from .authurls import AuthURLs
 from .credentialstore import CredentialStore
 
+__all__ = ["AuthSession"]
+
 
 class AuthSession:
     """

--- a/pyvo/auth/authurls.py
+++ b/pyvo/auth/authurls.py
@@ -3,6 +3,8 @@ import logging
 
 from . import securitymethods
 
+__all__ = ["AuthURLs"]
+
 
 class AuthURLs():
     """

--- a/pyvo/auth/credentialstore.py
+++ b/pyvo/auth/credentialstore.py
@@ -4,6 +4,8 @@ from pyvo.utils.http import create_session
 
 from . import securitymethods
 
+__all__ = ["CredentialStore"]
+
 
 class CredentialStore(object):
     """


### PR DESCRIPTION
For some reason, the docstrings for the auth classes aren't
being built into the docs.  Add a link from the main page to
get things generated.