### PR TITLE
Adding missing test files

### DIFF
--- a/pyvo/dal/tests/setup_package.py
+++ b/pyvo/dal/tests/setup_package.py
@@ -17,5 +17,7 @@ def get_package_data():
         os.path.join('data/ssa', '*.xml'),
         os.path.join('data/datalink', '*.xml'),
         os.path.join('data', '*.xml'),
+        os.path.join('data/mimetype', '*jpg'),
+        os.path.join('data/mimetype', '*fits'),
     ]
     return {'pyvo.dal.tests': paths}


### PR DESCRIPTION
PR #276 added these files, but they were not pickup at build time.

CI didn't choke on this as it was running pytest directly on the source directory without building it, so it wouldn't pick up any issues with files not ending up in the source distribution. We bumped in this issue (as well as into the missing pillow which could be easily solved with #281) with @tomdonaldson when we run the test locally before cutting a release.