### PR TITLE
Handle description of None when describing a TAP service's tables

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@
 
 - Add default for UWS version. [#199]
 
+- Handle description of None when describing a TAP service's tables. [#197]
 
 1.0 (2019-09-20)
 ================

--- a/pyvo/io/vosi/tests/data/tables/no_table_description.xml
+++ b/pyvo/io/vosi/tests/data/tables/no_table_description.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<?xml-stylesheet href='/static/xsl/vosi.xsl' type='text/xsl'?>
+<vtm:tableset xmlns:vs="http://www.ivoa.net/xml/VODataService/v1.1" xmlns:vtm="http://www.ivoa.net/xml/VOSITables/v1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.ivoa.net/xml/VODataService/v1.1 http://vo.ari.uni-heidelberg.de/docs/schemata/VODataService-v1.1.xsd http://www.ivoa.net/xml/VOSITables/v1.0 http://vo.ari.uni-heidelberg.de/docs/schemata/VOSITables-v1.0.xsd">
+  <schema>
+    <name>test</name>
+    <table>
+      <name>description</name>
+    </table>
+  </schema>
+</vtm:tableset>

--- a/pyvo/io/vosi/tests/data/tables/single_table_description.xml
+++ b/pyvo/io/vosi/tests/data/tables/single_table_description.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<?xml-stylesheet href='/static/xsl/vosi.xsl' type='text/xsl'?>
+<vtm:tableset xmlns:vs="http://www.ivoa.net/xml/VODataService/v1.1" xmlns:vtm="http://www.ivoa.net/xml/VOSITables/v1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.ivoa.net/xml/VODataService/v1.1 http://vo.ari.uni-heidelberg.de/docs/schemata/VODataService-v1.1.xsd http://www.ivoa.net/xml/VOSITables/v1.0 http://vo.ari.uni-heidelberg.de/docs/schemata/VOSITables-v1.0.xsd">
+  <schema>
+    <name>test</name>
+    <table>
+      <name>description</name>
+      <description>A test table with a single description</description>
+    </table>
+  </schema>
+</vtm:tableset>

--- a/pyvo/io/vosi/tests/test_tables.py
+++ b/pyvo/io/vosi/tests/test_tables.py
@@ -3,6 +3,8 @@
 """
 Tests for pyvo.io.vosi
 """
+import contextlib
+import io
 import pytest
 
 import pyvo.io.vosi as vosi
@@ -377,10 +379,23 @@ class TestTables:
                     "data/tables/no_table_description.xml"))
         nodesc_table = tableset.get_first_table()
         assert nodesc_table.description is None
-        import io
-        from contextlib import redirect_stdout
 
-        with io.StringIO() as buf, redirect_stdout(buf):
+        with io.StringIO() as buf, contextlib.redirect_stdout(buf):
             nodesc_table.describe()
             output = buf.getvalue()
         assert 'No description' in output
+
+    def test_single_table_description(self):
+        """Test describing a table with a single description
+        """
+        tableset = vosi.parse_tables(
+                get_pkg_data_filename(
+                    "data/tables/single_table_description.xml"))
+        onedesc_table = tableset.get_first_table()
+        describe_string = 'A test table with a single description'
+        assert describe_string in onedesc_table.description
+
+        with io.StringIO() as buf, contextlib.redirect_stdout(buf):
+            onedesc_table.describe()
+            output = buf.getvalue()
+        assert describe_string in output

--- a/pyvo/io/vosi/tests/test_tables.py
+++ b/pyvo/io/vosi/tests/test_tables.py
@@ -368,3 +368,19 @@ class TestTables:
             vosi.parse_tables(
                 get_pkg_data_filename(
                     "data/tables/wrong_arraysize.xml"))
+
+    def test_no_table_description(self):
+        """Test handling of describing tables with no description
+        """
+        tableset = vosi.parse_tables(
+                get_pkg_data_filename(
+                    "data/tables/no_table_description.xml"))
+        nodesc_table = tableset.get_first_table()
+        assert nodesc_table.description is None
+        import io
+        from contextlib import redirect_stdout
+
+        with io.StringIO() as buf, redirect_stdout(buf):
+            nodesc_table.describe()
+            output = buf.getvalue()
+        assert 'No description' in output

--- a/pyvo/io/vosi/vodataservice.py
+++ b/pyvo/io/vosi/vodataservice.py
@@ -311,7 +311,10 @@ class Table(Element):
 
     def describe(self):
         print(self.name)
-        print(indent(self.description))
+        if self.description is not None:
+            print(indent(self.description))
+        else:
+            print('No description')
 
         print()
 


### PR DESCRIPTION
This small PR is to address an issue we have found in describing available tables from a TAP service, when a description is not provided.

To test:
```
import pyvo as vo
irsa_services = vo.regsearch(servicetype='table', keywords=['irsa'])
irsa_tap = irsa_services[0]
irsa_tap.service.tables.describe()
```
The fix in the PR is to print `No description` instead of raising an exception.