### PR TITLE
Added Jobs top element to fix the warning

### DIFF
--- a/pyvo/io/uws/endpoint.py
+++ b/pyvo/io/uws/endpoint.py
@@ -8,7 +8,7 @@ from astropy.utils.xml.writer import XMLWriter
 from astropy.io.votable.util import convert_to_writable_filelike
 
 from ...utils.xml.elements import xmlattribute, parse_for_object
-from .tree import JobSummary, JobList
+from .tree import JobSummary, Jobs
 
 __all__ = ["parse_job", "parse_job_list", "JobFile"]
 
@@ -45,8 +45,8 @@ def parse_job_list(
     --------
     pyvo.io.vosi.exceptions : The exceptions this function may raise.
     """
-    return parse_for_object(source, JobList, pedantic, filename,
-                            _debug_python_based_parser)
+    return parse_for_object(source, Jobs, pedantic, filename,
+                            _debug_python_based_parser).jobs
 
 
 def parse_job(

--- a/pyvo/io/uws/tree.py
+++ b/pyvo/io/uws/tree.py
@@ -278,8 +278,24 @@ class JobSummary(Element):
         self._message = message
 
 
-class JobList(UWSElement, HomogeneousList):
-    def __init__(self, config=None, pos=None, _name='jobs', **kwargs):
+class Jobs(UWSElement):
+    def __init__(self, config=None, pos=None, _name='jobref', **kwargs):
+        self._jobs = JobList()
+
+    @uwselement
+    def jobs(self):
+        """The parameters to the job"""
+        return self._jobs
+
+    @jobs.adder
+    def jobs(self, iterator, tag, data, config, pos):
+        job_list = JobList(config, pos, 'jobref', **data)
+        job_list.parse(iterator, config)
+        self._jobs = job_list
+
+
+class JobList(HomogeneousList, UWSElement):
+    def __init__(self, config=None, pos=None, _name='jobref', **kwargs):
         HomogeneousList.__init__(self, JobSummary)
         UWSElement.__init__(self, config, pos, _name, **kwargs)
 


### PR DESCRIPTION
UWS is not aware of the `<jobs>` top element and warns:
```
pyvo/dal/tests/test_tap.py::TestTAPService::test_get_job_list
[119](https://github.com/astropy/pyvo/runs/6629666069?check_suite_focus=true#step:5:120)
  /home/runner/work/pyvo/pyvo/pyvo/utils/xml/elements.py:306: UnknownElementWarning: None:2:0: UnknownElementWarning: Unknown element jobs
  ```
  
  This is the structure of the `jobs` document that `PyVO` should be able to successfully parse:
  
  ```
  <?xml version="1.0" encoding="UTF-8"?>
<uws:jobs xmlns:uws="http://www.ivoa.net/xml/UWS/v1.0" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1">
  <uws:jobref id="zy070e3nebjaw5ta">
    <uws:phase>PENDING</uws:phase>
    <uws:ownerId>21</uws:ownerId>
  </uws:jobref>
</uws:jobs>
```

This fixes this to eliminate the warning.