### PR TITLE
Get wraps from functools instead of astropy

### DIFF
--- a/pyvo/utils/decorators.py
+++ b/pyvo/utils/decorators.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from functools import partial
-from astropy.utils.decorators import wraps
+from functools import partial, wraps
 
 
 def stream_decode_content(func):


### PR DESCRIPTION
CI broke [against devastropy](https://github.com/astropy/pyvo/runs/4710107403?check_suite_focus=true) due to the `wraps` decorator being removed from `astropy.utils.decorators` as part of astropy/astropy#12625.

It looks like that `wraps` was just a pass through from `functools`, so I changed the import to get `wraps` directly from `functools`. 