### PR TITLE
Ignore XML namespaces in xsi:type

### DIFF
--- a/pyvo/io/vosi/exceptions.py
+++ b/pyvo/io/vosi/exceptions.py
@@ -242,6 +242,8 @@ class W21(VOSIWarning, XMLWarning):
     """
     TAP Capabilties must have at least one outputFormat element.
     """
+    message_template = (
+        "TAP Capabilties must have at least one `outputFormat` element.")
 
 
 class W22(VOSIWarning, XMLWarning):

--- a/pyvo/io/vosi/tests/test_capabilities.py
+++ b/pyvo/io/vosi/tests/test_capabilities.py
@@ -180,16 +180,17 @@ class TestInterface:
 def cap_with_free_prefix(recwarn):
         caps = vosi.parse_capabilities(io.BytesIO(b"""
 <ns2:capabilities xmlns:ns2="http://www.ivoa.net/xml/VOSICapabilities/v1.0">
-  <capability 
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-    xmlns:ns4="http://www.ivoa.net/xml/TAPRegExt/v1.0" 
-    xsi:type="ns4:TableAccess" 
+  <capability
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ns4="http://www.ivoa.net/xml/TAPRegExt/v1.0"
+    xsi:type="ns4:TableAccess"
     standardID="ivo://ivoa.net/std/TAP">
-    <interface xmlns:ns5="http://www.ivoa.net/xml/VODataService/v1.1" 
+    <interface xmlns:ns5="http://www.ivoa.net/xml/VODataService/v1.1"
         xsi:type="ns5:ParamHTTP" version="1.1" role="std">
       <accessURL use="base">https://archive.eso.org/tap_obs</accessURL>
     </interface>
     <dataModel ivo-id="ivo://ivoa.net/std/ObsCore#core-1.1">ObsCore-1.1</dataModel>
+    <outputFormat/>
     <language>
       <name>ADQL</name>
       <version ivo-id="ivo://ivoa.net/std/ADQL#v2.0">2.0</version>
@@ -206,3 +207,7 @@ class TestFreePrefixes:
     def test_parses_without_warning(self, cap_with_free_prefix):
         warnings, _ = cap_with_free_prefix
         assert len(warnings)==0
+
+    def test_parses_as_tapregext(self, cap_with_free_prefix):
+        _, cap = cap_with_free_prefix
+        assert isinstance(cap[0], tr.TableAccess)

--- a/pyvo/io/vosi/vodataservice.py
+++ b/pyvo/io/vosi/vodataservice.py
@@ -22,7 +22,7 @@ from astropy.utils.xml import check as xml_check
 from astropy.io.votable.exceptions import vo_raise, vo_warn, warn_or_raise
 
 from ...utils.xml.elements import (
-    xmlattribute, xmlelement, Element, ContentMixin)
+    xmlattribute, xmlelement, Element, ElementWithXSIType, ContentMixin)
 
 from . import voresource as vr
 from .exceptions import (
@@ -682,7 +682,7 @@ class InputParam(BaseParam):
             vo_raise(E06, self._Element__name, config=config, pos=self._pos)
 
 
-class DataType(ContentMixin, Element):
+class DataType(ContentMixin, ElementWithXSIType):
     """
     DataType element as described in
     http://www.ivoa.net/xml/VODataService/v1.1
@@ -817,27 +817,6 @@ class TableDataType(DataType):
 
     Subtypes must be decorated with ``register_xsi_type('ns:name')``.
     """
-    _xsi_type_mapping = {}
-
-    @classmethod
-    def register_xsi_type(cls, typename):
-        """Decorator factory for registering subtypes"""
-        def register(class_):
-            """Decorator for registering subtypes"""
-            cls._xsi_type_mapping[typename] = class_
-            return class_
-        return register
-
-    def __new__(cls, *args, **kwargs):
-        if 'xsi:type' not in kwargs:
-            pass
-
-        xsi_type = kwargs.get('xsi:type')
-        dtype = cls._xsi_type_mapping.get(xsi_type, cls)
-
-        obj = DataType.__new__(dtype)
-        obj.__init__(*args, **kwargs)
-        return obj
 
 
 @TableDataType.register_xsi_type('vs:VOTable')

--- a/pyvo/io/vosi/voresource.py
+++ b/pyvo/io/vosi/voresource.py
@@ -17,7 +17,7 @@ from astropy.utils.collections import HomogeneousList
 from astropy.utils.misc import indent
 
 from ...utils.xml.elements import (
-    Element, ContentMixin, xmlattribute, xmlelement)
+    Element, ElementWithXSIType, ContentMixin, xmlattribute, xmlelement)
 from .exceptions import W06
 
 __all__ = [
@@ -201,7 +201,7 @@ class SecurityMethod(ContentMixin, Element):
         self._standardid = standardid
 
 
-class Interface(Element):
+class Interface(ElementWithXSIType):
     """
     Interface element as described in
     http://www.ivoa.net/xml/VOResource/v1.0
@@ -214,28 +214,6 @@ class Interface(Element):
     Additional interface subtypes (beyond WebService and WebBrowser) are
     defined in the VODataService schema.
     """
-    _xsi_type_mapping = {}
-
-    @classmethod
-    def register_xsi_type(cls, typename):
-        """Decorator factory for registering subtypes"""
-        def register(class_):
-            """Decorator for registering subtypes"""
-            cls._xsi_type_mapping[typename] = class_
-            return class_
-        return register
-
-    def __new__(cls, *args, **kwargs):
-        if 'xsi:type' not in kwargs:
-            pass
-
-        xsi_type = kwargs.get('xsi:type')
-        dtype = cls._xsi_type_mapping.get(xsi_type, cls)
-
-        obj = Element.__new__(dtype)
-        obj.__init__(*args, **kwargs)
-        return obj
-
     def __init__(
         self, config=None, pos=None, _name='interface', version='1.0',
         role=None, **kwargs
@@ -359,7 +337,7 @@ class Interface(Element):
         self._resulttype = resulttype
 
 
-class Capability(Element):
+class Capability(ElementWithXSIType):
     """
     Capability element as described in
     http://www.ivoa.net/xml/VOResource/v1.0
@@ -368,28 +346,6 @@ class Capability(Element):
     (in terms of context-specific behavior), and how to use it
     (in terms of an interface)
     """
-    _xsi_type_mapping = {}
-
-    @classmethod
-    def register_xsi_type(cls, typename):
-        """Decorator factory for registering subtypes"""
-        def register(class_):
-            """Decorator for registering subtypes"""
-            cls._xsi_type_mapping[typename] = class_
-            return class_
-        return register
-
-    def __new__(cls, *args, **kwargs):
-        if 'xsi:type' not in kwargs:
-            pass
-
-        xsi_type = kwargs.get('xsi:type')
-        dtype = cls._xsi_type_mapping.get(xsi_type, cls)
-
-        obj = Element.__new__(dtype)
-        obj.__init__(*args, **kwargs)
-        return obj
-
     def __init__(
         self, config=None, pos=None, _name='capability', standardID=None,
         **kwargs

--- a/pyvo/utils/xml/elements.py
+++ b/pyvo/utils/xml/elements.py
@@ -359,6 +359,64 @@ class Element:
                     w.element(name, str(child))
 
 
+class ElementWithXSIType(Element):
+    """
+    An XML element that supports type dispatch through xsi:type.
+
+    When a class A is derived from this, it gains a decorator
+    register_xsi_type, which classes derived from A can use to say
+    "construct me rather than A when xsi:type has the value I'm putting 
+    in.
+
+    At this point we are doing *no* namespace processing in our XML 
+    parsing.  Hence, we discard any prefixes both when registering
+    and when matching.
+
+    We probably should do namespaces one day; astropy.utils.xml will
+    presumably learn them when they add VO-DML support.  Let's revisit
+    this when it's there safely.  Meanwhere, use canonical Registry
+    prefixes (cf. RegTAP 1.1, sect. 5) everywhere in your code; these 
+    will continue to be safe no matter what.
+    """
+    _xsi_type_mapping = {}
+
+    @classmethod
+    def register_xsi_type(cls, typename):
+        """Decorator factory for registering subtypes."""
+        def register(class_):
+            """Decorator for registering subtypes"""
+            cls._xsi_type_mapping[typename.split(":")[-1]] = class_
+            return class_
+        return register
+
+    def __new__(cls, *args, **kwargs):
+        xsi_type = None
+        # Another namespace trouble: people can bind the xsi URI
+        # to anything, *and* it's not unlikely they have another
+        # type attribute, too.  Wiggle out of it by preferring a
+        # literal xsi:type and otherwise hope for the best.  This
+        # really needs to be fixed when we switch to namespace-aware
+        # parsing.
+        for name, val in kwargs.items():
+            if name=="xsi:type":
+                xsi_type = val
+                break
+            elif name.split(":")[-1]=="type":
+                xsi_type = val
+
+        if xsi_type is None:
+            dtype = cls
+        else:
+            try:
+                dtype = cls._xsi_type_mapping[xsi_type.split(":")[-1]]
+            except KeyError:
+                raise RuntimeError(f"Unknown schema type {xsi_type}")
+
+        obj = Element.__new__(dtype)
+        obj.__init__(*args, **kwargs)
+        return obj
+
+
 class ContentMixin(Element):
     """
     Mixin class for elements with inner content.

--- a/pyvo/utils/xml/tests/test_elements.py
+++ b/pyvo/utils/xml/tests/test_elements.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Tests for pyvo.utils.xml.elements
+"""
+
+import io
+
+import pytest
+from astropy.utils.xml import iterparser
+
+from pyvo.utils.xml import elements
+
+class TBase(elements.ElementWithXSIType):
+    pass
+    
+@TBase.register_xsi_type("foo:TOther1")
+class TOther1(TBase):
+    pass   
+
+@TBase.register_xsi_type("TOther2")
+class TOther2(TBase):
+    pass
+
+class _Root(elements.Element):
+    def __init__(self):
+        super().__init__(self, _name="root")
+        self._tbase = None
+
+    @elements.xmlelement(name="tbase", cls=TBase)
+    def tbase(self):
+        return self._tbase
+
+    @tbase.setter
+    def tbase(self, obj):
+        self._tbase = obj
+
+
+class TestXSIType:
+    def _parse_string(self, xml_source):
+        with iterparser.get_xml_iterator(io.BytesIO(xml_source)) as i:
+            return _Root().parse(i, {})
+
+    def test_no_type(self):
+        found_type = self._parse_string(b'<tbase/>').tbase.__class__
+        assert found_type.__name__ == "TBase"
+
+    def test_prefixed_type(self):
+        found_type = self._parse_string(b'<tbase xsi:type="foo:TOther1"/>'
+            ).tbase.__class__
+        assert found_type.__name__ == "TOther1"
+
+    def test_unprefixed_type(self):
+        found_type = self._parse_string(b'<tbase xsi:type="TOther1"/>'
+            ).tbase.__class__
+        assert found_type.__name__ == "TOther1"
+
+    def test_badprefixed_type(self):
+        found_type = self._parse_string(b'<tbase xsi:type="ns1:TOther2"/>'
+            ).tbase.__class__
+        assert found_type.__name__ == "TOther2"
+
+    def test_bad_type(self):
+        with pytest.raises(RuntimeError) as excinfo:
+            self._parse_string(b'<tbase xsi:type="ns1:NoSuchType"/>')
+        assert str(excinfo.value) == "Unknown schema type ns1:NoSuchType"
+


### PR DESCRIPTION
This PR addresses bug #257 in the lamest possible way:  It just ignores namespace prefixes on xsi:type-s.

Rationale: It turns out that astropy.utils.xml completely discards all namespace information.  That you can parse Registry/capability documents with it in the first place is just because we only have local elements with elementFormDefault=unqualified.  Ah well.

Given that, we can either do XML processing ourselves, properly managing namespaces.  Or we ignore namespaces and namespace prefixes, too.  Since I can't think of anywhere that would be trouble in the current VO, this commit opts for the second option.

I suppose I'd scupper astropy.utils.xml for registry documents and have our own XML parser (which isn't a big deal in this context) unless I'd expect that astropy.utils.xml will deal with namespaces in *some* way in the near future, as namespaces in VOTable will probably become relevant when VO-DML annotation enters VOTables.  If that happens, we ought to revise ignoring namespaces here.  If not... well, we can always employ our own namespace-aware XML parser later.