### PR TITLE
Cleanup usage of deprecated features

### DIFF
--- a/pyvo/conftest.py
+++ b/pyvo/conftest.py
@@ -23,7 +23,7 @@ else:
     # automatically made available when Astropy is installed. This means it's
     # not necessary to import them here, but we still need to import global
     # variables that are used for configuration.
-    from astropy.tests.plugins.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
+    from pytest_astropy_header.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
 
 from astropy.tests.helper import enable_deprecations_as_exceptions
 

--- a/pyvo/dal/params.py
+++ b/pyvo/dal/params.py
@@ -3,7 +3,7 @@
 This file contains functionallity related to VOTABLE Params.
 """
 import numpy as np
-from collections import MutableSet
+from collections.abc import MutableSet
 import abc
 
 from astropy import units as u

--- a/pyvo/dal/query.py
+++ b/pyvo/dal/query.py
@@ -34,7 +34,7 @@ import collections
 
 from warnings import warn
 
-from astropy.table.table import Table
+from astropy.table import Table
 from astropy.io.votable import parse as votableparse
 from astropy.io.votable.ucd import parse_ucd
 from astropy.utils.exceptions import AstropyDeprecationWarning

--- a/pyvo/dal/tests/test_query.py
+++ b/pyvo/dal/tests/test_query.py
@@ -319,7 +319,7 @@ class TestDALResults:
         dalresults = DALResults.from_result_url(
             'http://example.com/query/basic')
 
-        assert repr(dalresults) == repr(dalresults.table())
+        assert repr(dalresults) == repr(dalresults.to_table())
 
     def test_iter(self):
         dalresults = DALResults.from_result_url(
@@ -345,8 +345,8 @@ class TestDALResults:
         dalresults = DALResults.from_result_url(
             'http://example.com/query/basic')
 
-        assert isinstance(dalresults.table(), Table)
-        assert len(dalresults) == len(dalresults.table())
+        assert isinstance(dalresults.to_table(), Table)
+        assert len(dalresults) == len(dalresults.to_table())
 
     def test_id_over_name(self):
         dalresults = DALResults.from_result_url(


### PR DESCRIPTION
The deprecated namespace import of `MuteableSet` triggers an error in the astroquery CI, so have fixed it.

And while I have been at it, I've cleaned up the rest of the deprecations I saw when running the pyvo tests.


```
In [3]: from collections import MutableSet
<ipython-input-3-54f28932addb>:1: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
```