### PR TITLE
access_url in RegTAP backward compatibility hacks

### DIFF
--- a/pyvo/registry/regtap.py
+++ b/pyvo/registry/regtap.py
@@ -645,6 +645,15 @@ class RegistryResource(dalq.Record):
             If there are multiple capabilities for service_type, the
             function choose the first matching capability by default
             Pass lax=False to instead raise a DALQueryError.
+
+        Returns
+        -------
+        `pyvo.dal.DALService`
+            For standard service types, a specific DAL service instance
+            (e.g., a `pyvo.dal.tap.TAPService` when requesting ``tap``
+            services) is returned.  For ``web`` services, what is returned is
+            an opaque service object that has a ``search()`` method simply
+            opening a web browser on the access URL.
         """
         return self.get_interface(service_type, lax, std_only=True
             ).to_service()


### PR DESCRIPTION
There is a warning now, though, that ought to tip people off when things
go wrong.  See also https://github.com/astropy/pyvo/issues/340; it does
not directly address the problem outlined there.

Relatedly, we now properly parse the arrays-in-strings we get back from
TAP.  So far, an empty result yielded [""] in the array of, e.g., access_url.
We ought to have proper string arrays in VOTable one day.