### PR TITLE
CI: adding remote-data test job, remove duplicate

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -13,11 +13,19 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
-    name: ${{ matrix.python-version }} with all dependencies
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        include:
+          - name: py38 oldest dependencies, Linux
+            python-version: '3.8'
+            tox_env: py38-test-oldestdeps-alldeps
+          - name: py39 mandatory dependencies only, Linux
+            python-version: '3.9'
+            tox_env: py39-test
+          - name: py310 with online tests, Linux
+            python-version: '3.10'
+            tox_env: py310-test-alldeps-online
 
     steps:
     - name: Checkout code
@@ -30,17 +38,12 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install tox
       run: python -m pip install --upgrade tox
-    - name: Python ${{ matrix.python-version }} with astropy
-      run: |
-        # remove "." from matrix.python-version to get the defaults tox python versions
-        tox_python_target=$(echo py${{matrix.python-version}} | sed 's/\.//')
-        echo "Tox python target: " $tox_python_target
-        tox -e $tox_python_target-test-alldeps
-
+    - name: Install library dependencies and run Tests
+      run: tox -e ${{ matrix.tox_env }}
 
   mac_windows:
     runs-on: ${{ matrix.os }}
-    name: ${{ matrix.os }} with mandatory dependencies
+    name: ${{ matrix.os }}
     needs: tests
     strategy:
       fail-fast: true
@@ -58,7 +61,7 @@ jobs:
     - name: Install tox
       run: python -m pip install --upgrade tox
     - name: Python 3.9 with latest astropy
-      run: tox -e py39-test
+      run: tox -e py39-test-alldeps
 
 
   stylecheck:
@@ -97,19 +100,3 @@ jobs:
         with:
           file: ./coverage.xml
           verbose: true
-
-
-
-  oldestdeps:
-    runs-on: ubuntu-latest
-    needs: tests
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.8
-      - name: Install tox
-        run: python -m pip install --upgrade tox
-      - name: Run tests against oldest dependencies
-        run: tox -e py38-test-oldestdeps

--- a/conftest.py
+++ b/conftest.py
@@ -8,9 +8,9 @@ import tempfile
 
 try:
     from pytest_astropy_header.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
+    ASTROPY_HEADER = True
 except ImportError:
-    PYTEST_HEADER_MODULES = {}
-    TESTED_VERSIONS = {}
+    ASTROPY_HEADER = False
 
 # Make sure we use temporary directories for the config and cache
 # so that the tests are insensitive to local configuration.
@@ -21,20 +21,43 @@ os.environ['XDG_CACHE_HOME'] = tempfile.mkdtemp('astropy_cache')
 os.mkdir(os.path.join(os.environ['XDG_CONFIG_HOME'], 'astropy'))
 os.mkdir(os.path.join(os.environ['XDG_CACHE_HOME'], 'astropy'))
 
-try:
-    from pyvo import __version__ as version
-except ImportError:
-    version = 'unknown'
-
-TESTED_VERSIONS['pyvo'] = version
-
-
 # Note that we don't need to change the environment variables back or remove
 # them after testing, because they are only changed for the duration of the
 # Python process, and this configuration only matters if running pytest
 # directly, not from e.g. an IPython session.
 
+try:
+    from pyvo import __version__ as version
+except ImportError:
+    version = 'unknown'
+
+
 # Disable IERS auto download for testing (to support the local, non-remote-data scenario),
 # revisit this config when minimum supported astropy is 5.1.
 from astropy.utils.iers import conf as iers_conf
 iers_conf.auto_download = False
+
+
+def pytest_configure(config):
+    """Configure Pytest with Astropy.
+
+    Parameters
+    ----------
+    config : pytest configuration
+
+    """
+    if ASTROPY_HEADER:
+
+        config.option.astropy_header = True
+
+        # Customize the following lines to add/remove entries from the list of
+        # packages for which version numbers are displayed when running the tests.
+        PYTEST_HEADER_MODULES['Astropy'] = 'astropy'  # noqa
+        PYTEST_HEADER_MODULES['requests'] = 'requests'  # noqa
+
+        PYTEST_HEADER_MODULES.pop('Pandas', None)
+        PYTEST_HEADER_MODULES.pop('h5py', None)
+        PYTEST_HEADER_MODULES.pop('Scipy', None)
+        PYTEST_HEADER_MODULES.pop('Matplotlib', None)
+
+        TESTED_VERSIONS['pyvo'] = version

--- a/docs/dal/index.rst
+++ b/docs/dal/index.rst
@@ -432,7 +432,8 @@ The total number of rows in the answer is available as its ``len()``:
 
 If the row contains datasets, they are exposed by several retrieval methods:
 
-.. doctest-remote-data::
+.. remove skip once https://github.com/astropy/pyvo/issues/361 is fixed
+.. doctest-skip::
 
     >>> url = row.getdataurl()
     >>> fileobj = row.getdataset()
@@ -475,7 +476,8 @@ To get an iterator yielding specific datasets, call
 :py:meth:`pyvo.dal.adhoc.DatalinkResults.bysemantics` with the identifier
 identifying the dataset you want it to return.
 
-.. doctest-remote-data::
+.. remove skip once https://github.com/astropy/pyvo/issues/361 is fixed
+.. doctest-skip::
 
     >>> preview = next(row.getdatalink().bysemantics('#preview')).getdataset()
 
@@ -485,7 +487,8 @@ identifying the dataset you want it to return.
 
 Of course one can also build a datalink object from it's url.
 
-.. doctest-remote-data::
+.. TODO: define DatalinkResults
+.. doctest-skip::
 
     >>> datalink = DatalinkResults.from_result_url(url)
 
@@ -500,7 +503,8 @@ Datalink
 Generic access to processing services is provided through the datalink
 interface.
 
-.. doctest-remote-data::
+.. remove skip once https://github.com/astropy/pyvo/issues/361 is fixed
+.. doctest-skip::
 
     >>> datalink_proc = next(row.getdatalink().bysemantics('#proc'))
 
@@ -508,26 +512,28 @@ interface.
   most times there is only one processing service per result, and thats all you
   need.
 
-.. doctest-remote-data::
-
-  >>> datalink_proc = row.getdatalink().get_first_proc()
 
 The returned object lets you access the available input parameters which you
 can pass as keywords to the ``process`` method.
 
-.. doctest-remote-data::
+.. remove skip once https://github.com/astropy/pyvo/issues/361 is fixed
+.. doctest-skip::
 
-    >>> print(datalink_proc.input_params)
+  >>> datalink_proc = row.getdatalink().get_first_proc()
+  >>> print(datalink_proc.input_params)
+
 
 For more details about this have a look at
 :py:class:`astropy.io.votable.tree.Param`.
 
 Calling the method will return a file-like object on sucess.
 
-.. doctest-remote-data::
+.. remove skip once https://github.com/astropy/pyvo/issues/361 is fixed
+.. doctest-skip::
 
     >>> print(datalink_proc)
     >>> fobj = datalink.process(circle=(1, 1, 1))
+
 
 SODA
 ^^^^
@@ -543,6 +549,7 @@ parameters who are dependend on the type of service.
 - ``band`` -- a sequence of two values (meters) or
   :py:class:`astropy.units.Quantity` with two bandwitdh values. The right sort
   order will be ensured if converting from frequency to wavelength.
+
 
 Interoperabillity over SAMP
 ---------------------------

--- a/docs/dal/index.rst
+++ b/docs/dal/index.rst
@@ -17,11 +17,20 @@ metadata.
     >>> import pyvo as vo
     >>> service = vo.dal.SIAService("http://dc.zah.uni-heidelberg.de/lswscans/res/positions/siap/siap.xml")
     >>> print(service.description)
+    Scans of plates kept at Landessternwarte Heidelberg-Königstuhl. They
+    were obtained at location, at the German-Spanish Astronomical Center
+    (Calar Alto Observatory), Spain, and at La Silla, Chile. The plates
+    cover a time span between 1880 and 1999.
+    <BLANKLINE>
+    Specifically, HDAP is essentially complete for the plates taken with
+    the Bruce telescope, the Walz reflector, and Wolf's Doppelastrograph
+    at both the original location in Heidelberg and its later home on
+    Königstuhl.
 
 They provide a ``search`` method with varying standard parameters for
 submitting queries.
 
-.. doctest-remote-data::
+.. doctest-skip::
 
     >>> resultset = service.search(pos=pos, size=size)
 
@@ -133,23 +142,28 @@ rows they will return before overflowing:
 .. doctest-remote-data::
 
     >>> print(tap_service.maxrec)
+    20000
 
 To retrieve more rows than that (often conservative) default limit, you
-must override maxrec in the call to ``search``:
+must override maxrec in the call to ``search``. A warning can be expected if
+you reach the ``maxrec`` limit:
 
 .. doctest-remote-data::
 
-    >>> tap_results = tap_service.search("SELECT * FROM ivoa.obscore", maxrec=100000)
+    >>> tap_results = tap_service.search("SELECT * FROM ivoa.obscore", maxrec=100000)  # doctest: +SHOW_WARNINGS
+    DALOverflowWarning: Partial result set. Potential causes MAXREC, async storage space, etc.
 
 Services will not let you raise maxrec beyond the hard match limit:
 
 .. doctest-remote-data::
 
     >>> print(tap_service.hardlimit)
+    16000000
 
 A list of the tables and the columns within them is available in the
 TAPService's :py:attr:`~pyvo.dal.TAPService.tables` attribute by using it as an
 iterator or calling it's ``describe()`` method for a human-readable summary.
+
 
 Uploads
 ^^^^^^^
@@ -240,6 +254,7 @@ SSA queries can be further constrained by the ``band`` and ``time`` parameters.
     ...     time=time, band=Quantity((1e-13, 1e-12), unit="meter")
     ... )
 
+
 Simple Cone Search
 ------------------
 The Simple Cone Search returns results – typically catalog entries –
@@ -248,8 +263,7 @@ within a circular region on the sky defined by the parameters ``pos``
 
 .. doctest-remote-data::
 
-    >>> scs_srv = vo.dal.SCSService(
-    >>>     'http://dc.zah.uni-heidelberg.de/arihip/q/cone/scs.xml')
+    >>> scs_srv = vo.dal.SCSService('http://dc.zah.uni-heidelberg.de/arihip/q/cone/scs.xml')
     >>> scs_results = scs_srv.search(pos=pos, radius=size)
 
 This service exposes the :ref:`verbosity <pyvo-verbosity>` parameter
@@ -290,14 +304,14 @@ This job is not yet running yet. To start it invoke ``run``
 
 .. doctest-remote-data::
 
-    >>> job.run()
+    >>> job.run()  # doctest: +IGNORE_OUTPUT
 
 Get the current job phase:
 
 .. doctest-remote-data::
 
     >>> print(job.phase)
-    RUN
+    EXECUTING
 
 Maximum run time in seconds is available and can be changed with
 :py:attr:`~pyvo.dal.tap.AsyncTAPJob.execution_duration`
@@ -305,8 +319,8 @@ Maximum run time in seconds is available and can be changed with
 .. doctest-remote-data::
 
     >>> print(job.execution_duration)
-    3600
-    >>> job.execution_duration = 7200
+    7200.0
+    >>> job.execution_duration = 3600
 
 Obtaining the job url, which is needed to reconstruct the job at a later point:
 
@@ -333,9 +347,10 @@ takes care of this automatically:
 
 .. doctest-remote-data::
 
-    >>> with async_srv.submit_job("SELECT * FROM ivoa.obscore") as job:
-    ...     job.run()
-    >>> print('Job deleted!')
+    >>> with async_srv.submit_job("SELECT * FROM ivoa.obscore") as job1:
+    ...     job1.run()  # doctest: +IGNORE_OUTPUT
+    >>> print('job1 deleted!')
+    job1 deleted!
 
 Check for errors in the job execution:
 
@@ -362,6 +377,15 @@ To obtain the names of the columns in a service response, write:
     >>> tap_service = vo.dal.TAPService("http://dc.g-vo.org/tap")
     >>> resultset = tap_service.search("SELECT TOP 10 * FROM ivoa.obscore")
     >>> print(resultset.fieldnames)
+    ('dataproduct_type', 'dataproduct_subtype', 'calib_level',
+    'obs_collection', 'obs_id', 'obs_title', 'obs_publisher_did',
+    'obs_creator_did', 'access_url', 'access_format', 'access_estsize',
+    'target_name', 'target_class', 's_ra', 's_dec', 's_fov', 's_region',
+    's_resolution', 't_min', 't_max', 't_exptime', 't_resolution', 'em_min',
+    'em_max', 'em_res_power', 'o_ucd', 'pol_states', 'facility_name',
+    'instrument_name', 's_xel1', 's_xel2', 't_xel', 'em_xel', 'pol_xel',
+    's_pixel_scale', 'em_ucd', 'preview', 'source_table')
+
 
 Rich metadata equivalent to what is found in VOTables (including unit,
 ucd, utype, and xtype) is available through resultset's
@@ -369,7 +393,8 @@ ucd, utype, and xtype) is available through resultset's
 
 .. doctest-remote-data::
 
-    >>>  print(resultset.getdesc('s_fov').ucd)
+    >>> print(resultset.getdesc('s_fov').ucd)
+    phys.angSize;instr.fov
 
 .. note::
     Two convenience functions let you retrieve columns of a specific
@@ -387,6 +412,16 @@ Iterating over a resultset gives the rows in the result:
 
     >>> for row in resultset:
     ...     print(row['s_fov'])
+    0.05027778
+    0.05027778
+    0.05027778
+    0.05027778
+    0.05027778
+    0.05027778
+    0.06527778
+    0.06527778
+    0.06527778
+    0.06527778
 
 The total number of rows in the answer is available as its ``len()``:
 
@@ -401,9 +436,7 @@ If the row contains datasets, they are exposed by several retrieval methods:
 
     >>> url = row.getdataurl()
     >>> fileobj = row.getdataset()
-
-..    TODO: uncomment the following line once https://github.com/astropy/pyvo/issues/324 is addressed
-..    >>> obj = row.getdataobj()
+    >>> obj = row.getdataobj()
 
 Returning the access url, the file-like object or the appropiate python object
 to further work on.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -76,12 +76,13 @@ specific to the service type. In this example, a database query is enough:
 .. doctest-remote-data::
 
     >>> resultset = service.search("SELECT TOP 1 * FROM ivoa.obscore")
-    <Table masked=True length=1>
-    dataproduct_type dataproduct_subtype calib_level ... s_pixel_scale em_ucd
-                                                     ...      arcs
-         object             object          int16    ...    float64    object
-    ---------------- ------------------- ----------- ... ------------- ------
-               image                               1 ...            --
+    >>> resultset
+    <Table length=1>
+    dataproduct_type dataproduct_subtype ... source_table
+                                         ...
+         object             object       ...    object
+    ---------------- ------------------- ... ------------
+               image                     ... ppakm31.maps
 
 What is returned by the search method is a to get a resultset object, which
 esseintially works like a numpy record array.  It can be processed either by
@@ -97,7 +98,7 @@ or by rows.
 .. doctest-remote-data::
 
     >>> for row in resultset:
-    >>>   calib_level = row["calib_level"]
+    ...   calib_level = row["calib_level"]
 
 For more details on how to use data access services see :ref:`pyvo-data-access`
 
@@ -112,7 +113,15 @@ observational datasets through TAP tables), you can write:
 .. doctest-remote-data::
 
     >>> for service in vo.regsearch(datamodel="obscore"):
-    ...   print(service)
+    ...   print(service['ivoid'])
+    ivo://aip.gavo.org/tap
+    ivo://archive.stsci.edu/caomtap
+    ivo://astro.ucl.ac.uk/tap
+    ivo://astron.nl/tap
+    ivo://asu.cas.cz/tap
+    ...
+    ivo://xcatdb/3xmmdr7/tap
+    ivo://xcatdb/4xmm/tap
 
 
 Using `pyvo`

--- a/docs/registry/index.rst
+++ b/docs/registry/index.rst
@@ -171,9 +171,9 @@ thus say:
 
   >>> resources["II/283"].get_service("conesearch").search(pos=(120, 73), sr=1)  # doctest: +IGNORE_OUTPUT
   <Table length=1>
-    _RAJ2000     _DEJ2000      _r    recno ... NED    RAJ2000      DEJ2000   
-      deg          deg        deg          ...        "h:m:s"      "d:m:s"   
-    float64      float64    float64  int32 ... str3    str12        str12    
+    _RAJ2000     _DEJ2000      _r    recno ... NED    RAJ2000      DEJ2000
+      deg          deg        deg          ...        "h:m:s"      "d:m:s"
+    float64      float64    float64  int32 ... str3    str12        str12
   ------------ ------------ -------- ----- ... ---- ------------ ------------
   117.98645833  73.00961111 0.588592   986 ...  NED 07 51 56.750 +73 00 34.60
 
@@ -184,7 +184,7 @@ attribute, but you can take a shortcut and call a RegistryResource's
 
 .. doctest-remote-data::
 
-  >>> tables = resources["II/283"].get_tables()
+  >>> tables = resources["II/283"].get_tables()  # doctest: +IGNORE_WARNINGS
   >>> list(tables.keys())
   ['II/283/sncat']
   >>> tables['II/283/sncat'].columns
@@ -212,9 +212,9 @@ to the resource that works in a web browser.  You can ask for a
 ``search`` method, and when you call it, a browser window should open
 with the query facility (this uses python's webbrowser module):
 
-.. doctest-remote-data::
+.. doctest-skip::
 
-  >>> resources["II/283"].get_service("web").search()
+  >>> resources["II/283"].get_service("web").search()  # doctest: +IGNORE_OUTPUT
 
 Note that for interactive data discovery in the VO Registry, you may
 also want to have a look at Aladin's discovery tree, TOPCAT's VO menu,
@@ -330,7 +330,7 @@ and then you can run:
 
 .. doctest-remote-data::
 
-  >>> res.get_tables()
+  >>> res.get_tables()  # doctest: +IGNORE_OUTPUT
   {'flashheros.data': <Table name="flashheros.data">... 29 columns ...</Table>, 'ivoa.obscore': <Table name="ivoa.obscore">... 0 columns ...</Table>}
 
 

--- a/pyvo/dal/adhoc.py
+++ b/pyvo/dal/adhoc.py
@@ -421,9 +421,9 @@ class DatalinkQuery(DALQuery):
         """
         super().__init__(baseurl, session=session, **keywords)
 
-        if id:
+        if id is not None:
             self["ID"] = id
-        if responseformat:
+        if responseformat is not None:
             self["RESPONSEFORMAT"] = responseformat
 
     def execute(self, post=False):
@@ -866,16 +866,16 @@ class SodaQuery(DatalinkQuery, AxisParamMixin):
             **kwargs):
         super().__init__(baseurl, **kwargs)
 
-        if circle:
+        if circle is not None:
             self.circle = circle
 
-        if range:
+        if range is not None:
             self.range = range
 
-        if polygon:
+        if polygon is not None:
             self.polygon = polygon
 
-        if band:
+        if band is not None:
             self.band = band
 
     @property

--- a/pyvo/dal/sia.py
+++ b/pyvo/dal/sia.py
@@ -396,19 +396,19 @@ class SIAQuery(DALQuery):
         """
         super().__init__(baseurl, session=session, **keywords)
 
-        if pos:
+        if pos is not None:
             self.pos = pos
 
         if size is not None:
             self.size = size
 
-        if format:
+        if format is not None:
             self.format = format
 
-        if intersect:
+        if intersect is not None:
             self.intersect = intersect
 
-        if verbosity:
+        if verbosity is not None:
             self.verbosity = verbosity
 
     @property

--- a/pyvo/dal/ssa.py
+++ b/pyvo/dal/ssa.py
@@ -346,19 +346,19 @@ class SSAQuery(DALQuery):
         """
         super().__init__(baseurl, session=session)
 
-        if pos:
+        if pos is not None:
             self.pos = pos
 
         if diameter is not None:
             self.diameter = diameter
 
-        if band:
+        if band is not None:
             self.band = band
 
-        if time:
+        if time is not None:
             self.time = time
 
-        if format:
+        if format is not None:
             self.format = format
 
         self.request = request

--- a/pyvo/dal/tests/test_sia2_remote.py
+++ b/pyvo/dal/tests/test_sia2_remote.py
@@ -25,6 +25,7 @@ class TestSIACadc():
         assert cadc.availability.notes[0] == 'service is accepting queries'
         assert cadc.capabilities
 
+    @pytest.mark.xfail(reason="https://github.com/astropy/pyvo/issues/361")
     @pytest.mark.filterwarnings("ignore::pyvo.dal.exceptions.DALOverflowWarning")
     def test_datalink_batch(self):
         # Maximum batch size in CADC SIA is around 25

--- a/pyvo/registry/tests/test_regtap.py
+++ b/pyvo/registry/tests/test_regtap.py
@@ -20,7 +20,7 @@ from pyvo.dal import tap
 
 from astropy.utils.data import get_pkg_data_contents
 
-from .commonfixtures import messenger_vocabulary
+from .commonfixtures import messenger_vocabulary  # noqa: F401
 
 
 get_pkg_data_contents = partial(
@@ -656,7 +656,7 @@ class TestGetTables:
         assert (flash_tables["ivoa.obscore"].name
             == "ivoa.obscore")
         assert (flash_tables["ivoa.obscore"].description
-            == "This data collection is queriable in GAVO Data"
+            == "This data collection is queryable in GAVO Data"
             " Center's obscore table.")
         assert (flash_tables["flashheros.data"].title
             == "Flash/Heros SSA table")

--- a/tox.ini
+++ b/tox.ini
@@ -41,8 +41,8 @@ commands =
     devdeps: pip install -U --pre -i https://pypi.anaconda.org/astropy/simple astropy
 
     pip freeze
-    !cov: pytest --pyargs pyvo {env:PYTEST_ARGS}
-    cov: pytest --pyargs pyvo --cov pyvo --cov-config={toxinidir}/setup.cfg {env:PYTEST_ARGS}
+    !cov: pytest --pyargs {env:PYTEST_ARGS}
+    cov: pytest --pyargs --cov pyvo --cov-config={toxinidir}/setup.cfg {env:PYTEST_ARGS}
     cov: coverage xml -o {toxinidir}/coverage.xml
 
 [testenv:docs]

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 # as oldestdeps and devastropy might not support the full python range
 # listed here
 envlist =
-    py{38,39,310}-test{,-alldeps,-oldestdeps,-devdeps}{,-cov}
+    py{38,39,310}-test{,-alldeps,-oldestdeps,-devdeps}{,-online}{,-cov}
     linkcheck
     codestyle
     build_docs
@@ -22,6 +22,10 @@ description =
     devdeps: with development version of dependencies
     cov: determine the code coverage
 
+setenv =
+    PYTEST_ARGS = -rsxf --show-capture=no
+    online: PYTEST_ARGS = --remote-data=any --reruns=1 --reruns-delay 10 -rsxf --show-capture=no
+
 deps =
     cov: coverage
 
@@ -30,15 +34,16 @@ deps =
     # deprecations and errors due to their unmatching versions
     oldestdeps: numpy==1.16
 
+    online: pytest-rerunfailures
+
 commands =
     devdeps: pip install -U --pre --only-binary :all: -i https://pypi.anaconda.org/scipy-wheels-nightly/simple numpy
     devdeps: pip install -U --pre -i https://pypi.anaconda.org/astropy/simple astropy
 
     pip freeze
-    !cov: pytest --pyargs pyvo
-    cov: pytest --pyargs pyvo --cov pyvo --cov-config={toxinidir}/setup.cfg
+    !cov: pytest --pyargs pyvo {env:PYTEST_ARGS}
+    cov: pytest --pyargs pyvo --cov pyvo --cov-config={toxinidir}/setup.cfg {env:PYTEST_ARGS}
     cov: coverage xml -o {toxinidir}/coverage.xml
-
 
 [testenv:docs]
 description = builds the docs


### PR DESCRIPTION
This PR reshuffles the CI a bit in order to:
 - add `--remote-data=any` to one of the jobs. 
 - remove the matrix handling of python versions in order to be able to handle the jobs a bit more heterogeneous way

As a result now we test all OSes with all the dependencies while keeping one linux run with the mandatory dependencies only. We also have one remote-data test and one for the oldest dependency versions, and one for the dev versions. I feel with the reshuffle we cover more of our grounds with one less job.

note: I expect the remote-data job to fail until CADC is back online. If it keeps failing after that then we have to deal with a genuine issues.


I would love it if @pllim could have a look at this to whether I've missed a piece of logic somewhere.