### PR TITLE
MNT: Bump Python minversion

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ package_info['package_data'][PACKAGENAME].extend(c_files)
 setup(name=PACKAGENAME,
       version=VERSION,
       description=DESCRIPTION,
-      python_requires='>=3.5',
+      python_requires='>=3.7',
       install_requires=metadata.get('install_requires', 'astropy').strip().split(),
       author=AUTHOR,
       author_email=AUTHOR_EMAIL,


### PR DESCRIPTION
Direct follow-up of #246 . I inferred your supported Python minversion from your new test matrix.

Officially dropping Python 3.5 is required for #239 to proceed.