### PR TITLE
Support for TAP table create/delete/upload CADC prototype

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,6 @@
 1.4 (unreleased)
 ================
+- Added the TAP Table Manipulation prototype (cadc-tb-upload). [#274]
 
 - we now ignore namespaces in xsi-type attributes; this is a lame fix
   for services like ESO's and MAST's TAP, which do not use canonical

--- a/docs/dal/index.rst
+++ b/docs/dal/index.rst
@@ -186,6 +186,61 @@ The uploaded tables will be available as ``TAP_UPLOAD.name``.
   The supported upload methods are available under
   :py:meth:`~pyvo.dal.tap.TAPService.upload_methods`.
 
+.. _table manipulation:
+
+Table Manipulation
+^^^^^^^^^^^^^^^^^^
+
+.. note::
+    This is a prototype implementation and the interface might not be stable.
+    More details about the feature at: :ref:`cadc-tb-upload`
+
+Some services allow users to create, modify and delete tables. Typically, these
+functionality is only available to authenticated (and authorized) users.
+
+.. Requires proper credentials and authorization
+.. doctest-skip::
+
+    >>> auth_session = vo.auth.AuthSession()
+    >>> # authenticate. For ex: auth_session.credentials.set_client_certificate('<cert_file>')
+    >>> tap_service = vo.dal.TAPService("https://ws-cadc.canfar.net/youcat", auth_session)
+    >>>
+    >>> table_definition = '''
+    >>> <vosi:table xmlns:vosi="http://www.ivoa.net/xml/VOSITables/v1.0" xmlns:vod="http://www.ivoa.net/xml/VODataService/v1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" type="output">
+    >>>     <name>my_table</name>
+    >>>     <description>This is my very own table</description>
+    >>>     <column>
+    >>>         <name>article</name>
+    >>>         <description>some article</description>
+    >>>         <dataType xsi:type="vod:VOTableType" arraysize="30*">char</dataType>
+    >>>     </column>
+    >>>     <column>
+    >>>         <name>count</name>
+    >>>         <description>how many</description>
+    >>>         <dataType xsi:type="vod:VOTableType">long</dataType>
+    >>>     </column>
+    >>> </vosi:table> '''
+    >>> tap_service.create_table('test_schema.test_table', StringIO(table_definition))
+
+Table content can be loaded from a file or from memory. Supported data formats:
+tab-separated values (tsv), comma-separated values (cvs) or VOTable (VOTable):
+
+.. doctest-skip::
+
+    >>> tap_service.load_table('test_schema.test_table', StringIO('article,count\narticle1,10\narticle2,20\n'), 'csv')
+
+Users can also create indexes on single columns:
+.. doctest-skip::
+
+    >>> tap_service.create_index('test_schema.test_table', 'article', unique=True)
+
+Finally, tables and their content can be removed:
+
+.. doctest-skip::
+
+    >>> tap_service.remove_table('test_schema.test_table')
+
+
 .. _pyvo-sia:
 
 Simple Image Access

--- a/docs/dal/index.rst
+++ b/docs/dal/index.rst
@@ -206,39 +206,40 @@ functionality is only available to authenticated (and authorized) users.
     >>> tap_service = vo.dal.TAPService("https://ws-cadc.canfar.net/youcat", auth_session)
     >>>
     >>> table_definition = '''
-    >>> <vosi:table xmlns:vosi="http://www.ivoa.net/xml/VOSITables/v1.0" xmlns:vod="http://www.ivoa.net/xml/VODataService/v1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" type="output">
-    >>>     <name>my_table</name>
-    >>>     <description>This is my very own table</description>
-    >>>     <column>
-    >>>         <name>article</name>
-    >>>         <description>some article</description>
-    >>>         <dataType xsi:type="vod:VOTableType" arraysize="30*">char</dataType>
-    >>>     </column>
-    >>>     <column>
-    >>>         <name>count</name>
-    >>>         <description>how many</description>
-    >>>         <dataType xsi:type="vod:VOTableType">long</dataType>
-    >>>     </column>
-    >>> </vosi:table> '''
-    >>> tap_service.create_table('test_schema.test_table', StringIO(table_definition))
+    ... <vosi:table xmlns:vosi="http://www.ivoa.net/xml/VOSITables/v1.0" xmlns:vod="http://www.ivoa.net/xml/VODataService/v1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" type="output">
+    ...     <name>my_table</name>
+    ...     <description>This is my very own table</description>
+    ...     <column>
+    ...         <name>article</name>
+    ...         <description>some article</description>
+    ...         <dataType xsi:type="vod:VOTableType" arraysize="30*">char</dataType>
+    ...     </column>
+    ...     <column>
+    ...         <name>count</name>
+    ...         <description>how many</description>
+    ...         <dataType xsi:type="vod:VOTableType">long</dataType>
+    ...     </column>
+    ... </vosi:table> '''
+    >>> tap_service.create_table(name='test_schema.test_table', definition=StringIO(table_definition))
 
 Table content can be loaded from a file or from memory. Supported data formats:
 tab-separated values (tsv), comma-separated values (cvs) or VOTable (VOTable):
 
 .. doctest-skip::
 
-    >>> tap_service.load_table('test_schema.test_table', StringIO('article,count\narticle1,10\narticle2,20\n'), 'csv')
+    >>> tap_service.load_table(name='test_schema.test_table',
+    ...                        source=StringIO('article,count\narticle1,10\narticle2,20\n'), format='csv')
 
 Users can also create indexes on single columns:
 .. doctest-skip::
 
-    >>> tap_service.create_index('test_schema.test_table', 'article', unique=True)
+    >>> tap_service.create_index(table_name='test_schema.test_table', column_name='article', unique=True)
 
 Finally, tables and their content can be removed:
 
 .. doctest-skip::
 
-    >>> tap_service.remove_table('test_schema.test_table')
+    >>> tap_service.remove_table(name='test_schema.test_table')
 
 
 .. _pyvo-sia:

--- a/docs/prototypes/index.rst
+++ b/docs/prototypes/index.rst
@@ -76,7 +76,7 @@ Feature Registry
 ================
 
 The feature registry is a static ``features`` dictionary in the `~pyvo.utils.prototype` package. The key is the name
-of the feature and the value is an instance of the `~pyvo.utils.prototype.Feature` class. This class is responsible for determining
+of the feature and the value is an instance of the `~pyvo.utils.protofeature.Feature` class. This class is responsible for determining
 whether an instance should error or not, and to format an error message if it's not. While the current implementation
 of the ``Feature`` class is simple, future requirements might lead to other implementations with more complex logic or
 additional documentation elements.
@@ -87,3 +87,23 @@ Reference/API
 =============
 
 .. automodapi:: pyvo.utils.prototype
+
+
+Existing Prototypes
+===================
+
+.. _cadc-tb-upload:
+
+CADC Table Manipulation (cadc-tb-upload)
+----------------------------------------
+
+This is a proposed extension to the TAP protocol to allow users to manipulate
+tables (https://wiki.ivoa.net/twiki/bin/view/IVOA/TAP-1_1-Next). The
+`~pyvo.dal.tap.TAPService` has been extended with methods that allow for:
+
+* table creation
+* column index creation
+* table content upload
+* table removal
+
+More details at: :ref:`table manipulation`

--- a/pyvo/auth/authsession.py
+++ b/pyvo/auth/authsession.py
@@ -69,6 +69,18 @@ class AuthSession:
         """
         return self._request('POST', url, **kwargs)
 
+    def put(self, url, **kwargs):
+        """
+        Wrapper to make a HTTP PUT request with authentication.
+        """
+        return self._request('PUT', url, **kwargs)
+
+    def delete(self, url, **kwargs):
+        """
+        Wrapper to make a HTTP DELETE request with authentication.
+        """
+        return self._request('DELETE', url, **kwargs)
+
     def _request(self, http_method, url, **kwargs):
         """
         Make an HTTP request with authentication.

--- a/pyvo/dal/tests/test_tap.py
+++ b/pyvo/dal/tests/test_tap.py
@@ -8,6 +8,7 @@ import datetime
 import re
 from io import BytesIO
 from urllib.parse import parse_qsl
+import tempfile
 
 import pytest
 import requests_mock
@@ -15,6 +16,7 @@ import requests_mock
 from pyvo.dal.tap import escape, search, AsyncTAPJob, TAPService
 from pyvo.io.uws import JobFile
 from pyvo.io.uws.tree import Parameter, Result
+from pyvo.utils import prototype
 
 from astropy.time import Time, TimeDelta
 
@@ -48,6 +50,82 @@ def sync_fixture(mocker):
         'POST', 'http://example.com/tap/sync', content=callback
     ) as matcher:
         yield matcher
+
+
+@pytest.fixture()
+def create_fixture(mocker):
+    def match_request(request):
+        data = request.text.read()
+        if b'VOSITable' in data:
+            assert request.headers['Content-Type'] == 'text/xml',\
+                'Wrong file format'
+        elif b'VOTable' in data:
+            assert request.headers['Content-Type'] == \
+                   'application/x-votable+xml', 'Wrong file format'
+        else:
+            assert False, 'BUG'
+        return True
+
+    with mocker.register_uri(
+        'PUT', 'https://example.com/tap/tables/abc',
+        additional_matcher=match_request, status_code=201
+    ) as matcher:
+        yield matcher
+
+
+@pytest.fixture()
+def delete_fixture(mocker):
+    with mocker.register_uri(
+        'DELETE', 'https://example.com/tap/tables/abc', status_code=200,
+    ) as matcher:
+        yield matcher
+
+
+@pytest.fixture()
+def load_fixture(mocker):
+    def match_request(request):
+        data = request.text.read()
+        if b',' in data:
+            assert request.headers['Content-Type'] == 'text/csv',\
+                'Wrong file format'
+        elif b'\t' in data:
+            assert request.headers['Content-Type'] == \
+                   'text/tab-separated-values', 'Wrong file format'
+        elif b'FITSTable' in data:
+            assert request.headers['Content-Type'] == \
+                   'application/fits', 'Wrong file format'
+        else:
+            assert False, 'BUG'
+        return True
+
+    with mocker.register_uri(
+        'POST', 'https://example.com/tap/load/abc',
+        additional_matcher=match_request, status_code=200,
+    ) as matcher:
+        yield matcher
+
+
+def get_index_job(phase):
+    return """<?xml version="1.0" encoding="UTF-8"?>
+    <uws:job xmlns:uws="http://www.ivoa.net/xml/UWS/v1.0"
+    xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1">
+        <uws:jobId>v3njuz4k1ebpdb5q</uws:jobId>
+        <uws:runId />
+        <uws:ownerId>user</uws:ownerId>
+        <uws:phase>{}</uws:phase>
+        <uws:quote>2021-10-29T17:34:19.638</uws:quote>
+        <uws:creationTime>2021-10-28T17:34:19.638</uws:creationTime>
+        <uws:startTime xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+        <uws:endTime xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+        <uws:executionDuration>14400</uws:executionDuration>
+        <uws:destruction>2021-11-04T17:34:19.638</uws:destruction>
+        <uws:parameters>
+            <uws:parameter id="index">article</uws:parameter>
+            <uws:parameter id="table">cadcauthtest1.pyvoTestTable</uws:parameter>
+            <uws:parameter id="unique">true</uws:parameter>
+        </uws:parameters>
+        <uws:results />
+    </uws:job>""".format(phase).encode('utf-8')
 
 
 class MockAsyncTAPServer:
@@ -516,3 +594,100 @@ class TestTAPService:
         assert len(service.get_job_list(phases=['EXECUTING'], last=3)) == 5
         assert len(service.get_job_list(phases=['EXECUTING'], last=3,
                                         after=datetime.datetime.now())) == 6
+
+    @pytest.mark.usefixtures('create_fixture')
+    def test_create_table(self):
+        prototype.activate_features('cadc-tb-upload')
+        try:
+            buffer = BytesIO(b'table definition in VOSITable format')
+            service = TAPService('https://example.com/tap')
+            service.create_table(name='abc', definition=buffer)
+            tmpfile = tempfile.NamedTemporaryFile('w+b', delete=False)
+            tmpfile.write(b'table definition in VOTable format here')
+            tmpfile.close()
+            with open(tmpfile.name, 'rb') as f:
+                service.create_table('abc', definition=f, format='VOTable')
+
+            with pytest.raises(ValueError):
+                service.create_table('abc', definition=buffer, format='Unknown')
+            with pytest.raises(ValueError):
+                service.create_table('abc', definition=None, format='VOSITable')
+        finally:
+            prototype.deactivate_features('cadc-tb-upload')
+
+    @pytest.mark.usefixtures('delete_fixture')
+    def test_remove_table(self):
+        prototype.activate_features('cadc-tb-upload')
+        try:
+            service = TAPService('https://example.com/tap')
+            service.remove_table(name='abc')
+        finally:
+            prototype.deactivate_features('cadc-tb-upload')
+
+    @pytest.mark.usefixtures('load_fixture')
+    def test_load_table(self):
+        # csv content in buffer
+        prototype.activate_features('cadc-tb-upload')
+        try:
+            service = TAPService('https://example.com/tap')
+            table_content = BytesIO(b'article,count\nart1,1\nart2,2\nart3,3')
+            service.load_table(name='abc', source=table_content, format='csv')
+
+            # tsv content in file
+            tmpfile = tempfile.NamedTemporaryFile('w+b', delete=False)
+            tmpfile.write(b'article\tcount\nart1\t1\nart2\t2\nart3\t3')
+            tmpfile.close()
+            with open(tmpfile.name, 'rb') as f:
+                service.load_table('abc', source=f, format='tsv')
+
+            # FITSTable content in file
+            tmpfile = tempfile.NamedTemporaryFile('w+b', delete=False)
+            tmpfile.write(b'FITSTable content here')
+            tmpfile.close()
+            with open(tmpfile.name, 'rb') as f:
+                service.load_table('abc', source=f, format='FITSTable')
+
+            with pytest.raises(ValueError):
+                service.load_table('abc', source=table_content, format='Unknown')
+
+            with pytest.raises(ValueError):
+                service.load_table('abc', source=None, format='tsv')
+        finally:
+            prototype.deactivate_features('cadc-tb-upload')
+
+    def test_create_index(self):
+        prototype.activate_features('cadc-tb-upload')
+        try:
+            service = TAPService('https://example.com/tap')
+
+            def match_request_text(request):
+                # check details of index are present
+                return 'table=abc&index=col1&unique=true' in request.text
+
+            with requests_mock.Mocker() as rm:
+                # mock initial post to table-update and the subsequent calls to
+                # get, run and check status of the job
+                rm.post('https://example.com/tap/table-update',
+                        additional_matcher=match_request_text,
+                        status_code=303,
+                        headers={'Location': 'https://example.com/tap/uws'})
+                rm.get('https://example.com/tap/uws',
+                       [{'content': get_index_job("PENDING")},
+                        {'content':get_index_job("COMPLETED")}])
+                rm.post('https://example.com/tap/uws/phase', status_code=200)
+                # finally the call
+                service.create_index(table_name='abc', column_name='col1',
+                                     unique=True)
+            # test wrong return status code
+                with requests_mock.Mocker() as rm:
+                    # mock initial post to table-update and the subsequent calls to
+                    # get, run and check status of the job
+                    rm.post('https://example.com/tap/table-update',
+                            additional_matcher=match_request_text,
+                            status_code=200,  # NOT EXPECTED!
+                            headers={'Location': 'https://example.com/tap/uws'})
+                    with pytest.raises(RuntimeError):
+                        service.create_index(table_name='abc', column_name='col1',
+                                             unique=True)
+        finally:
+            prototype.deactivate_features('cadc-tb-upload')

--- a/pyvo/utils/protofeature.py
+++ b/pyvo/utils/protofeature.py
@@ -1,0 +1,52 @@
+from dataclasses import dataclass
+
+__all__ = ['Feature']
+
+
+@dataclass
+class Feature:
+    """
+    A prototype feature implementing a standard that is currently in the process of being approved, but that might
+    change as a result of the approval process. A Feature must have a name. Optionally, a feature may have a *url*
+    that is displayed to the user in case a feature is used without the user explicitly opting in on its usage.
+    The URL is expected to contain more information about the standard and its state in the approval process.
+    """
+    name: str
+    url: str = ''
+    on: bool = False
+
+    def should_error(self):
+        """
+        Should accessing this feature fail?
+
+        Returns
+        -------
+        bool Whether accessing this feature should result in an error.
+        """
+        return not self.on
+
+    def error(self, function_name):
+        """
+        Format an error message when the feature is being accesses without the user having opted in its usage.
+
+        This function will be used as a callback when an error message needs to be displayed to the user, with the
+        function name that was accessed as an argument. Extensions of this class may have additional information to
+        display.
+
+        Parameters
+        ----------
+        function_name: str
+            The name of the function associated to this feature and that the user called.
+
+        Returns
+        -------
+        str: The error message to be displayed to the user.
+
+        """
+        message = f'{function_name} is part of a prototype feature ({self.name}) that has not been activated. ' \
+                  f'For information about prototype features please refer to ' \
+                  f'https://pyvo.readthedocs.io/en/latest/prototypes .'
+        if self.url:
+            message += f' For more information about the {self.name} feature please visit {self.url}.'
+        message += f' To suppress this error and enable the feature use `pyvo.utils.activate_features(\'{self.name}\')`'
+        return message


### PR DESCRIPTION
This represents an implementation of a soon-to-be-proposed prototype for TAP1.2 to allow for the create/deletion of tables as well as bulk uploads of table content. The prototype service runs at the CADC and has the following characteristics:

**Table creation:**
Works with a PUT to the `/tables/<tableName>` end point. It supports 2 formats for the table schema: `VOSITable` and `VOTable`. These formats are identified by their corresponding `Content-Type`: `text/xml` and `application/x-votable+xml` respectively.

**Table removal (table drop in DB):**
Works with a DELETE to the `/tables/<tableName>` end point.

**Table load:**
Works with a sync POST to a special end point `/load/<tableName>` that is a sibling of the `/tables` end point. Supported data formats and their corresponding `Content-Type` are: `tsv` (`text/tab-separated-values`), `csv` (`text/csv`) and `FITSTable` as in FITS Binary Table (`application/fits`). Table must exist on the service.

**Index creation:**
Works with an async POST to a special end point `/table-update` that is sibling of the `/tables` end point. This mechanism supports the creation of single-column indexes only.