### PR TITLE
MNT: Ignore import error in pytest collection

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,3 +45,6 @@ install_requires = astropy requests mimeparse
 version = 1.1.dev
 
 [entry_points]
+
+[tool:pytest]
+addopts = --doctest-ignore-import-errors


### PR DESCRIPTION
This is an automated update made by the `batchpr` tool :robot: to future-proof test collection behavior `pytest-doctestplus` - feel free to close if it doesn't look good or isn't relevant! You can report issues to @pllim.