### PR TITLE
Raise warnings as exceptions

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Run tests against devastropy
         run: tox -e py310-test-devastropy
 
-  oldestastropy:
+  oldestdeps:
     runs-on: ubuntu-latest
     needs: tests
     steps:
@@ -121,8 +121,8 @@ jobs:
           python-version: 3.8
       - name: Install tox
         run: python -m pip install --upgrade tox
-      - name: Run tests against oldestastropy
-        run: tox -e py38-test-oldestastropy
+      - name: Run tests against oldest dependencies
+        run: tox -e py38-test-oldestdeps
 
   #publish:
   #needs: coverage

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ htmlcov
 .coverage
 MANIFEST
 .ipynb_checkpoints
+.hypothesis
 
 # Sphinx
 docs/api
@@ -31,6 +32,7 @@ docs/_build
 
 # Packages/installer info
 *.egg
+*.eggs
 *.egg-info
 dist
 build

--- a/conftest.py
+++ b/conftest.py
@@ -12,13 +12,6 @@ except ImportError:
     PYTEST_HEADER_MODULES = {}
     TESTED_VERSIONS = {}
 
-try:
-    from pyvo import __version__ as version
-except ImportError:
-    version = 'unknown'
-
-TESTED_VERSIONS['pyvo'] = version
-
 # Make sure we use temporary directories for the config and cache
 # so that the tests are insensitive to local configuration.
 
@@ -28,7 +21,20 @@ os.environ['XDG_CACHE_HOME'] = tempfile.mkdtemp('astropy_cache')
 os.mkdir(os.path.join(os.environ['XDG_CONFIG_HOME'], 'astropy'))
 os.mkdir(os.path.join(os.environ['XDG_CACHE_HOME'], 'astropy'))
 
+try:
+    from pyvo import __version__ as version
+except ImportError:
+    version = 'unknown'
+
+TESTED_VERSIONS['pyvo'] = version
+
+
 # Note that we don't need to change the environment variables back or remove
 # them after testing, because they are only changed for the duration of the
 # Python process, and this configuration only matters if running pytest
 # directly, not from e.g. an IPython session.
+
+from astropy.utils.iers import conf as iers_conf
+
+# Disable IERS auto download for testing
+iers_conf.auto_download = False

--- a/conftest.py
+++ b/conftest.py
@@ -34,7 +34,7 @@ TESTED_VERSIONS['pyvo'] = version
 # Python process, and this configuration only matters if running pytest
 # directly, not from e.g. an IPython session.
 
+# Disable IERS auto download for testing (to support the local, non-remote-data scenario),
+# revisit this config when minimum supported astropy is 5.1.
 from astropy.utils.iers import conf as iers_conf
-
-# Disable IERS auto download for testing
 iers_conf.auto_download = False

--- a/docs/auth/index.rst
+++ b/docs/auth/index.rst
@@ -8,9 +8,3 @@ Reference/API
 =============
 
 .. automodapi:: pyvo.auth
-
-.. automodapi:: pyvo.auth.authsession
-
-.. automodapi:: pyvo.auth.authurls
-
-.. automodapi:: pyvo.auth.credentialstore

--- a/docs/dal/index.rst
+++ b/docs/dal/index.rst
@@ -358,6 +358,7 @@ datasets and/or access to additional data services.
 
 To obtain the names of the columns in a service response, write:
 
+.. doctest-skip::
 .. doctest-remote-data::
 
 >>> print(resultset.fieldnames)
@@ -366,6 +367,7 @@ Rich metadata equivalent to what is found in VOTables (including unit,
 ucd, utype, and xtype) is available through resultset's
 :py:meth:`~pyvo.dal.query.DALResults.getdesc` method:
 
+.. doctest-skip::
 .. doctest-remote-data::
 
 >>>  print(resultset.getdesc("accref").ucd)
@@ -375,10 +377,14 @@ ucd, utype, and xtype) is available through resultset's
     physics (by UCD) or with a particular legacy data model annotation
     (by utype), like this:
 
+.. doctest-skip::
+
     >>> fieldname = resultset.fieldname_with_ucd('phot.mag;em.opt.V')
     >>> fieldname = resultset.fieldname_with_utype('Access.Reference')
 
 Iterating over a resultset gives the rows in the result:
+
+.. doctest-skip::
 
 >>> for row in resultset:
 >>>     print row['accref']
@@ -386,10 +392,14 @@ Iterating over a resultset gives the rows in the result:
 
 The total number of rows in the answer is available as its ``len()``:
 
+.. doctest-skip::
+
 >>> print(len(resultset))
 9
 
 If the row contains datasets, they are exposed by several retrieval methods:
+
+.. doctest-skip::
 
 >>> url = row.getdataurl()
 >>> fileobj = row.getdataset()
@@ -401,13 +411,19 @@ to further work on.
 As with general numpy arrays, accessing individual columns via names gives an
 array of all of their values:
 
+.. doctest-skip::
+
 >>> column = resultset['accref']
 
 whereas integers retrieve columns:
 
+.. doctest-skip::
+
 >>> row = resultset[0]
 
 and both combined gives a single value:
+
+.. doctest-skip::
 
 >>> value = resultset['accref', 0]
 

--- a/docs/dal/index.rst
+++ b/docs/dal/index.rst
@@ -540,4 +540,3 @@ Reference/API
 
 .. automodapi:: pyvo.dal
 .. automodapi:: pyvo.dal.adhoc
-.. automodapi:: pyvo.dal.exceptions

--- a/docs/dal/index.rst
+++ b/docs/dal/index.rst
@@ -14,16 +14,16 @@ metadata.
 
 .. doctest-remote-data::
 
->>> import pyvo as vo
->>> service = vo.dal.SIAService("http://dc.zah.uni-heidelberg.de/lswscans/res/positions/siap/siap.xml")
->>> print(service.description)
+    >>> import pyvo as vo
+    >>> service = vo.dal.SIAService("http://dc.zah.uni-heidelberg.de/lswscans/res/positions/siap/siap.xml")
+    >>> print(service.description)
 
 They provide a ``search`` method with varying standard parameters for
 submitting queries.
 
 .. doctest-remote-data::
 
->>> resultset = service.search(pos=pos, size=size)
+    >>> resultset = service.search(pos=pos, size=size)
 
 which returns a :ref:`resultset <pyvo-resultsets>`.
 
@@ -44,7 +44,7 @@ Astrometrical parameters
 Most services expose the astrometrical parameters ``pos`` and ``size`` for which
 PyVO accept `~astropy.coordinates.SkyCoord` or `~astropy.units.Quantity`
 objects as well as any other sequence containing right ascension and declination
-in degrees, which are converted to the standard coordinate frame 
+in degrees, which are converted to the standard coordinate frame
 (in the VO, that usually is ICRS) in the standard units (always degrees
 in the VO) before they are submitted to the service.
 
@@ -53,12 +53,12 @@ astronomical objects you are searching for.
 
 .. doctest-remote-data::
 
->>> import pyvo as vo
->>> from astropy.coordinates import SkyCoord
->>> from astropy.units import Quantity
->>> 
->>> pos = SkyCoord.from_name('NGC 4993')
->>> size = Quantity(0.5, unit="deg")
+    >>> import pyvo as vo
+    >>> from astropy.coordinates import SkyCoord
+    >>> from astropy.units import Quantity
+    >>>
+    >>> pos = SkyCoord.from_name('NGC 4993')
+    >>> size = Quantity(0.5, unit="deg")
 
 See :ref:`astropy-coordinates` and :ref:`astropy-units` for details.
 
@@ -67,9 +67,9 @@ astrometrical parameter, such as waveband ranges.
 
 Some services also accept `~astropy.time.Time` as ``time`` parameter.
 
->>> from astropy.time import Time
->>> time = Time(('2015-01-01T00:00:00', '2018-01-01T00:00:00'),
-...             format='isot', scale='utc')
+    >>> from astropy.time import Time
+    >>> time = Time(('2015-01-01T00:00:00', '2018-01-01T00:00:00'),
+    ...             format='isot', scale='utc')
 
 See :ref:`astropy-time` for explanation.
 
@@ -90,12 +90,12 @@ VO services should offer some standard ”support” interfaces specified in
 VOSI.  In pyVO, the information obtained from these endpoints can be
 obtained from some service attributes.
 
-For availability (i.e., is the service up and running?), 
+For availability (i.e., is the service up and running?),
 this is :py:attr:`~pyvo.dal.mixin.AvailabilityMixin.available`
 and :py:attr:`~pyvo.dal.mixin.AvailabilityMixin.up_since`
 
 Capabilities describe specific pieces of functionality (such as “this is a
-spectral search”) and further metadata (such as ”this service will never 
+spectral search”) and further metadata (such as ”this service will never
 return more than 10000 rows”).
 
 This information is contained in the datastructure
@@ -124,29 +124,28 @@ language called *ADQL* instead of predefined search constraints.
 
 .. doctest-remote-data::
 
->>> tap_service = vo.dal.TAPService("http://dc.g-vo.org/tap")
->>> tap_results = tap_service.search("SELECT TOP 10 * FROM ivoa.obscore")
+    >>> tap_service = vo.dal.TAPService("http://dc.g-vo.org/tap")
+    >>> tap_results = tap_service.search("SELECT TOP 10 * FROM ivoa.obscore")
 
 As a sanity precaution, most services have some default limit of how many
 rows they will return before overflowing:
 
 .. doctest-remote-data::
 
->>> print(tap_service.maxrec)
+    >>> print(tap_service.maxrec)
 
 To retrieve more rows than that (often conservative) default limit, you
 must override maxrec in the call to ``search``:
 
 .. doctest-remote-data::
 
->>> tap_results = tap_service.search(
->>>     "SELECT * FROM ivoa.obscore", maxrec=100000)
+    >>> tap_results = tap_service.search("SELECT * FROM ivoa.obscore", maxrec=100000)
 
 Services will not let you raise maxrec beyond the hard match limit:
 
 .. doctest-remote-data::
 
->>> print(tap_service.hardlimit)
+    >>> print(tap_service.hardlimit)
 
 A list of the tables and the columns within them is available in the
 TAPService's :py:attr:`~pyvo.dal.TAPService.tables` attribute by using it as an
@@ -185,16 +184,16 @@ Basic queries are done with the ``pos`` and ``size`` parameters described in
 
 .. doctest-remote-data::
 
->>> pos = SkyCoord.from_name('Eta Carina')
->>> size = Quantity(0.5, unit="deg")
->>> sia_service = vo.dal.SIAService("http://dc.zah.uni-heidelberg.de/hppunion/q/im/siap.xml")
->>> sia_results = sia_service.search(pos=pos, size=size)
+    >>> pos = SkyCoord.from_name('Eta Carina')
+    >>> size = Quantity(0.5, unit="deg")
+    >>> sia_service = vo.dal.SIAService("http://dc.zah.uni-heidelberg.de/hppunion/q/im/siap.xml")
+    >>> sia_results = sia_service.search(pos=pos, size=size)
 
 The dataset format, 'all' by default, can be specified:
 
 .. doctest-remote-data::
 
->>> sia_results = sia_service.search(pos=pos, size=size, format='graphics')
+    >>> sia_results = sia_service.search(pos=pos, size=size, format='graphics')
 
 This would return all graphical image formats (png, jpeg, gif) available. Other
 possible values are image/* mimetypes, or ``metadata``, which returns no image
@@ -207,7 +206,7 @@ coverage of the images (case-insensitively):
 
 .. doctest-remote-data::
 
->>> sia_results = sia_service.search(pos=pos, size=size, intersect='covers')
+    >>> sia_results = sia_service.search(pos=pos, size=size, intersect='covers')
 
 Available values:
     ========= ======================================================
@@ -229,17 +228,17 @@ region is always circular with ``pos`` as center:
 
 .. doctest-remote-data::
 
->>> ssa_service = vo.dal.SSAService("http://www.isdc.unige.ch/vo-services/lc")
->>> ssa_results = ssa_service.search(pos=pos, diameter=size)
+    >>> ssa_service = vo.dal.SSAService("http://www.isdc.unige.ch/vo-services/lc")
+    >>> ssa_results = ssa_service.search(pos=pos, diameter=size)
 
 SSA queries can be further constrained by the ``band`` and ``time`` parameters.
 
 .. doctest-remote-data::
 
->>> ssa_results = ssa_service.search(
->>>     pos=pos, diameter=size,
->>>     time=time, band=Quantity((1e-13, 1e-12), unit="meter")
->>> )
+    >>> ssa_results = ssa_service.search(
+    ...     pos=pos, diameter=size,
+    ...     time=time, band=Quantity((1e-13, 1e-12), unit="meter")
+    ... )
 
 Simple Cone Search
 ------------------
@@ -249,9 +248,9 @@ within a circular region on the sky defined by the parameters ``pos``
 
 .. doctest-remote-data::
 
->>> scs_srv = vo.dal.SCSService(
->>>     'http://dc.zah.uni-heidelberg.de/arihip/q/cone/scs.xml')
->>> scs_results = scs_srv.search(pos=pos, radius=size)
+    >>> scs_srv = vo.dal.SCSService(
+    >>>     'http://dc.zah.uni-heidelberg.de/arihip/q/cone/scs.xml')
+    >>> scs_results = scs_srv.search(pos=pos, radius=size)
 
 This service exposes the :ref:`verbosity <pyvo-verbosity>` parameter
 
@@ -281,8 +280,8 @@ When you invoke ``submit job`` you will get a job object.
 
 .. doctest-remote-data::
 
->>> async_srv = vo.dal.TAPService("http://dc.g-vo.org/tap")
->>> job = async_srv.submit_job("SELECT * FROM ivoa.obscore")
+    >>> async_srv = vo.dal.TAPService("http://dc.g-vo.org/tap")
+    >>> job = async_srv.submit_job("SELECT * FROM ivoa.obscore")
 
 .. note::
     Currently, only `pyvo.dal.tap.TAPService` supports server-side jobs.
@@ -291,30 +290,30 @@ This job is not yet running yet. To start it invoke ``run``
 
 .. doctest-remote-data::
 
->>> job.run()
+    >>> job.run()
 
 Get the current job phase:
 
 .. doctest-remote-data::
 
->>> print(job.phase)
-RUN
+    >>> print(job.phase)
+    RUN
 
 Maximum run time in seconds is available and can be changed with
 :py:attr:`~pyvo.dal.tap.AsyncTAPJob.execution_duration`
 
 .. doctest-remote-data::
 
->>> print(job.execution_duration)
-3600
->>> job.execution_duration = 7200
+    >>> print(job.execution_duration)
+    3600
+    >>> job.execution_duration = 7200
 
 Obtaining the job url, which is needed to reconstruct the job at a later point:
 
 .. doctest-remote-data::
 
->>> job_url = job.url
->>> job = vo.dal.tap.AsyncTAPJob(job_url)
+    >>> job_url = job.url
+    >>> job = vo.dal.tap.AsyncTAPJob(job_url)
 
 Besides ``run`` there are also several other job control methods:
 
@@ -334,15 +333,15 @@ takes care of this automatically:
 
 .. doctest-remote-data::
 
->>> with async_srv.submit_job("SELECT * FROM ivoa.obscore") as job:
-...     job.run()
->>> print('Job deleted!')
+    >>> with async_srv.submit_job("SELECT * FROM ivoa.obscore") as job:
+    ...     job.run()
+    >>> print('Job deleted!')
 
 Check for errors in the job execution:
 
 .. doctest-remote-data::
 
->>> job.raise_if_error()
+    >>> job.raise_if_error()
 
 If the execution was successful, the resultset can be obtained using
 :py:meth:`~pyvo.dal.tap.AsyncTAPJob.fetch_result`
@@ -359,18 +358,16 @@ datasets and/or access to additional data services.
 To obtain the names of the columns in a service response, write:
 
 .. doctest-skip::
-.. doctest-remote-data::
 
->>> print(resultset.fieldnames)
+    >>> print(resultset.fieldnames)
 
 Rich metadata equivalent to what is found in VOTables (including unit,
 ucd, utype, and xtype) is available through resultset's
 :py:meth:`~pyvo.dal.query.DALResults.getdesc` method:
 
 .. doctest-skip::
-.. doctest-remote-data::
 
->>>  print(resultset.getdesc("accref").ucd)
+    >>>  print(resultset.getdesc("accref").ucd)
 
 .. note::
     Two convenience functions let you retrieve columns of a specific
@@ -386,24 +383,24 @@ Iterating over a resultset gives the rows in the result:
 
 .. doctest-skip::
 
->>> for row in resultset:
->>>     print row['accref']
-...
+    >>> for row in resultset:
+    ...     print row['accref']
+    ...
 
 The total number of rows in the answer is available as its ``len()``:
 
 .. doctest-skip::
 
->>> print(len(resultset))
-9
+    >>> print(len(resultset))
+    9
 
 If the row contains datasets, they are exposed by several retrieval methods:
 
 .. doctest-skip::
 
->>> url = row.getdataurl()
->>> fileobj = row.getdataset()
->>> obj = row.getdataobj()
+    >>> url = row.getdataurl()
+    >>> fileobj = row.getdataset()
+    >>> obj = row.getdataobj()
 
 Returning the access url, the file-like object or the appropiate python object
 to further work on.
@@ -413,19 +410,19 @@ array of all of their values:
 
 .. doctest-skip::
 
->>> column = resultset['accref']
+    >>> column = resultset['accref']
 
 whereas integers retrieve columns:
 
 .. doctest-skip::
 
->>> row = resultset[0]
+    >>> row = resultset[0]
 
 and both combined gives a single value:
 
 .. doctest-skip::
 
->>> value = resultset['accref', 0]
+    >>> value = resultset['accref', 0]
 
 Row objects may expose certain key columns as properties. See the corresponding
 API spec listed below for details.
@@ -444,7 +441,7 @@ identifying the dataset you want it to return.
 
 .. doctest-remote-data::
 
->>> preview = next(row.getdatalink().bysemantics('#preview')).getdataset()
+    >>> preview = next(row.getdatalink().bysemantics('#preview')).getdataset()
 
 .. note::
   Since the creation of datalink objects requires a network roundtrip, it is
@@ -454,7 +451,7 @@ Of course one can also build a datalink object from it's url.
 
 .. doctest-remote-data::
 
->>> datalink = DatalinkResults.from_result_url(url)
+    >>> datalink = DatalinkResults.from_result_url(url)
 
 Server-side processing
 ----------------------
@@ -469,7 +466,7 @@ interface.
 
 .. doctest-remote-data::
 
->>> datalink_proc = next(row.getdatalink().bysemantics('#proc'))
+    >>> datalink_proc = next(row.getdatalink().bysemantics('#proc'))
 
 .. note::
   most times there is only one processing service per result, and thats all you
@@ -484,7 +481,7 @@ can pass as keywords to the ``process`` method.
 
 .. doctest-remote-data::
 
->>> print(datalink_proc.input_params)
+    >>> print(datalink_proc.input_params)
 
 For more details about this have a look at
 :py:class:`astropy.io.votable.tree.Param`.
@@ -493,8 +490,8 @@ Calling the method will return a file-like object on sucess.
 
 .. doctest-remote-data::
 
->>> print(datalink_proc)
->>> fobj = datalink.process(circle=(1, 1, 1))
+    >>> print(datalink_proc)
+    >>> fobj = datalink.process(circle=(1, 1, 1))
 
 SODA
 ^^^^

--- a/docs/dal/index.rst
+++ b/docs/dal/index.rst
@@ -12,11 +12,16 @@ Getting started
 Service objects are created with the service url and provide service-specific
 metadata.
 
+.. doctest-remote-data::
+
+>>> import pyvo as vo
 >>> service = vo.dal.SIAService("http://dc.zah.uni-heidelberg.de/lswscans/res/positions/siap/siap.xml")
 >>> print(service.description)
 
 They provide a ``search`` method with varying standard parameters for
 submitting queries.
+
+.. doctest-remote-data::
 
 >>> resultset = service.search(pos=pos, size=size)
 
@@ -46,6 +51,8 @@ in the VO) before they are submitted to the service.
 Also, `~astropy.coordinates.SkyCoord` can be used to lookup names of
 astronomical objects you are searching for.
 
+.. doctest-remote-data::
+
 >>> import pyvo as vo
 >>> from astropy.coordinates import SkyCoord
 >>> from astropy.units import Quantity
@@ -61,10 +68,8 @@ astrometrical parameter, such as waveband ranges.
 Some services also accept `~astropy.time.Time` as ``time`` parameter.
 
 >>> from astropy.time import Time
->>> time = Time(
->>>     ('2015-01-01T00:00:00', '2018-01-01T00:00:00'),
->>>     format='isot', scale='utc'
->>> )
+>>> time = Time(('2015-01-01T00:00:00', '2018-01-01T00:00:00'),
+...             format='isot', scale='utc')
 
 See :ref:`astropy-time` for explanation.
 
@@ -117,21 +122,29 @@ Table Access Protocol
 Unlike the other services, this one works with tables queryable by an sql-ish
 language called *ADQL* instead of predefined search constraints.
 
+.. doctest-remote-data::
+
 >>> tap_service = vo.dal.TAPService("http://dc.g-vo.org/tap")
 >>> tap_results = tap_service.search("SELECT TOP 10 * FROM ivoa.obscore")
 
 As a sanity precaution, most services have some default limit of how many
 rows they will return before overflowing:
 
+.. doctest-remote-data::
+
 >>> print(tap_service.maxrec)
 
 To retrieve more rows than that (often conservative) default limit, you
 must override maxrec in the call to ``search``:
 
+.. doctest-remote-data::
+
 >>> tap_results = tap_service.search(
 >>>     "SELECT * FROM ivoa.obscore", maxrec=100000)
 
 Services will not let you raise maxrec beyond the hard match limit:
+
+.. doctest-remote-data::
 
 >>> print(tap_service.hardlimit)
 
@@ -170,12 +183,16 @@ Basic queries are done with the ``pos`` and ``size`` parameters described in
 :ref:`pyvo-astro-params`, with ``size`` being the rectangular region around
 ``pos``.
 
+.. doctest-remote-data::
+
 >>> pos = SkyCoord.from_name('Eta Carina')
 >>> size = Quantity(0.5, unit="deg")
 >>> sia_service = vo.dal.SIAService("http://dc.zah.uni-heidelberg.de/hppunion/q/im/siap.xml")
 >>> sia_results = sia_service.search(pos=pos, size=size)
 
 The dataset format, 'all' by default, can be specified:
+
+.. doctest-remote-data::
 
 >>> sia_results = sia_service.search(pos=pos, size=size, format='graphics')
 
@@ -187,6 +204,8 @@ by the given service.
 The ``intersect`` argument (defaulting to ``OVERLAPS``) lets a program
 specify the desired relationship between the region of interest and the
 coverage of the images (case-insensitively):
+
+.. doctest-remote-data::
 
 >>> sia_results = sia_service.search(pos=pos, size=size, intersect='covers')
 
@@ -208,10 +227,14 @@ subtile differences:
 The size parameter is called ``diameter`` here, and hence the search
 region is always circular with ``pos`` as center:
 
+.. doctest-remote-data::
+
 >>> ssa_service = vo.dal.SSAService("http://www.isdc.unige.ch/vo-services/lc")
 >>> ssa_results = ssa_service.search(pos=pos, diameter=size)
 
 SSA queries can be further constrained by the ``band`` and ``time`` parameters.
+
+.. doctest-remote-data::
 
 >>> ssa_results = ssa_service.search(
 >>>     pos=pos, diameter=size,
@@ -223,6 +246,8 @@ Simple Cone Search
 The Simple Cone Search returns results – typically catalog entries –
 within a circular region on the sky defined by the parameters ``pos``
 (again, ICRS) and ``radius``:
+
+.. doctest-remote-data::
 
 >>> scs_srv = vo.dal.SCSService(
 >>>     'http://dc.zah.uni-heidelberg.de/arihip/q/cone/scs.xml')
@@ -254,6 +279,8 @@ to run several queries in parallel from one script.
 
 When you invoke ``submit job`` you will get a job object.
 
+.. doctest-remote-data::
+
 >>> async_srv = vo.dal.TAPService("http://dc.g-vo.org/tap")
 >>> job = async_srv.submit_job("SELECT * FROM ivoa.obscore")
 
@@ -262,9 +289,13 @@ When you invoke ``submit job`` you will get a job object.
 
 This job is not yet running yet. To start it invoke ``run``
 
+.. doctest-remote-data::
+
 >>> job.run()
 
 Get the current job phase:
+
+.. doctest-remote-data::
 
 >>> print(job.phase)
 RUN
@@ -272,11 +303,15 @@ RUN
 Maximum run time in seconds is available and can be changed with
 :py:attr:`~pyvo.dal.tap.AsyncTAPJob.execution_duration`
 
+.. doctest-remote-data::
+
 >>> print(job.execution_duration)
 3600
 >>> job.execution_duration = 7200
 
 Obtaining the job url, which is needed to reconstruct the job at a later point:
+
+.. doctest-remote-data::
 
 >>> job_url = job.url
 >>> job = vo.dal.tap.AsyncTAPJob(job_url)
@@ -294,14 +329,18 @@ Besides ``run`` there are also several other job control methods:
     The destruction time can be obtained and changed with
     :py:attr:`~pyvo.dal.tap.AsyncTAPJob.destruction`
 
-    Also, :py:class:`pyvo.dal.tap.AsyncTAPJob` works as a context manager which
-    takes care of this automatically:
+Also, :py:class:`pyvo.dal.tap.AsyncTAPJob` works as a context manager which
+takes care of this automatically:
 
-    >>> with async_srv.submit_job("SELECT * FROM ivoa.obscore") as job:
-    >>>     job.run()
-    >>> print('Job deleted!')
+.. doctest-remote-data::
+
+>>> with async_srv.submit_job("SELECT * FROM ivoa.obscore") as job:
+...     job.run()
+>>> print('Job deleted!')
 
 Check for errors in the job execution:
+
+.. doctest-remote-data::
 
 >>> job.raise_if_error()
 
@@ -319,11 +358,15 @@ datasets and/or access to additional data services.
 
 To obtain the names of the columns in a service response, write:
 
+.. doctest-remote-data::
+
 >>> print(resultset.fieldnames)
 
 Rich metadata equivalent to what is found in VOTables (including unit,
 ucd, utype, and xtype) is available through resultset's
 :py:meth:`~pyvo.dal.query.DALResults.getdesc` method:
+
+.. doctest-remote-data::
 
 >>>  print(resultset.getdesc("accref").ucd)
 
@@ -383,6 +426,8 @@ To get an iterator yielding specific datasets, call
 :py:meth:`pyvo.dal.adhoc.DatalinkResults.bysemantics` with the identifier
 identifying the dataset you want it to return.
 
+.. doctest-remote-data::
+
 >>> preview = next(row.getdatalink().bysemantics('#preview')).getdataset()
 
 .. note::
@@ -390,6 +435,8 @@ identifying the dataset you want it to return.
   recommended to call ``getdatalink`` only once.
 
 Of course one can also build a datalink object from it's url.
+
+.. doctest-remote-data::
 
 >>> datalink = DatalinkResults.from_result_url(url)
 
@@ -404,16 +451,22 @@ Datalink
 Generic access to processing services is provided through the datalink
 interface.
 
+.. doctest-remote-data::
+
 >>> datalink_proc = next(row.getdatalink().bysemantics('#proc'))
 
 .. note::
   most times there is only one processing service per result, and thats all you
   need.
 
+.. doctest-remote-data::
+
   >>> datalink_proc = row.getdatalink().get_first_proc()
 
 The returned object lets you access the available input parameters which you
 can pass as keywords to the ``process`` method.
+
+.. doctest-remote-data::
 
 >>> print(datalink_proc.input_params)
 
@@ -421,6 +474,8 @@ For more details about this have a look at
 :py:class:`astropy.io.votable.tree.Param`.
 
 Calling the method will return a file-like object on sucess.
+
+.. doctest-remote-data::
 
 >>> print(datalink_proc)
 >>> fobj = datalink.process(circle=(1, 1, 1))

--- a/docs/dal/index.rst
+++ b/docs/dal/index.rst
@@ -357,50 +357,53 @@ datasets and/or access to additional data services.
 
 To obtain the names of the columns in a service response, write:
 
-.. doctest-skip::
+.. doctest-remote-data::
 
+    >>> tap_service = vo.dal.TAPService("http://dc.g-vo.org/tap")
+    >>> resultset = tap_service.search("SELECT TOP 10 * FROM ivoa.obscore")
     >>> print(resultset.fieldnames)
 
 Rich metadata equivalent to what is found in VOTables (including unit,
 ucd, utype, and xtype) is available through resultset's
 :py:meth:`~pyvo.dal.query.DALResults.getdesc` method:
 
-.. doctest-skip::
+.. doctest-rmeote-data::
 
-    >>>  print(resultset.getdesc("accref").ucd)
+    >>>  print(resultset.getdesc('s_fov').ucd)
 
 .. note::
     Two convenience functions let you retrieve columns of a specific
     physics (by UCD) or with a particular legacy data model annotation
     (by utype), like this:
 
-.. doctest-skip::
+.. doctest-remote-data::
 
-    >>> fieldname = resultset.fieldname_with_ucd('phot.mag;em.opt.V')
-    >>> fieldname = resultset.fieldname_with_utype('Access.Reference')
+    >>> fieldname = resultset.fieldname_with_ucd('phys.angSize;instr.fov')
+    >>> fieldname = resultset.fieldname_with_utype('obscore:access.reference')
 
 Iterating over a resultset gives the rows in the result:
 
-.. doctest-skip::
+.. doctest-remote-data::
 
     >>> for row in resultset:
-    ...     print row['accref']
-    ...
+    ...     print(row['s_fov'])
 
 The total number of rows in the answer is available as its ``len()``:
 
-.. doctest-skip::
+.. doctest-remote-data::
 
     >>> print(len(resultset))
-    9
+    10
 
 If the row contains datasets, they are exposed by several retrieval methods:
 
-.. doctest-skip::
+.. doctest-remote-data::
 
     >>> url = row.getdataurl()
     >>> fileobj = row.getdataset()
-    >>> obj = row.getdataobj()
+
+..    TODO: uncomment the following line once https://github.com/astropy/pyvo/issues/324 is addressed
+..    >>> obj = row.getdataobj()
 
 Returning the access url, the file-like object or the appropiate python object
 to further work on.
@@ -408,21 +411,21 @@ to further work on.
 As with general numpy arrays, accessing individual columns via names gives an
 array of all of their values:
 
-.. doctest-skip::
+.. doctest-remote-data::
 
-    >>> column = resultset['accref']
+    >>> column = resultset['obs_id']
 
-whereas integers retrieve columns:
+whereas integers retrieve rows:
 
-.. doctest-skip::
+.. doctest-remote-data::
 
     >>> row = resultset[0]
 
 and both combined gives a single value:
 
-.. doctest-skip::
+.. doctest-remote-data::
 
-    >>> value = resultset['accref', 0]
+    >>> value = resultset['obs_id', 0]
 
 Row objects may expose certain key columns as properties. See the corresponding
 API spec listed below for details.

--- a/docs/dal/index.rst
+++ b/docs/dal/index.rst
@@ -367,7 +367,7 @@ Rich metadata equivalent to what is found in VOTables (including unit,
 ucd, utype, and xtype) is available through resultset's
 :py:meth:`~pyvo.dal.query.DALResults.getdesc` method:
 
-.. doctest-rmeote-data::
+.. doctest-remote-data::
 
     >>>  print(resultset.getdesc('s_fov').ucd)
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -67,21 +67,21 @@ First, there is a class describing a specific type of service:
 
 .. doctest-remote-data::
 
->>> import pyvo as vo
->>> service = vo.dal.TAPService("http://dc.g-vo.org/tap")
+    >>> import pyvo as vo
+    >>> service = vo.dal.TAPService("http://dc.g-vo.org/tap")
 
 Once you have a service object, you can run queries with parameters
 specific to the service type. In this example, a database query is enough:
 
 .. doctest-remote-data::
 
->>> resultset = service.search("SELECT TOP 1 * FROM ivoa.obscore")
-<Table masked=True length=1>
-dataproduct_type dataproduct_subtype calib_level ... s_pixel_scale em_ucd
-                                                 ...      arcs
-     object             object          int16    ...    float64    object
----------------- ------------------- ----------- ... ------------- ------
-           image                               1 ...            --
+    >>> resultset = service.search("SELECT TOP 1 * FROM ivoa.obscore")
+    <Table masked=True length=1>
+    dataproduct_type dataproduct_subtype calib_level ... s_pixel_scale em_ucd
+                                                     ...      arcs
+         object             object          int16    ...    float64    object
+    ---------------- ------------------- ----------- ... ------------- ------
+               image                               1 ...            --
 
 What is returned by the search method is a to get a resultset object, which
 esseintially works like a numpy record array.  It can be processed either by
@@ -89,15 +89,15 @@ columns:
 
 .. doctest-remote-data::
 
->>> row = resultset[0]
->>> column = resultset["dataproduct_type"]
+    >>> row = resultset[0]
+    >>> column = resultset["dataproduct_type"]
 
 or by rows.
 
 .. doctest-remote-data::
 
->>> for row in resultset:
->>>   calib_level = row["calib_level"]
+    >>> for row in resultset:
+    >>>   calib_level = row["calib_level"]
 
 For more details on how to use data access services see :ref:`pyvo-data-access`
 
@@ -111,8 +111,8 @@ observational datasets through TAP tables), you can write:
 
 .. doctest-remote-data::
 
->>> for service in vo.regsearch(datamodel="obscore"):
-...   print(service)
+    >>> for service in vo.regsearch(datamodel="obscore"):
+    ...   print(service)
 
 
 Using `pyvo`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -65,11 +65,15 @@ spectra, TAP for tables).  All of these behave in a similar way.
 
 First, there is a class describing a specific type of service:
 
+.. doctest-remote-data::
+
 >>> import pyvo as vo
 >>> service = vo.dal.TAPService("http://dc.g-vo.org/tap")
 
 Once you have a service object, you can run queries with parameters
 specific to the service type. In this example, a database query is enough:
+
+.. doctest-remote-data::
 
 >>> resultset = service.search("SELECT TOP 1 * FROM ivoa.obscore")
 <Table masked=True length=1>
@@ -83,10 +87,14 @@ What is returned by the search method is a to get a resultset object, which
 esseintially works like a numpy record array.  It can be processed either by
 columns:
 
+.. doctest-remote-data::
+
 >>> row = resultset[0]
 >>> column = resultset["dataproduct_type"]
 
 or by rows.
+
+.. doctest-remote-data::
 
 >>> for row in resultset:
 >>>   calib_level = row["calib_level"]
@@ -100,6 +108,8 @@ PyVO also contains a component that lets your programs interrogate the
 IVOA Registry in a simple way.  For instance, to iterate over all TAP
 services supporting the obscore data model (which lets people publish
 observational datasets through TAP tables), you can write:
+
+.. doctest-remote-data::
 
 >>> for service in vo.regsearch(datamodel="obscore"):
 ...   print(service)

--- a/docs/registry/index.rst
+++ b/docs/registry/index.rst
@@ -11,7 +11,7 @@ Getting started
 Registry searches are performed using the :py:meth:`pyvo.registry.search`
 method.
 
->>> from pyvo.registry import search as regsearch
+    >>> from pyvo.registry import search as regsearch
 
 It is possible to match against a list of ``keywords`` to find resources
 related to a particular topic, for instances services containing data about
@@ -19,33 +19,33 @@ quasars.
 
 .. doctest-remote-data::
 
->>> services = regsearch(keywords=['quasar'])
+    >>> services = regsearch(keywords=['quasar'])
 
 A single keyword can be specified as a single string instead of a list.
 
 .. doctest-remote-data::
 
->>> services = regsearch(keywords='quasar')
+    >>> services = regsearch(keywords='quasar')
 
 Furthermore the search can be limited to a certain ``servicetype``, one of
 sia, ssa, scs, sla, tap.
 
 .. doctest-remote-data::
 
->>> services = regsearch(keywords=['quasar'], servicetype='tap')
+    >>> services = regsearch(keywords=['quasar'], servicetype='tap')
 
 Filtering by the desired waveband is also possible.
 
 .. doctest-remote-data::
 
->>> services = regsearch(
-...     keywords=['quasar'], servicetype='tap', waveband='x-ray')
+    >>> services = regsearch(
+    ...     keywords=['quasar'], servicetype='tap', waveband='x-ray')
 
 And at last, the data model can be specified.
 
 .. doctest-remote-data::
 
->>> obscore_services = regsearch(datamodel='ObsCore')
+    >>> obscore_services = regsearch(datamodel='ObsCore')
 
 Search results
 ==============

--- a/docs/registry/index.rst
+++ b/docs/registry/index.rst
@@ -17,23 +17,33 @@ It is possible to match against a list of ``keywords`` to find resources
 related to a particular topic, for instances services containing data about
 quasars.
 
+.. doctest-remote-data::
+
 >>> services = regsearch(keywords=['quasar'])
 
 A single keyword can be specified as a single string instead of a list.
+
+.. doctest-remote-data::
 
 >>> services = regsearch(keywords='quasar')
 
 Furthermore the search can be limited to a certain ``servicetype``, one of
 sia, ssa, scs, sla, tap.
 
+.. doctest-remote-data::
+
 >>> services = regsearch(keywords=['quasar'], servicetype='tap')
 
 Filtering by the desired waveband is also possible.
+
+.. doctest-remote-data::
 
 >>> services = regsearch(
 ...     keywords=['quasar'], servicetype='tap', waveband='x-ray')
 
 And at last, the data model can be specified.
+
+.. doctest-remote-data::
 
 >>> obscore_services = regsearch(datamodel='ObsCore')
 

--- a/pyvo/dal/adhoc.py
+++ b/pyvo/dal/adhoc.py
@@ -475,7 +475,7 @@ class DatalinkResults(DatalinkResultsMixin, DALResults):
     as an Astropy :py:class:`~astropy.table.table.Table` via the
     following conversion:
 
-    >>> table = results.to_table()
+    ``table = results.to_table()``
 
     ``DatalinkResults`` supports the array item operator ``[...]`` in a
     read-only context.  When the argument is numerical, the result

--- a/pyvo/dal/mimetype.py
+++ b/pyvo/dal/mimetype.py
@@ -25,11 +25,8 @@ def mime2extension(mimetype, default=None):
     implementations of ``suggest_extension()`` in ``Record`` subclasses.
 
       >>> mime2extension('application/fits')
-      fits
       >>> mime2extension('image/jpeg')
-      jpg
       >>> mime2extension('application/x-zed', 'dat')
-      dat
 
     Parameters
     ----------

--- a/pyvo/dal/scs.py
+++ b/pyvo/dal/scs.py
@@ -426,10 +426,6 @@ class SCSResults(DatalinkResultsMixin, DALResults):
     :py:class:`~pyvo.dal.scs.SCSRecord` instances) are typically
     accessed by iterating over an ``SCSResults`` instance.
 
-    >>> results = pyvo.conesearch(url, pos=[12.24, -13.1], radius=0.1)
-    >>> for src in results:
-    ...     print("{0}: {1} {2}".format(src.id, src.ra, src.dec))
-
     Alternatively, records can be accessed randomly via
     :py:meth:`getrecord` or through a Python Database API (v2)
     Cursor (via :py:meth:`~pyvo.dal.query.DALResults.cursor`).
@@ -448,7 +444,7 @@ class SCSResults(DatalinkResultsMixin, DALResults):
     as an Astropy :py:class:`~astropy.table.table.Table` via the
     following conversion:
 
-    >>> table = results.votable.to_table()
+    ``table = results.votable.to_table()``
 
     ``SCSResults`` supports the array item operator ``[...]`` in a
     read-only context.  When the argument is numerical, the result

--- a/pyvo/dal/sia.py
+++ b/pyvo/dal/sia.py
@@ -585,10 +585,6 @@ class SIAResults(DatalinkResultsMixin, DALResults):
     :py:class:`~pyvo.dal.sia.SIARecord` instances) are typically
     accessed by iterating over an ``SIAResults`` instance.
 
-    >>> results = pyvo.imagesearch(url, pos=[12.24, -13.1], size=0.1)
-    >>> for image in results:
-    ...     print("{0}: {1}".format(image.title, title.getdataurl()))
-
     Alternatively, records can be accessed randomly via
     :py:meth:`getrecord` or through a Python Database API (v2)
     Cursor (via :py:meth:`~pyvo.dal.query.DALResults.cursor`).
@@ -607,7 +603,7 @@ class SIAResults(DatalinkResultsMixin, DALResults):
     as an Astropy :py:class:`~astropy.table.table.Table` via the
     following conversion:
 
-    >>> table = results.votable.to_table()
+    ``table = results.votable.to_table()``
 
     ``SIAResults`` supports the array item operator ``[...]`` in a
     read-only context.  When the argument is numerical, the result

--- a/pyvo/dal/sia2.py
+++ b/pyvo/dal/sia2.py
@@ -465,10 +465,6 @@ class SIAResults(DatalinkResultsMixin, DALResults):
     :py:class:`~pyvo.dal.sia2.ObsCoreRecord` instances) are typically
     accessed by iterating over an ``SIAResults`` instance.
 
-    >>> results = pyvo.imagesearch(url, pos=[12.24, -13.1], size=0.1)
-    >>> for image in results:
-    ...     print("{0}: {1}".format(image.title, title.getdataurl()))
-
     Alternatively, records can be accessed randomly via
     :py:meth:`getrecord` or through a Python Database API (v2)
     Cursor (via :py:meth:`~pyvo.dal.query.DALResults.cursor`).
@@ -487,7 +483,7 @@ class SIAResults(DatalinkResultsMixin, DALResults):
     as an Astropy :py:class:`~astropy.table.table.Table` via the
     following conversion:
 
-    >>> table = results.votable.to_table()
+    ``table = results.votable.to_table()``
 
     ``SIAResults`` supports the array item operator ``[...]`` in a
     read-only context.  When the argument is numerical, the result

--- a/pyvo/dal/sla.py
+++ b/pyvo/dal/sla.py
@@ -359,10 +359,6 @@ class SLAResults(DALResults):
     :py:class:`~pyvo.dal.sia.SLARecord` instances) are typically
     accessed by iterating over an ``SLAResults`` instance.
 
-    >>> results = pyvo.linesearch(url, wavelength=(0.0265,0.0280))
-    >>> for spl in results:
-    ...     print("{0}: {1}".format(spl.species_name, spl.wavelength))
-
     Alternatively, records can be accessed randomly via
     :py:meth:`getrecord` or through a Python Database API (v2)
     Cursor (via :py:meth:`~pyvo.dal.query.DALResults.cursor`).
@@ -381,7 +377,7 @@ class SLAResults(DALResults):
     as an Astropy :py:class:`~astropy.table.table.Table` via the
     following conversion:
 
-    >>> table = results.votable.to_table()
+    ``table = results.votable.to_table()``
 
     ``SLAResults`` supports the array item operator ``[...]`` in a
     read-only context.  When the argument is numerical, the result

--- a/pyvo/dal/ssa.py
+++ b/pyvo/dal/ssa.py
@@ -582,10 +582,6 @@ class SSAResults(DatalinkResultsMixin, DALResults):
     :py:class:`~pyvo.dal.ssa.SSARecord` instances) are typically
     accessed by iterating over an ``SSAResults`` instance.
 
-    >>> results = pyvo.spectrumsearch(url, pos=[12.24, -13.1], diameter=0.2)
-    >>> for spec in results:
-    ...     print("{0}: {1}".format(spec.title, spec.getdataurl()))
-
     Alternatively, records can be accessed randomly via
     :py:meth:`getrecord` or through a Python Database API (v2)
     Cursor (via :py:meth:`~pyvo.dal.query.DALResults.cursor`).
@@ -604,7 +600,7 @@ class SSAResults(DatalinkResultsMixin, DALResults):
     as an Astropy :py:class:`~astropy.table.table.Table` via the
     following conversion:
 
-    >>> table = results.votable.to_table()
+    ``table = results.votable.to_table()``
 
     ``SSAResults`` supports the array item operator ``[...]`` in a
     read-only context.  When the argument is numerical, the result

--- a/pyvo/dal/tap.py
+++ b/pyvo/dal/tap.py
@@ -994,7 +994,7 @@ class TAPResults(DatalinkResultsMixin, DALResults):
     as an Astropy :py:class:`~astropy.table.table.Table` via the
     following conversion:
 
-    >>> table = results.table
+    ``table = results.table``
 
     ``SIAResults`` supports the array item operator ``[...]`` in a
     read-only context.  When the argument is numerical, the result

--- a/pyvo/dal/tests/test_datalink.py
+++ b/pyvo/dal/tests/test_datalink.py
@@ -148,30 +148,27 @@ def _debytify(v):
 @pytest.mark.filterwarnings("ignore::astropy.io.votable.exceptions.W06")
 @pytest.mark.filterwarnings("ignore::astropy.io.votable.exceptions.W48")
 @pytest.mark.filterwarnings("ignore::astropy.io.votable.exceptions.E02")
-@pytest.mark.remote_data
 class TestSemanticsRetrieval:
     def test_access_with_string(self):
         datalink = DatalinkResults.from_result_url('http://example.com/proc')
         res = [_debytify(r["access_url"])
-            for r in datalink.bysemantics("#this")]
-        assert len(res)==1
+               for r in datalink.bysemantics("#this")]
+        assert len(res) == 1
         assert res[0].endswith("eq010000ms/20100927.comb_avg.0001.fits.fz")
 
-    @pytest.mark.remote_data
     def test_access_with_list(self):
         datalink = DatalinkResults.from_result_url('http://example.com/proc')
         res = [_debytify(r["access_url"])
-            for r in datalink.bysemantics(["#this", "#preview-image"])]
-        assert len(res)==2
+               for r in datalink.bysemantics(["#this", "#preview-image"])]
+        assert len(res) == 2
         assert res[0].endswith("eq010000ms/20100927.comb_avg.0001.fits.fz")
         assert res[1].endswith("20100927.comb_avg.0001.fits.fz?preview=True")
 
-    @pytest.mark.remote_data
     def test_access_with_expansion(self):
         datalink = DatalinkResults.from_result_url('http://example.com/proc')
         res = [_debytify(r["access_url"])
-            for r in datalink.bysemantics(["#this", "#preview"])]
-        assert len(res)==3
+               for r in datalink.bysemantics(["#this", "#preview"])]
+        assert len(res) == 3
         assert res[0].endswith("eq010000ms/20100927.comb_avg.0001.fits.fz")
         assert res[1].endswith("20100927.comb_avg.0001.fits.fz?preview=True")
         assert res[2].endswith("http://dc.zah.uni-heidelberg.de/wider.dat")
@@ -179,31 +176,29 @@ class TestSemanticsRetrieval:
     def test_access_without_expansion(self):
         datalink = DatalinkResults.from_result_url('http://example.com/proc')
         res = [_debytify(r["access_url"])
-            for r in datalink.bysemantics(
-               ["#this", "#preview"],
-               include_narrower=False)]
-        assert len(res)==2
+               for r in datalink.bysemantics(
+                       ["#this", "#preview"],
+                       include_narrower=False)]
+        assert len(res) == 2
         assert res[0].endswith("eq010000ms/20100927.comb_avg.0001.fits.fz")
         assert res[1].endswith("http://dc.zah.uni-heidelberg.de/wider.dat")
 
-    @pytest.mark.remote_data
     def test_with_full_url(self):
         datalink = DatalinkResults.from_result_url('http://example.com/proc')
         res = [_debytify(r["access_url"])
-            for r in datalink.bysemantics("urn:example:rdf/dlext#oracle")]
-        assert len(res)==1
+               for r in datalink.bysemantics("urn:example:rdf/dlext#oracle")]
+        assert len(res) == 1
         assert res[0].endswith("when-will-it-be-back")
 
-    @pytest.mark.remote_data
     def test_all_mixed(self):
         datalink = DatalinkResults.from_result_url('http://example.com/proc')
         res = [_debytify(r["access_url"])
-            for r in datalink.bysemantics([
-                "urn:example:rdf/dlext#oracle",
-                'http://www.ivoa.net/rdf/datalink/core#preview',
-                '#this',
-                'non-existing-term'])]
-        assert len(res)==4
+               for r in datalink.bysemantics([
+                       "urn:example:rdf/dlext#oracle",
+                       'http://www.ivoa.net/rdf/datalink/core#preview',
+                       '#this',
+                       'non-existing-term'])]
+        assert len(res) == 4
         assert res[0].endswith("eq010000ms/20100927.comb_avg.0001.fits.fz")
         assert res[1].endswith("comb_avg.0001.fits.fz?preview=True")
         assert res[2].endswith("http://dc.zah.uni-heidelberg.de/wider.dat")

--- a/pyvo/dal/tests/test_datalink.py
+++ b/pyvo/dal/tests/test_datalink.py
@@ -148,6 +148,7 @@ def _debytify(v):
 @pytest.mark.filterwarnings("ignore::astropy.io.votable.exceptions.W06")
 @pytest.mark.filterwarnings("ignore::astropy.io.votable.exceptions.W48")
 @pytest.mark.filterwarnings("ignore::astropy.io.votable.exceptions.E02")
+@pytest.mark.remote_data
 class TestSemanticsRetrieval:
     def test_access_with_string(self):
         datalink = DatalinkResults.from_result_url('http://example.com/proc')
@@ -156,6 +157,7 @@ class TestSemanticsRetrieval:
         assert len(res)==1
         assert res[0].endswith("eq010000ms/20100927.comb_avg.0001.fits.fz")
 
+    @pytest.mark.remote_data
     def test_access_with_list(self):
         datalink = DatalinkResults.from_result_url('http://example.com/proc')
         res = [_debytify(r["access_url"])
@@ -164,6 +166,7 @@ class TestSemanticsRetrieval:
         assert res[0].endswith("eq010000ms/20100927.comb_avg.0001.fits.fz")
         assert res[1].endswith("20100927.comb_avg.0001.fits.fz?preview=True")
 
+    @pytest.mark.remote_data
     def test_access_with_expansion(self):
         datalink = DatalinkResults.from_result_url('http://example.com/proc')
         res = [_debytify(r["access_url"])
@@ -183,6 +186,7 @@ class TestSemanticsRetrieval:
         assert res[0].endswith("eq010000ms/20100927.comb_avg.0001.fits.fz")
         assert res[1].endswith("http://dc.zah.uni-heidelberg.de/wider.dat")
 
+    @pytest.mark.remote_data
     def test_with_full_url(self):
         datalink = DatalinkResults.from_result_url('http://example.com/proc')
         res = [_debytify(r["access_url"])
@@ -190,6 +194,7 @@ class TestSemanticsRetrieval:
         assert len(res)==1
         assert res[0].endswith("when-will-it-be-back")
 
+    @pytest.mark.remote_data
     def test_all_mixed(self):
         datalink = DatalinkResults.from_result_url('http://example.com/proc')
         res = [_debytify(r["access_url"])

--- a/pyvo/dal/tests/test_params.py
+++ b/pyvo/dal/tests/test_params.py
@@ -149,6 +149,7 @@ def test_serialize():
 
 @pytest.mark.usefixtures('proc')
 @pytest.mark.usefixtures('proc_ds')
+@pytest.mark.filterwarnings("ignore::astropy.io.votable.exceptions.E02")
 def test_serialize_exceptions():
     datalink = DatalinkResults.from_result_url('http://example.com/proc')
     proc = datalink[0]
@@ -173,6 +174,7 @@ def test_serialize_exceptions():
 
 @pytest.mark.usefixtures('proc_units')
 @pytest.mark.usefixtures('proc_units_ds')
+@pytest.mark.filterwarnings("ignore::astropy.io.votable.exceptions.E02")
 def test_units():
     datalink = DatalinkResults.from_result_url('http://example.com/proc_units')
     proc = datalink[0]
@@ -182,6 +184,7 @@ def test_units():
 
 @pytest.mark.usefixtures('proc_inf')
 @pytest.mark.usefixtures('proc_inf_ds')
+@pytest.mark.filterwarnings("ignore::astropy.io.votable.exceptions.E02")
 def test_inf():
     datalink = DatalinkResults.from_result_url('http://example.com/proc_inf')
     proc = datalink[0]

--- a/pyvo/dal/tests/test_sia2_remote.py
+++ b/pyvo/dal/tests/test_sia2_remote.py
@@ -31,8 +31,8 @@ class TestSIACadc():
         results = search(CADC_SIA_URL, pos=(2.8425, 74.4846, 10), maxrec=55)
         ids = []
         for i in results.iter_datalinks():
-            assert i.table[0]['ID'] not in ids
-            ids.append(i.table[0]['ID'])
+            assert i.to_table()[0]['ID'] not in ids
+            ids.append(i.to_table()[0]['ID'])
         assert len(ids) == 55
 
     def test_pos(self):

--- a/pyvo/dal/tests/test_tap.py
+++ b/pyvo/dal/tests/test_tap.py
@@ -468,6 +468,7 @@ class TestTAPService:
         assert job.ownerid == '222'
 
     @pytest.mark.usefixtures('async_fixture')
+    @pytest.mark.remote_data
     def test_get_job_list(self):
         service = TAPService('http://example.com/tap')
         # server returns:

--- a/pyvo/io/vosi/endpoint.py
+++ b/pyvo/io/vosi/endpoint.py
@@ -4,7 +4,6 @@ This file contains a contains the high-level functions to read the various
 VOSI Endpoints.
 """
 
-from astropy.utils import minversion
 from astropy.utils.xml import iterparser
 from astropy.utils.collections import HomogeneousList
 from astropy.io.votable.exceptions import vo_raise, vo_warn
@@ -19,8 +18,6 @@ from .exceptions import W15, W16, E07, E10
 __all__ = [
     "parse_tables", "parse_capabilities", "parse_availability",
     "TablesFile", "CapabilitiesFile", "AvailabilityFile"]
-
-ASTROPY_GT_4 = minversion('astropy', '4.0')
 
 
 def _pedantic_settings(pedantic):
@@ -40,16 +37,12 @@ def _pedantic_settings(pedantic):
 
     Returns
     -------
-    A dict containing configuration settings for astropy, which for
-    version 4.0 and after use 'verify', and previously use 'pedantic'.
+    A dict containing 'verify' configuration settings.
     """
-    if ASTROPY_GT_4:
-        if pedantic:
-            return {'verify': 'exception'}
-        else:
-            return {'verify': 'warn'}
+    if pedantic:
+        return {'verify': 'exception'}
     else:
-        return {'pedantic': pedantic}
+        return {'verify': 'warn'}
 
 
 def parse_tables(source, pedantic=None, filename=None,

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,12 @@ addopts = --doctest-rst
 remote_data_strict = true
 filterwarnings =
     error
+    ignore:numpy.ndarray size changed:RuntimeWarning
+    ignore:unclosed <socket:ResourceWarning
+    ignore:unclosed <ssl.SSLSocket:ResourceWarning
+# This can be removed once the minimum astropy is 5.0.1?
+    ignore:distutils Version classes are deprecated:DeprecationWarning
+
 
 [flake8]
 max-line-length = 110

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-[tools:pytest]
+[tool:pytest]
 minversion = 6.0
 norecursedirs = build docs/_build
 testpaths = "pyvo" "docs"
@@ -87,5 +87,3 @@ exclude_lines =
   pragma: py{ignore_python_version}
   # Don't complain about IPython completion helper
   def _ipython_key_completions_
-
-[entry_points]

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,8 @@ doctest_plus = enabled
 text_file_format = rst
 addopts = --doctest-rst
 remote_data_strict = true
+filterwarnings =
+    error
 
 [flake8]
 max-line-length = 110

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 # Please note that not all the combinations below are guaranteed to work
-# as oldestastropy and devastropy might not support the full python range
+# as oldestdeps and devastropy might not support the full python range
 # listed here
 envlist =
-    py{38,39,310}-test{,-oldestastropy, -devastropy}
+    py{38,39,310}-test{,-oldestdeps, -devastropy}
     egg_info
     cov
     linkcheck
@@ -36,13 +36,15 @@ commands =
 #
 description =
     run tests
-    oldestastropy: with astropy 4.0.*
+    oldestdeps: with astropy 4.0.*
     devastropy: with astropy latest
 
 deps =
     devastropy: git+https://github.com/astropy/astropy.git#egg=astropy
-    oldestastropy: astropy==4.0
-
+    oldestdeps: astropy==4.0
+    # We set a suitably old numpy along with an old astropy, no need to pick up
+    # deprecations and errors due to their unmatching versions
+    oldestdeps: numpy==1.16
 
 [testenv:egg_info]
 description = ensure egg_info works without dependencies
@@ -72,7 +74,7 @@ commands =
 
 [testenv:linkcheck]
 changedir = docs
-deps = 
+deps =
     sphinx_astropy
 description = check the links in the HTML docs
 extras = docs


### PR DESCRIPTION
This is to make the testing more robust in pyvo itself.

First commit just fixes the heading in setup.cfg which uncovers a lot of issues on its own already, will enable the warning raising once these are all fixed.

to close #307

The fix to the config file also fixes #306 (though most doctests will also need remote-data enabled to run)