### PR TITLE
Handle custom terms in datalink.bysemantics again.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 1.3 (unreleased)
 ================
 
+- pyvo deals with non-core terms in datalink.bysemantics again. [#299]
 
 1.2.1 (2022-01-12)
 ==================

--- a/pyvo/dal/tests/data/datalink/proc.xml
+++ b/pyvo/dal/tests/data/datalink/proc.xml
@@ -71,6 +71,16 @@
             <TD>image/jpeg</TD>
             <TD>-1</TD>
           </TR>
+          <TR>
+            <TD>ivo://org.gavo.dc/s/data/gds_big/v6a/2010/GDS_0644-0035/i_s/eq010000ms/20100927.comb_avg.0001.fits.fz</TD>
+            <TD>http://example.edu/when-will-it-be-back</TD>
+            <TD/>
+            <TD/>
+            <TD>Something requiring custom semantics.</TD>
+            <TD>urn:example:rdf/dlext#oracle</TD>
+            <TD>text/x-prediction</TD>
+            <TD>-1</TD>
+          </TR>
         </TABLEDATA>
       </DATA>
     </TABLE>

--- a/pyvo/dal/tests/test_datalink.py
+++ b/pyvo/dal/tests/test_datalink.py
@@ -162,3 +162,24 @@ class TestSemanticsRetrieval:
         assert len(res)==2
         assert res[0].endswith("eq010000ms/20100927.comb_avg.0001.fits.fz")
         assert res[1].endswith("http://dc.zah.uni-heidelberg.de/wider.dat")
+
+    def test_with_full_url(self):
+        datalink = DatalinkResults.from_result_url('http://example.com/proc')
+        res = [_debytify(r["access_url"])
+            for r in datalink.bysemantics("urn:example:rdf/dlext#oracle")]
+        assert len(res)==1
+        assert res[0].endswith("when-will-it-be-back")
+
+    def test_all_mixed(self):
+        datalink = DatalinkResults.from_result_url('http://example.com/proc')
+        res = [_debytify(r["access_url"])
+            for r in datalink.bysemantics([
+                "urn:example:rdf/dlext#oracle",
+                'http://www.ivoa.net/rdf/datalink/core#preview',
+                '#this',
+                'non-existing-term'])]
+        assert len(res)==4
+        assert res[0].endswith("eq010000ms/20100927.comb_avg.0001.fits.fz")
+        assert res[1].endswith("comb_avg.0001.fits.fz?preview=True")
+        assert res[2].endswith("http://dc.zah.uni-heidelberg.de/wider.dat")
+        assert res[3].endswith("when-will-it-be-back")


### PR DESCRIPTION
This is done by extracting non-core terms -- really, anything with a URI
that starts with something that is not the core URI -- and excepting
it from our normalisation.

This would fix #298.