### PR TITLE
BUG: Don’t test for truth but on None for kwargs 

### DIFF
--- a/pyvo/dal/adhoc.py
+++ b/pyvo/dal/adhoc.py
@@ -421,9 +421,9 @@ class DatalinkQuery(DALQuery):
         """
         super().__init__(baseurl, session=session, **keywords)
 
-        if id:
+        if id is not None:
             self["ID"] = id
-        if responseformat:
+        if responseformat is not None:
             self["RESPONSEFORMAT"] = responseformat
 
     def execute(self, post=False):
@@ -866,16 +866,16 @@ class SodaQuery(DatalinkQuery, AxisParamMixin):
             **kwargs):
         super().__init__(baseurl, **kwargs)
 
-        if circle:
+        if circle is not None:
             self.circle = circle
 
-        if range:
+        if range is not None:
             self.range = range
 
-        if polygon:
+        if polygon is not None:
             self.polygon = polygon
 
-        if band:
+        if band is not None:
             self.band = band
 
     @property

--- a/pyvo/dal/sia.py
+++ b/pyvo/dal/sia.py
@@ -396,19 +396,19 @@ class SIAQuery(DALQuery):
         """
         super().__init__(baseurl, session=session, **keywords)
 
-        if pos:
+        if pos is not None:
             self.pos = pos
 
         if size is not None:
             self.size = size
 
-        if format:
+        if format is not None:
             self.format = format
 
-        if intersect:
+        if intersect is not None:
             self.intersect = intersect
 
-        if verbosity:
+        if verbosity is not None:
             self.verbosity = verbosity
 
     @property

--- a/pyvo/dal/ssa.py
+++ b/pyvo/dal/ssa.py
@@ -346,19 +346,19 @@ class SSAQuery(DALQuery):
         """
         super().__init__(baseurl, session=session)
 
-        if pos:
+        if pos is not None:
             self.pos = pos
 
         if diameter is not None:
             self.diameter = diameter
 
-        if band:
+        if band is not None:
             self.band = band
 
-        if time:
+        if time is not None:
             self.time = time
 
-        if format:
+        if format is not None:
             self.format = format
 
         self.request = request


### PR DESCRIPTION
This is to fix the deprecation warnings coming from astropy, but I ended up adding this fix for more kwargs than just the Quantity ones, as it's better to be explicit.

```
    warnings.warn('The truth value of a Quantity is ambiguous. '
astropy.utils.exceptions.AstropyDeprecationWarning: The truth value of a Quantity is ambiguous. In the future this will raise a ValueError.
```