### PR TITLE
Github action to publish to pypi and test pypi

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,56 @@
+name: Publish to pypi
+
+on:
+  push:
+
+jobs:
+  build-n-publish:
+    name: Build and publish Python 🐍 distributions 📦 to PyPI
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    - name: Install python-build and twine
+      run: python -m pip install build "twine>=3.3"
+
+    - name: Build package
+      run: python -m build --sdist --wheel .
+
+    - name: List result
+      run: ls -l dist
+
+    - name: Check long_description
+      run: python -m twine check --strict dist/*
+
+    - name: Do a test install of the package
+      run: |
+        cd ..
+        python -m venv testenv
+        testenv/bin/pip install pyvo pyvo/dist/*.whl
+
+    - name: Test publish package to TestPyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/
+
+    - name: Check version is valid
+      if: startsWith(github.ref, 'refs/tags')
+      run: |
+        REPO_VERSION=`echo "$GITHUB_REF" | sed -E 's,/refs/tags/,,'`
+        grep "^version = $REPO_VERSION" setup.cfg || (echo "Version in tag $REPO_VERSION does not match version in setup.cfg" && exit -1)
+
+    - name: Publish distribution 📦 to PyPI
+      if: startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}
+

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -5,20 +5,17 @@ These steps are intended to help guide a developer into
 making a new release.  For these instructions, version
 is to be replaced by the version number of the release.
 
-1. Edit setup.cfg and remove .dev from the version number
+1. Make a PR with the following changes to publish a release:
 
-2. Edit CHANGES.rst to change unreleased to the date of the release.
+- Edit setup.cfg and remove .dev from the version number
+- Edit CHANGES.rst to change unreleased to the date of the release
 
-3. Commit and push
+2. Use the GitHub releases to draft a new release, and put the version
+number in for the tag.  This tag must match what is in the setup.cfg
+(without the dev).  This will trigger a github action that builds
+the release and uploads it to pypi.
 
-4. git tag -a version -m "releasing new version version" (this makes a release tag)
+3. Make a PR with the following changes to begin the new release cycle:
 
-5. git push origin version
-
-6. python setup.py sdist (this makes a .tar.gz of the package in dist)
-
-7. twine upload sdist/* (this uploads the output of the previous step to pypi)
-
-8. Edit setup.cfg and set the version to the next release number and add .dev after the version number.  Add a new section at the top for the next release number
-
-9. Commit and push.  This begins the new release
+- Edit setup.cfg and set the version to the next release number plus ".dev"
+- Add a new section at the top of CHANGES.rst for the next release number

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ exclude = extern,sphinx,*parsetab.py
 package_name = pyvo
 description = Astropy affiliated package for accessing Virtual Observatory data and services
 long_description =
+long_description_content_type = text/x-rst
 author = the IVOA community
 author_email = sbecker@ari.uni-heidelberg.de
 license = BSD


### PR DESCRIPTION
Fixes #247. Also fixes #181 .

Adds a github publish hook that should run if we make a tag.  Also updated the release instructions