### PR TITLE
Travis job to release to PyPI

### DIFF
--- a/.publish.sh
+++ b/.publish.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
-# Deploys a Python library or application
+# Deploys a Python library or application to the PyPI repo
+# $TRAVIS_TAG is the version of the software and need to match the version
+# specified in the setup.cfg file. Calling environment must also provide the
+# value of the TWINE_PASSWORD environment variable.
 
 echo "Deploying version $TRAVIS_TAG..."
 # check that the version in the tag and in setup.cfg match
@@ -12,9 +15,9 @@ sed 's/ //g' setup.cfg | grep "^version=$TRAVIS_TAG" || { \
 python setup.py clean sdist bdist_wheel || { echo "Errors building"; exit 255; }
 #upload to pypi
 
-echo "Publishing pyvo ${TRAVIS_TAG} on pypi"
-export TWINE_USERNAME=adriand
-export TWINE_REPOSITORY_URL=https://test.pypi.org/legacy/  #TODO comment out unless testing
+echo "Publishing pyvo $TRAVIS_TAG on pypi"
+export TWINE_USERNAME=PYPIUSER  # TODO replace with real user
+export TWINE_REPOSITORY_URL=https://test.pypi.org/legacy/  # TODO comment out unless testing
 twine upload --verbose dist/* || { echo "Errors publishing $TRAVIS_TAG"; exit 255; }
 
 

--- a/.publish.sh
+++ b/.publish.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Deploys a Python library or application
+
+echo "Deploying version $TRAVIS_TAG..."
+# check that the version in the tag and in setup.cfg match
+sed 's/ //g' setup.cfg | grep "^version=$TRAVIS_TAG" || { \
+   echo "Version in tag ($TRAVIS_TAG) does not match version in setup.cfg \
+($(sed 's/ //g' setup.cfg | grep '^version=' | awk -F '=' '{print $2}'))"; \
+   exit 255; }
+
+# build
+python setup.py clean sdist bdist_wheel || { echo "Errors building"; exit 255; }
+#upload to pypi
+
+echo "Publishing pyvo ${TRAVIS_TAG} on pypi"
+export TWINE_USERNAME=adriand
+export TWINE_REPOSITORY_URL=https://test.pypi.org/legacy/  #TODO comment out unless testing
+twine upload --verbose dist/* || { echo "Errors publishing $TRAVIS_TAG"; exit 255; }
+
+
+# check version available
+pip uninstall -y pyvo
+pip install --upgrade --pre pyvo==$TRAVIS_TAG || { echo "$TRAVIS_TAG not installed on pypi" ; exit 255; }

--- a/.publish.sh
+++ b/.publish.sh
@@ -6,6 +6,7 @@
 
 echo "Deploying version $TRAVIS_TAG..."
 # check that the version in the tag and in setup.cfg match
+ [ -z "$TRAVIS_TAG" ] && echo "BUG: TRAVIS_TAG empty" && exit 255
 sed 's/ //g' setup.cfg | grep "^version=$TRAVIS_TAG" || { \
    echo "Version in tag ($TRAVIS_TAG) does not match version in setup.cfg \
 ($(sed 's/ //g' setup.cfg | grep '^version=' | awk -F '=' '{print $2}'))"; \

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,9 @@ stages:
    # These will only run when cron is opted in
    - name: Cron tests
      if: type = cron
+   - name: Release to PyPI
+     if: (env(TWINE_PASSWORD) IS present) AND (tag IS present)
+
 
 env:
     global:
@@ -95,6 +98,12 @@ matrix:
         - os: windows
           stage: Windows test
 
+        - os: linux
+          stage: Release
+          env: PYTHON_VERSION=3.7 PIP_DEPENDENCIES='pytest-astropy requests mimeparse requests_mock wheel twine'
+               MAIN_CMD='./.publish.sh'
+
+
 
 install:
     - git clone git://github.com/astropy/ci-helpers.git
@@ -107,3 +116,4 @@ after_success:
     - if [[ $SETUP_CMD == 'test --coverage' ]]; then
           codecov;
       fi
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,7 @@ matrix:
           stage: Windows test
 
         - os: linux
-          stage: Release
+          stage: Release to PyPI
           env: PYTHON_VERSION=3.7 PIP_DEPENDENCIES='pytest-astropy requests mimeparse requests_mock wheel twine'
                MAIN_CMD='./.publish.sh'
 

--- a/pyvo/dal/params.py
+++ b/pyvo/dal/params.py
@@ -335,13 +335,13 @@ class PosQueryParam(AbstractDalQueryParam):
             self._validate_ra(ra_min)
             self._validate_ra(ra_max)
             if ra_max.to(u.deg) < ra_min.to(u.deg):
-                raise ValueError('min > max in ra range: '.format(ra_min,
-                                                                  ra_max))
+                raise ValueError('min > max in ra range: {} > {}'.
+                                 format(ra_min, ra_max))
             self._validate_dec(dec_min)
             self._validate_dec(dec_max)
             if dec_max.to(u.deg) < dec_min.to(u.deg):
-                raise ValueError('min > max in dec range: '.format(dec_min,
-                                                                   dec_max))
+                raise ValueError('min > max in dec range: {} > {}'.
+                                 format(dec_min, dec_max))
         else:
             for i, m in enumerate(pos):
                 if i % 2:
@@ -387,8 +387,9 @@ class IntervalQueryParam(AbstractDalQueryParam):
                 low = val[0]
                 high = val[1]
             else:
-                raise ValueError('Too few/many values in interval attribute: '.
-                                 format(val))
+                raise ValueError(
+                    'Too few/many values in interval attribute: {}'.
+                    format(val))
         else:
             high = low = val
         if isinstance(low, (int, float)) and isinstance(high, (int, float))\
@@ -422,8 +423,9 @@ class TimeQueryParam(AbstractDalQueryParam):
                 min_time = val[0]
                 max_time = val[1]
             else:
-                raise ValueError('Too few/many members in time attribute: '.
-                                 format(val))
+                raise ValueError(
+                    'Too few/many members in time attribute: {}'.
+                    format(val))
         else:
             max_time = min_time = val
 


### PR DESCRIPTION
#181 

The idea is to reduce the releasing of a new version of `pypi` to creating a release in github, with Travis taking care of PyPI publishing. The only requirement is that the `astropy/pyvo` in Travis is configured with the TWINE_PASSWORD environment variable. Although Travis has some safeguards around secret environment variables (https://docs.travis-ci.com/user/environment-variables/#defining-variables-in-repository-settings) it could be seen as lowering the security bar. @bsipocz has `astropy` org tried/discussed this before? We probably need their agreement.

For a new release, just create a new `github` release in `pyvo` with the label matching the version number. Note that the label needs to match the version number of the `setup.cfg` file in order for the release task to complete successfully.

The mechanism could be used to push to anaconda as well. I'm just not familiar with that process.

Bonus: this also publishes the wheel to address #228 

@cbanek @funbaker @msdemlei or others - please feel free to comment.