### PR TITLE
Fix __repr__ on DataType

### DIFF
--- a/pyvo/io/vosi/tests/test_tables.py
+++ b/pyvo/io/vosi/tests/test_tables.py
@@ -37,8 +37,9 @@ class TestTables:
         assert col.utype == "utype"
 
         assert type(col.datatype) == vs.TAPType
+        assert str(col.datatype) == "<DataType arraysize=*>VARCHAR</DataType>"
         assert col.datatype.arraysize == "*"
-        assert col.datatype.delim == ';'
+        assert col.datatype.delim == ";"
         assert col.datatype.size == "42"
         assert col.datatype.content == "VARCHAR"
 

--- a/pyvo/io/vosi/vodataservice.py
+++ b/pyvo/io/vosi/vodataservice.py
@@ -714,7 +714,7 @@ class DataType(ContentMixin, Element):
 
     def __repr__(self):
         return '<DataType arraysize={}>{}</DataType>'.format(
-            self.arraysize, self.value)
+            self.arraysize, self.content)
 
     @xmlattribute
     def arraysize(self):


### PR DESCRIPTION
Fixes #202, as mentioned on the issue, looks like we just need to
use content instead of value.  Added a test that fails to start,
and passes afterward.