### PR TITLE
MAINT: cleanup astropy <4.1 code

### DIFF
--- a/pyvo/dal/adhoc.py
+++ b/pyvo/dal/adhoc.py
@@ -16,7 +16,6 @@ from astropy.io.votable.tree import Param
 from astropy import units as u
 from astropy.units import Quantity, Unit
 from astropy.units import spectral as spectral_equivalencies
-from pyvo.utils.compat import ASTROPY_LT_4_1
 
 from astropy.io.votable.tree import Resource, Group
 from astropy.utils.collections import HomogeneousList
@@ -132,9 +131,7 @@ class AdhocServiceResultsMixin:
         Resource
             The resource element describing the service.
         """
-        if ASTROPY_LT_4_1 and isinstance(ivo_id, str):
-            ivo_id = ivo_id.encode('utf-8')
-        if not ASTROPY_LT_4_1 and isinstance(ivo_id, bytes):
+        if isinstance(ivo_id, bytes):
             ivo_id = ivo_id.decode('utf-8')
         for adhocservice in self.iter_adhocservices():
             if any(
@@ -592,12 +589,7 @@ class DatalinkResults(DatalinkResultsMixin, DALResults):
         for index, row in enumerate(rows):
             votable.array[index] = row
         # now remove unreferenced services from resources
-        if ASTROPY_LT_4_1:
-            referenced_serviced = \
-                [x.decode('utf-8') for x in votable.array['service_def'] if x]
-        else:
-            referenced_serviced = \
-                [x for x in votable.array['service_def'] if x]
+        referenced_serviced = [x for x in votable.array['service_def'] if x]
         # remove customized that are not referenced by the current results
         for x in copy_tb.resources:
             if x.ID and x.ID not in referenced_serviced:

--- a/pyvo/dal/tests/test_datalink.py
+++ b/pyvo/dal/tests/test_datalink.py
@@ -135,14 +135,6 @@ def test_datalink_batch():
     assert len([_ for _ in results.iter_datalinks()]) == 3
 
 
-# temporary hack while astropy <4.1 is still around; you can remove
-# this and its calls once that's no longer true.
-def _debytify(v):
-    if isinstance(v, bytes):
-        return v.decode("utf-8")
-    return v
-
-
 @pytest.mark.usefixtures('proc', 'datalink_vocabulary')
 @pytest.mark.filterwarnings("ignore::astropy.io.votable.exceptions.W27")
 @pytest.mark.filterwarnings("ignore::astropy.io.votable.exceptions.W06")
@@ -151,14 +143,13 @@ def _debytify(v):
 class TestSemanticsRetrieval:
     def test_access_with_string(self):
         datalink = DatalinkResults.from_result_url('http://example.com/proc')
-        res = [_debytify(r["access_url"])
-               for r in datalink.bysemantics("#this")]
+        res = [r["access_url"] for r in datalink.bysemantics("#this")]
         assert len(res) == 1
         assert res[0].endswith("eq010000ms/20100927.comb_avg.0001.fits.fz")
 
     def test_access_with_list(self):
         datalink = DatalinkResults.from_result_url('http://example.com/proc')
-        res = [_debytify(r["access_url"])
+        res = [r["access_url"]
                for r in datalink.bysemantics(["#this", "#preview-image"])]
         assert len(res) == 2
         assert res[0].endswith("eq010000ms/20100927.comb_avg.0001.fits.fz")
@@ -166,7 +157,7 @@ class TestSemanticsRetrieval:
 
     def test_access_with_expansion(self):
         datalink = DatalinkResults.from_result_url('http://example.com/proc')
-        res = [_debytify(r["access_url"])
+        res = [r["access_url"]
                for r in datalink.bysemantics(["#this", "#preview"])]
         assert len(res) == 3
         assert res[0].endswith("eq010000ms/20100927.comb_avg.0001.fits.fz")
@@ -175,24 +166,22 @@ class TestSemanticsRetrieval:
 
     def test_access_without_expansion(self):
         datalink = DatalinkResults.from_result_url('http://example.com/proc')
-        res = [_debytify(r["access_url"])
-               for r in datalink.bysemantics(
-                       ["#this", "#preview"],
-                       include_narrower=False)]
+        res = [r["access_url"] for r in datalink.bysemantics(
+                       ["#this", "#preview"], include_narrower=False)]
         assert len(res) == 2
         assert res[0].endswith("eq010000ms/20100927.comb_avg.0001.fits.fz")
         assert res[1].endswith("http://dc.zah.uni-heidelberg.de/wider.dat")
 
     def test_with_full_url(self):
         datalink = DatalinkResults.from_result_url('http://example.com/proc')
-        res = [_debytify(r["access_url"])
+        res = [r["access_url"]
                for r in datalink.bysemantics("urn:example:rdf/dlext#oracle")]
         assert len(res) == 1
         assert res[0].endswith("when-will-it-be-back")
 
     def test_all_mixed(self):
         datalink = DatalinkResults.from_result_url('http://example.com/proc')
-        res = [_debytify(r["access_url"])
+        res = [r["access_url"]
                for r in datalink.bysemantics([
                        "urn:example:rdf/dlext#oracle",
                        'http://www.ivoa.net/rdf/datalink/core#preview',

--- a/pyvo/dal/tests/test_query.py
+++ b/pyvo/dal/tests/test_query.py
@@ -22,7 +22,6 @@ from pyvo.dal.query import DALService, DALQuery, DALResults, Record
 from pyvo.dal.exceptions import DALServiceError, DALQueryError,\
     DALFormatError, DALOverflowWarning
 from pyvo.version import version
-from pyvo.utils.compat import ASTROPY_LT_4_1
 
 from astropy.table import Table
 from astropy.io.votable.tree import VOTableFile, Table as VOTable
@@ -131,12 +130,11 @@ def _test_results(results):
     assert results['1', 1] == 42
     assert results['1', 2] == 1337
 
-    truth = b'Illuminatus' if ASTROPY_LT_4_1 else 'Illuminatus'
+    truth = 'Illuminatus'
     assert results['2', 0] == truth
-    truth = b"Don't panic, and always carry a towel" \
-        if ASTROPY_LT_4_1 else "Don't panic, and always carry a towel"
+    truth = "Don't panic, and always carry a towel"
     assert results['2', 1] == truth
-    truth = b'Elite' if ASTROPY_LT_4_1 else 'Elite'
+    truth = 'Elite'
     assert results['2', 2] == truth
 
 
@@ -148,16 +146,15 @@ def _test_records(records):
 
     assert records[0]['1'] == 23
 
-    truth = b'Illuminatus' if ASTROPY_LT_4_1 else 'Illuminatus'
+    truth = 'Illuminatus'
     assert records[0]['2'] == truth
 
     assert records[1]['1'] == 42
-    truth = b"Don't panic, and always carry a towel" \
-        if ASTROPY_LT_4_1 else "Don't panic, and always carry a towel"
+    truth = "Don't panic, and always carry a towel"
     assert records[1]['2'] == truth
 
     assert records[2]['1'] == 1337
-    truth = b'Elite' if ASTROPY_LT_4_1 else 'Elite'
+    truth = 'Elite'
     assert records[2]['2'] == truth
 
 
@@ -410,7 +407,7 @@ class TestRecord:
             'http://example.com/query/basic')[0]
 
         assert record['1'] == 23
-        truth = b'Illuminatus' if ASTROPY_LT_4_1 else 'Illuminatus'
+        truth = 'Illuminatus'
         assert record['2'] == truth
 
         assert record['_1'] == 23
@@ -441,7 +438,7 @@ class TestRecord:
     def test_repr(self):
         record = DALResults.from_result_url(
             'http://example.com/query/basic')[0]
-        truth = b'Illuminatus' if ASTROPY_LT_4_1 else 'Illuminatus'
+        truth = 'Illuminatus'
         assert repr(record) == repr((23, truth))
 
     def test_get(self):
@@ -457,7 +454,7 @@ class TestRecord:
         assert record.getbyucd('foo') == 23
         assert record.getbyucd('bar') == 23
 
-        truth = b'Illuminatus' if ASTROPY_LT_4_1 else 'Illuminatus'
+        truth = 'Illuminatus'
         assert record.getbyutype('foobar') == truth
 
         record.getbyucd('baz') is None

--- a/pyvo/utils/compat.py
+++ b/pyvo/utils/compat.py
@@ -2,9 +2,5 @@
 """
 Placeholder for compatibility constructs
 """
-from packaging.version import Version
-import astropy
 
-__all__ = ['ASTROPY_LT_4_1']
-
-ASTROPY_LT_4_1 = Version(astropy.__version__) < Version('4.1')
+__all__ = []


### PR DESCRIPTION
Support for astropy <4.1 has been dropped for a while, these lines thus were not in use any more.