### PR TITLE
DOC: add pyvo to top header instead of astropy

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -104,6 +104,13 @@ release = package.__version__
 # name of a builtin theme or the name of a custom theme in html_theme_path.
 #html_theme = None
 
+# Customized theme options
+html_theme_options = {
+    'logotext1': 'Py',  # white, semi-bold
+    'logotext2': 'VO',  # orange, light
+    'logotext3': ''  # white, light
+}
+
 # Custom sidebar templates, maps document names to template names.
 #html_sidebars = {}
 


### PR DESCRIPTION
Fix the header, so it says "PyVO" instead of "astropy"


<img width="306" alt="Screenshot 2022-08-12 at 11 26 58" src="https://user-images.githubusercontent.com/6788290/184421175-3e43a828-bcdf-4c3e-9212-c8acabb354e7.png">





