### PR TITLE
Fix for #228 that sometimes fails installs on fresh Python environments.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ license = BSD
 url = https://github.com/astropy/pyvo
 edit_on_github = False
 github_project = astropy/pyvo
-install_requires = astropy requests mimeparse
+install_requires = wheel astropy requests mimeparse
 # version should be PEP440 compatible (http://www.python.org/dev/peps/pep-0440)
 version = 1.2.dev
 


### PR DESCRIPTION
Add wheel to the `install_requires` setup config for the time being.