### PR TITLE
CI: use nightly wheels

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -14,9 +14,9 @@ jobs:
   egginfo:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Install tox
@@ -31,13 +31,14 @@ jobs:
       fail-fast: true
       matrix:
         python-version: ["3.8", "3.9", "3.10"]
+
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install tox
@@ -59,11 +60,11 @@ jobs:
         os: [macos-latest, windows-latest]
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
     - name: Install tox
@@ -76,9 +77,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: tests
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Setup Graphviz
@@ -100,9 +101,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: tests
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python 3.10
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.10"
       - name: Install tox
@@ -114,9 +115,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: tests
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Install tox

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
-    name: ${{ matrix.python-version }}
+    name: ${{ matrix.python-version }} with all dependencies
     strategy:
       fail-fast: true
       matrix:
@@ -40,6 +40,7 @@ jobs:
 
   mac_windows:
     runs-on: ${{ matrix.os }}
+    name: ${{ matrix.os }} with mandatory dependencies
     needs: tests
     strategy:
       fail-fast: true

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -73,7 +73,7 @@ jobs:
       run: tox -e py39-test
 
 
-  style_coverage:
+  stylecheck:
     runs-on: ubuntu-latest
     needs: tests
     steps:
@@ -82,18 +82,11 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: 3.8
-      - name: Setup Graphviz
-        uses: ts-graphviz/setup-graphviz@v1
       - name: Install tox
         run: python -m pip install --upgrade tox
       - name: Check codestyle
         run: tox -e codestyle
-      - name: Check coverage
-        run: tox -e cov
-      - name: Upload coverage to codecov
-        uses: codecov/codecov-action@v2
-        with:
-          file: ./coverage.xml
+
 
   devdeps:
     # TODO: this job should be allowed to fail except that the functionality
@@ -109,7 +102,15 @@ jobs:
       - name: Install tox
         run: python -m pip install --upgrade tox
       - name: Run tests against dev dependencies
-        run: tox -e py310-test-devdeps
+        run: tox -e py310-test-devdeps-alldeps-cov
+
+      - name: Upload coverage to codecov
+        uses: codecov/codecov-action@v3
+        with:
+          file: ./coverage.xml
+          verbose: true
+
+
 
   oldestdeps:
     runs-on: ubuntu-latest
@@ -124,9 +125,3 @@ jobs:
         run: python -m pip install --upgrade tox
       - name: Run tests against oldest dependencies
         run: tox -e py38-test-oldestdeps
-
-  #publish:
-  #needs: coverage
-  #TODO - should be trigger by tagging associated with creating a new release in
-  # github. The tag should be compared to the version in setup.cfg to ensure
-  # consistency.

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -47,7 +47,7 @@ jobs:
         # remove "." from matrix.python-version to get the defaults tox python versions
         tox_python_target=$(echo py${{matrix.python-version}} | sed 's/\.//')
         echo "Tox python target: " $tox_python_target
-        tox -e $tox_python_target-test
+        tox -e $tox_python_target-test-alldeps
 
 
   mac_windows:
@@ -94,7 +94,7 @@ jobs:
         with:
           file: ./coverage.xml
 
-  devastropy:
+  devdeps:
     # TODO: this job should be allowed to fail except that the functionality
     # is not available in actions yet.
     runs-on: ubuntu-latest
@@ -107,8 +107,8 @@ jobs:
           python-version: "3.10"
       - name: Install tox
         run: python -m pip install --upgrade tox
-      - name: Run tests against devastropy
-        run: tox -e py310-test-devastropy
+      - name: Run tests against dev dependencies
+        run: tox -e py310-test-devdeps
 
   oldestdeps:
     runs-on: ubuntu-latest

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -11,20 +11,7 @@ on:
     - cron: "0 3 * * *"
 
 jobs:
-  egginfo:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.8
-      - name: Install tox
-        run: python -m pip install --upgrade tox
-      - name: egg-info
-        run: tox -e egg_info
   tests:
-    needs: egginfo
     runs-on: ubuntu-latest
     name: ${{ matrix.python-version }}
     strategy:

--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,6 @@ The following packages are required for PyVO:
 The following packages are optional dependencies and are required for the
 full functionality:
 
- * mimeparse
  * pillow
 
 For running the tests, and building the documentation, the following

--- a/pyvo/__init__.py
+++ b/pyvo/__init__.py
@@ -32,7 +32,6 @@ of which DALAccessError is the root parent exception.
 from ._astropy_init import *
 # ----------------------------------------------------------------------------
 
-# For egg_info test builds to pass, put package imports here.
 from . import registry
 from .dal import ssa, sia, sla, scs, tap
 from . import auth

--- a/pyvo/conftest.py
+++ b/pyvo/conftest.py
@@ -30,8 +30,13 @@ def pytest_configure(config):
 
         # Customize the following lines to add/remove entries from the list of
         # packages for which version numbers are displayed when running the tests.
+        PYTEST_HEADER_MODULES['Astropy'] = 'astropy'  # noqa
+        PYTEST_HEADER_MODULES['requests'] = 'requests'  # noqa
+
         PYTEST_HEADER_MODULES.pop('Pandas', None)
-        PYTEST_HEADER_MODULES['scikit-image'] = 'skimage'
+        PYTEST_HEADER_MODULES.pop('h5py', None)
+        PYTEST_HEADER_MODULES.pop('Scipy', None)
+        PYTEST_HEADER_MODULES.pop('Matplotlib', None)
 
         from . import __version__
         TESTED_VERSIONS['pyvo'] = __version__

--- a/pyvo/dal/tests/test_mimetype.py
+++ b/pyvo/dal/tests/test_mimetype.py
@@ -17,6 +17,12 @@ mime_url = 'https://someurl.com/'
 get_pkg_data_contents = partial(
     get_pkg_data_contents, package=__package__, encoding='binary')
 
+try:
+    from PIL import Image
+    HAS_PILLOW = True
+except ImportError:
+    HAS_PILLOW = False
+
 
 @pytest.fixture()
 def mime(mocker):
@@ -35,6 +41,7 @@ def mime(mocker):
 
 
 @pytest.mark.usefixtures('mime')
+@pytest.mark.skipif('not HAS_PILLOW')
 def test_mime_object_maker():
 
     assert 'Text content' == mime_object_maker(mime_url+'mime-text',

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,6 @@ python_requires = >=3.8
 
 [options.extras_require]
 all =
-    mimeparse
     pillow
 test =
     pytest-astropy

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 # as oldestdeps and devastropy might not support the full python range
 # listed here
 envlist =
-    py{38,39,310}-test{,-oldestdeps, -devastropy}
+    py{38,39,310}-test{,-alldeps,-oldestdeps,-devdeps}
     egg_info
     cov
     linkcheck
@@ -13,38 +13,30 @@ envlist =
 requires =
     setuptools >= 30.3.0
     pip >= 19.3.1
-    tox-pypi-filter >= 0.12
-
-[testenv]
-pypi_filter = https://raw.githubusercontent.com/astropy/ci-helpers/main/pip_pinnings.txt
 
 extras =
     test
-    all
+    alldeps: all
 
-commands =
-    pip freeze
-    pytest --pyargs pyvo
-
-# tox environments are constructed with so-called 'factors' (or terms)
-# separated by hyphens, e.g. test-devdeps-cov. Lines below starting with factor:
-# will only take effect if that factor is included in the environment name. To
-# see a list of example environments that can be run, along with a description,
-# run:
-#
-#     tox -l -v
-#
 description =
     run tests
-    oldestdeps: with astropy 4.1.*
-    devastropy: with astropy latest
+    oldestdeps: with oldest supported dependencies
+    devastropy: with development version of dependencies
 
 deps =
-    devastropy: git+https://github.com/astropy/astropy.git#egg=astropy
+
     oldestdeps: astropy==4.1
     # We set a suitably old numpy along with an old astropy, no need to pick up
     # deprecations and errors due to their unmatching versions
     oldestdeps: numpy==1.16
+
+commands =
+    devdeps: pip install -U --pre --only-binary :all: -i https://pypi.anaconda.org/scipy-wheels-nightly/simple numpy
+    devdeps: pip install -U --pre -i https://pypi.anaconda.org/astropy/simple astropy
+
+    pip freeze
+    pytest --pyargs pyvo
+
 
 [testenv:egg_info]
 description = ensure egg_info works without dependencies

--- a/tox.ini
+++ b/tox.ini
@@ -3,18 +3,17 @@
 # as oldestdeps and devastropy might not support the full python range
 # listed here
 envlist =
-    py{38,39,310}-test{,-alldeps,-oldestdeps,-devdeps}{-,cov}
-    cov
+    py{38,39,310}-test{,-alldeps,-oldestdeps,-devdeps}{,-cov}
     linkcheck
     codestyle
     build_docs
-
 requires =
     setuptools >= 30.3.0
     pip >= 19.3.1
 
+[testenv]
 extras =
-    test
+    test: test
     alldeps: all
 
 description =

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,6 @@
 # listed here
 envlist =
     py{38,39,310}-test{,-alldeps,-oldestdeps,-devdeps}{-,cov}
-    egg_info
     cov
     linkcheck
     codestyle
@@ -40,13 +39,6 @@ commands =
     !cov: pytest --pyargs pyvo
     cov: pytest --pyargs pyvo --cov pyvo --cov-config={toxinidir}/setup.cfg
     cov: coverage xml -o {toxinidir}/coverage.xml
-
-
-[testenv:egg_info]
-description = ensure egg_info works without dependencies
-commands =
-    pip freeze
-    python setup.py egg_info
 
 
 [testenv:docs]

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 # as oldestdeps and devastropy might not support the full python range
 # listed here
 envlist =
-    py{38,39,310}-test{,-alldeps,-oldestdeps,-devdeps}
+    py{38,39,310}-test{,-alldeps,-oldestdeps,-devdeps}{-,cov}
     egg_info
     cov
     linkcheck
@@ -21,9 +21,11 @@ extras =
 description =
     run tests
     oldestdeps: with oldest supported dependencies
-    devastropy: with development version of dependencies
+    devdeps: with development version of dependencies
+    cov: determine the code coverage
 
 deps =
+    cov: coverage
 
     oldestdeps: astropy==4.1
     # We set a suitably old numpy along with an old astropy, no need to pick up
@@ -35,7 +37,9 @@ commands =
     devdeps: pip install -U --pre -i https://pypi.anaconda.org/astropy/simple astropy
 
     pip freeze
-    pytest --pyargs pyvo
+    !cov: pytest --pyargs pyvo
+    cov: pytest --pyargs pyvo --cov pyvo --cov-config={toxinidir}/setup.cfg
+    cov: coverage xml -o {toxinidir}/coverage.xml
 
 
 [testenv:egg_info]
@@ -43,17 +47,6 @@ description = ensure egg_info works without dependencies
 commands =
     pip freeze
     python setup.py egg_info
-
-[testenv:cov]
-description = determine the code coverage
-deps:
-     # had to pin this
-    coverage==4.5.4
-
-commands =
-    pip freeze
-    pytest --pyargs pyvo --cov pyvo --cov-config={toxinidir}/setup.cfg
-    coverage xml -o {toxinidir}/coverage.xml
 
 
 [testenv:docs]


### PR DESCRIPTION
This PR does a few minor CI improvements:

- switches to use "nightly" wheels for dev versions rather than building from source
- opt-in to also include testing with the dev numpy 
- makes sure that we actually test with the mandatory dependencies only (previously all dependencies were always installed)
- run coverage test after a test suite run rather than after running the linter (as that one shouldn't install dependencies)
- minor cleanups to ensure the relevant versions are printed in the test header