### PR TITLE
Add mailmap file

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,15 @@
+Adam Ginsburg     <keflavich@gmail.com>
+Adrian Damian     <adrian.damian@nrc.ca> <Adrian.Damian@nrc.ca>
+Brigitta Sipőcz   <bsipocz@gmail.com>
+Brigitta Sipőcz   <bsipocz@gmail.com> <b.sipocz@gmail.com>
+Christine Banek   <cbanek@lsst.org> <cbanek@gmail.com>
+Hugo van Kemenade <hugovk@users.noreply.github.com>
+Markus Demleitner <m@tfiu.de>
+Pey Lian Lim      <2090236+pllim@users.noreply.github.com>
+Ray Plante        <rplante@ncsa.uiuc.edu> <rplante@ncsa.illinois.edu>
+Ray Plante        <rplante@ncsa.uiuc.edu> <raymond.plante@nist.gov>
+Stefan Becker     <ich@funbaker.de> <funbaker@users.noreply.github.com>
+Tess Jaffe        <trjaffe@gmail.com>
+Theresa Dower     <dower@stsci.edu>
+Tim Jenness       <tjenness@lsst.org> <tim.jenness@gmail.com>
+Tom Donaldson     <tdonaldson@stsci.edu>


### PR DESCRIPTION
The purpose of the mailmap file is to cleanup the inconsistencies for contributors in the git commits. No need to add everyone, only the cases that need some fixes (duplicates of names or emails, etc.)