### PR TITLE
DOC: Change link targets at the protocol overview into pyVO docs; add brief intro for each service protocol

### DIFF
--- a/docs/dal/index.rst
+++ b/docs/dal/index.rst
@@ -133,7 +133,8 @@ general table data, including astronomical catalogs as well as general
 database tables. Access is provided for both database and table metadata 
 as well as for actual table data. This version of the protocol includes 
 support for multiple query languages, including queries specified using 
-the Astronomical Data Query Language within an integrated interface. 
+the `Astronomical Data Query Language (ADQL) <https://www.ivoa.net/documents/ADQL/>`_ 
+within an integrated interface. 
 It also includes support for both synchronous and asynchronous queries. 
 Special support is provided for spatially indexed queries using the 
 spatial extensions in ADQL. A multi-position query capability permits 
@@ -141,9 +142,6 @@ queries against an arbitrarily large list of astronomical targets,
 providing a simple spatial cross-matching capability. 
 More sophisticated distributed cross-matching capabilities are possible by 
 orchestrating a distributed query across multiple TAP services.
-
-Unlike the other services, this one works with tables queryable by an sql-ish
-language called *ADQL* instead of predefined search constraints.
 
 .. doctest-remote-data::
 
@@ -263,17 +261,12 @@ Simple Image Access
 The `Simple Image Access (SIA) <https://www.ivoa.net/documents/SIA/>`_ protocol 
 provides capabilities for the discovery, description, access, and retrieval 
 of multi-dimensional image datasets, including 2-D images as well as datacubes 
-of three or more dimensions. SIA data discovery is based on the ObsCore Data Model, 
+of three or more dimensions. SIA data discovery is based on the 
+`ObsCore Data Model <https://www.ivoa.net/documents/ObsCore/>`_, 
 which primarily describes data products by the physical axes (spatial, spectral, 
 time, and polarization). Image datasets with dimension greater than 2 are often 
 referred to as datacubes, cube or image cube datasets and may be considered examples 
-of hypercube or n-cube data. In this document the term "image" refers to general 
-multi-dimensional datasets and is synonymous with these other terms unless the 
-image dimensionality is otherwise specified. SIA provides capabilities for 
-image discovery and access. Data discovery and metadata access (using ObsCoreDM) 
-are defined here. The capabilities for drilling down to data files 
-(and related resources) and services for remote access are defined elsewhere, 
-but SIA also allows for direct access to retrieval.
+of hypercube or n-cube data.
 
 Basic queries are done with the ``pos`` and ``size`` parameters described in
 :ref:`pyvo-astro-params`, with ``size`` being the rectangular region around
@@ -321,31 +314,16 @@ Simple Spectrum Access
 ----------------------
 The `Simple Spectral Access (SSA) Protocol (SSAP) <https://www.ivoa.net/documents/SSA/>`_ 
 defines a uniform interface to remotely discover and access one 
-dimensional spectra. SSA is a member of an integrated family of data access 
-altogether comprising the Data Access Layer (DAL) of the IVOA. 
+dimensional spectra.
 SSA is based on a more general data model capable of describing most tabular 
 spectrophotometric data, including time series and spectral energy distributions 
-(SEDs) as well as 1-D spectra; however the scope of the SSA interface as 
-specified in this document is limited to simple 1-D spectra, including 
-simple aggregations of 1-D spectra. The form of the SSA interface is simple: 
+(SEDs) as well as 1-D spectra. The form of the SSA interface is simple: 
 clients first query the global resource registry to find services of interest 
 and then issue a data discovery query to selected services to determine what 
 relevant data is available from each service; the candidate datasets 
 available are described uniformly in a VOTable format document which is 
 returned in response to the query. Finally, the client may retrieve selected 
-datasets for analysis. Spectrum datasets returned by an SSA spectrum service 
-may be either precomputed, archival datasets, or they may be virtual data 
-which is computed on the fly to respond to a client request. 
-Spectrum datasets may conform to a standard data model defined by SSA, 
-or may be native spectra with custom project-defined content. 
-Spectra may be returned in any of a number of standard data formats. 
-Spectral data is generally stored externally to the VO in a format specific 
-to each spectral data collection; currently there is no standard way to 
-represent astronomical spectra, and virtually every project does it 
-differently. Hence spectra may be actively mediated to the standard 
-SSA-defined data model at access time by the service, so that client analysis 
-programs do not have to be familiar with the idiosyncratic details of 
-each data collection to be accessed.
+datasets for analysis. 
 
 Access to (one-dimensional) spectra resembles image access, with some
 subtile differences:

--- a/docs/dal/index.rst
+++ b/docs/dal/index.rst
@@ -127,6 +127,20 @@ interface available.
 
 Table Access Protocol
 ---------------------
+The `Table Access Protocol (TAP) <https://www.ivoa.net/documents/TAP/>`_ 
+defines a service protocol for accessing 
+general table data, including astronomical catalogs as well as general 
+database tables. Access is provided for both database and table metadata 
+as well as for actual table data. This version of the protocol includes 
+support for multiple query languages, including queries specified using 
+the Astronomical Data Query Language within an integrated interface. 
+It also includes support for both synchronous and asynchronous queries. 
+Special support is provided for spatially indexed queries using the 
+spatial extensions in ADQL. A multi-position query capability permits 
+queries against an arbitrarily large list of astronomical targets, 
+providing a simple spatial cross-matching capability. 
+More sophisticated distributed cross-matching capabilities are possible by 
+orchestrating a distributed query across multiple TAP services.
 
 Unlike the other services, this one works with tables queryable by an sql-ish
 language called *ADQL* instead of predefined search constraints.
@@ -246,7 +260,20 @@ Finally, tables and their content can be removed:
 
 Simple Image Access
 -------------------
-Like the name says, this service serves astronomical images.
+The `Simple Image Access (SIA) <https://www.ivoa.net/documents/SIA/>`_ protocol 
+provides capabilities for the discovery, description, access, and retrieval 
+of multi-dimensional image datasets, including 2-D images as well as datacubes 
+of three or more dimensions. SIA data discovery is based on the ObsCore Data Model, 
+which primarily describes data products by the physical axes (spatial, spectral, 
+time, and polarization). Image datasets with dimension greater than 2 are often 
+referred to as datacubes, cube or image cube datasets and may be considered examples 
+of hypercube or n-cube data. In this document the term "image" refers to general 
+multi-dimensional datasets and is synonymous with these other terms unless the 
+image dimensionality is otherwise specified. SIA provides capabilities for 
+image discovery and access. Data discovery and metadata access (using ObsCoreDM) 
+are defined here. The capabilities for drilling down to data files 
+(and related resources) and services for remote access are defined elsewhere, 
+but SIA also allows for direct access to retrieval.
 
 Basic queries are done with the ``pos`` and ``size`` parameters described in
 :ref:`pyvo-astro-params`, with ``size`` being the rectangular region around
@@ -290,6 +317,34 @@ This service exposes the :ref:`verbosity <pyvo-verbosity>` parameter
 
 Simple Spectrum Access
 ----------------------
+The `Simple Spectral Access (SSA) Protocol (SSAP) <https://www.ivoa.net/documents/SSA/>`_ 
+defines a uniform interface to remotely discover and access one 
+dimensional spectra. SSA is a member of an integrated family of data access 
+altogether comprising the Data Access Layer (DAL) of the IVOA. 
+SSA is based on a more general data model capable of describing most tabular 
+spectrophotometric data, including time series and spectral energy distributions 
+(SEDs) as well as 1-D spectra; however the scope of the SSA interface as 
+specified in this document is limited to simple 1-D spectra, including 
+simple aggregations of 1-D spectra. The form of the SSA interface is simple: 
+clients first query the global resource registry to find services of interest 
+and then issue a data discovery query to selected services to determine what 
+relevant data is available from each service; the candidate datasets 
+available are described uniformly in a VOTable format document which is 
+returned in response to the query. Finally, the client may retrieve selected 
+datasets for analysis. Spectrum datasets returned by an SSA spectrum service 
+may be either precomputed, archival datasets, or they may be virtual data 
+which is computed on the fly to respond to a client request. 
+Spectrum datasets may conform to a standard data model defined by SSA, 
+or may be native spectra with custom project-defined content. 
+Spectra may be returned in any of a number of standard data formats. 
+Spectral data is generally stored externally to the VO in a format specific 
+to each spectral data collection; currently there is no standard way to 
+represent astronomical spectra, and virtually every project does it 
+differently. Hence spectra may be actively mediated to the standard 
+SSA-defined data model at access time by the service, so that client analysis 
+programs do not have to be familiar with the idiosyncratic details of 
+each data collection to be accessed.
+
 Access to (one-dimensional) spectra resembles image access, with some
 subtile differences:
 
@@ -313,6 +368,13 @@ SSA queries can be further constrained by the ``band`` and ``time`` parameters.
 
 Simple Cone Search
 ------------------
+The `Simple Cone Search (SCS) <https://www.ivoa.net/documents/latest/ConeSearch.html>`_ 
+API specification defines a simple query protocol for retrieving records from 
+a catalog of astronomical sources. The query describes sky position and 
+an angular distance, defining a cone on the sky. The response returns 
+a list of astronomical sources from the catalog whose positions 
+lie within the cone, formatted as a VOTable.
+
 The Simple Cone Search returns results – typically catalog entries –
 within a circular region on the sky defined by the parameters ``pos``
 (again, ICRS) and ``radius``:
@@ -326,6 +388,22 @@ This service exposes the :ref:`verbosity <pyvo-verbosity>` parameter
 
 Simple Line Access
 ------------------
+The `Simple Line Access Protocol (SLAP) <https://www.ivoa.net/documents/SLAP/>`_ 
+is an IVOA data access protocol which defines a protocol for retrieving 
+spectral lines coming from various Spectral Line Data Collections through 
+a uniform interface within the VO framework. These lines can be either 
+observed or theoretical and will be typically used to identify emission 
+or absorption features in astronomical spectra. It makes use of the Simple 
+Spectral Line Data Model to characterize spectral lines through the use of 
+utypes. The SLAP interface is meant to be reasonably simple to implement by 
+service providers. A basic query will be done in a wavelength range for the 
+different services. The service returns a list of spectral lines formatted 
+as a VOTable. Thus, an implementation of the service may support additional 
+search parameters (some which may be custom to that particular service) to 
+more finely control the selection of spectral lines. The specification also 
+describes how the search on extra parameters has to be done, making use of 
+the support provided by the Simple Spectral Line Data Model
+
 This service let you query for spectral lines in a certain ``wavelength``
 range. The unit of the values is meters, but any unit may be specified using
 `~astropy.units.Quantity`.

--- a/docs/dal/index.rst
+++ b/docs/dal/index.rst
@@ -120,28 +120,31 @@ See :py:mod:`pyvo.dal.exceptions`.
 Services
 ========
 
-There are five types of services with different purposes but a similiar
-interface available.
+There are five types of services with different purposes but a mostly
+similiar interface available.
 
 .. _pyvo_tap:
 
 Table Access Protocol
 ---------------------
-The `Table Access Protocol (TAP) <https://www.ivoa.net/documents/TAP/>`_ 
-defines a service protocol for accessing 
-general table data, including astronomical catalogs as well as general 
-database tables. Access is provided for both database and table metadata 
-as well as for actual table data. This version of the protocol includes 
-support for multiple query languages, including queries specified using 
-the `Astronomical Data Query Language (ADQL) <https://www.ivoa.net/documents/ADQL/>`_ 
-within an integrated interface. 
-It also includes support for both synchronous and asynchronous queries. 
-Special support is provided for spatially indexed queries using the 
-spatial extensions in ADQL. A multi-position query capability permits 
-queries against an arbitrarily large list of astronomical targets, 
-providing a simple spatial cross-matching capability. 
-More sophisticated distributed cross-matching capabilities are possible by 
-orchestrating a distributed query across multiple TAP services.
+
+.. pull-quote::
+
+    This protocol defines a service protocol for accessing 
+    general table data, including astronomical catalogs as well as general 
+    database tables. Access is provided for both database and table metadata 
+    as well as for actual table data. This protocol supports the query language
+    `Astronomical Data Query Language (ADQL) <https://www.ivoa.net/documents/ADQL/>`_ 
+    within an integrated interface. 
+    It also includes support for both synchronous and asynchronous queries. 
+    Special support is provided for spatially indexed queries using the 
+    spatial extensions in ADQL. A multi-position query capability permits 
+    queries against an arbitrarily large list of astronomical targets, 
+    providing a simple spatial cross-matching capability. 
+    More sophisticated distributed cross-matching capabilities are possible by 
+    orchestrating a distributed query across multiple TAP services.
+
+    -- `Table Access Protocol <https://www.ivoa.net/documents/TAP/>`_
 
 .. doctest-remote-data::
 
@@ -258,15 +261,20 @@ Finally, tables and their content can be removed:
 
 Simple Image Access
 -------------------
-The `Simple Image Access (SIA) <https://www.ivoa.net/documents/SIA/>`_ protocol 
-provides capabilities for the discovery, description, access, and retrieval 
-of multi-dimensional image datasets, including 2-D images as well as datacubes 
-of three or more dimensions. SIA data discovery is based on the 
-`ObsCore Data Model <https://www.ivoa.net/documents/ObsCore/>`_, 
-which primarily describes data products by the physical axes (spatial, spectral, 
-time, and polarization). Image datasets with dimension greater than 2 are often 
-referred to as datacubes, cube or image cube datasets and may be considered examples 
-of hypercube or n-cube data.
+
+.. pull-quote::
+
+    The Simple Image Access (SIA) protocol 
+    provides capabilities for the discovery, description, access, and retrieval 
+    of multi-dimensional image datasets, including 2-D images as well as datacubes 
+    of three or more dimensions. SIA data discovery is based on the 
+    `ObsCore Data Model <https://www.ivoa.net/documents/ObsCore/>`_, 
+    which primarily describes data products by the physical axes (spatial, spectral, 
+    time, and polarization). Image datasets with dimension greater than 2 are often 
+    referred to as datacubes, cube or image cube datasets and may be considered examples 
+    of hypercube or n-cube data. PyVO supports both versions of SIA.
+
+    -- `Simple IMage Access <https://www.ivoa.net/documents/SIA/>`_
 
 Basic queries are done with the ``pos`` and ``size`` parameters described in
 :ref:`pyvo-astro-params`, with ``size`` being the rectangular region around
@@ -312,18 +320,14 @@ This service exposes the :ref:`verbosity <pyvo-verbosity>` parameter
 
 Simple Spectrum Access
 ----------------------
-The `Simple Spectral Access (SSA) Protocol (SSAP) <https://www.ivoa.net/documents/SSA/>`_ 
-defines a uniform interface to remotely discover and access one 
-dimensional spectra.
-SSA is based on a more general data model capable of describing most tabular 
-spectrophotometric data, including time series and spectral energy distributions 
-(SEDs) as well as 1-D spectra. The form of the SSA interface is simple: 
-clients first query the global resource registry to find services of interest 
-and then issue a data discovery query to selected services to determine what 
-relevant data is available from each service; the candidate datasets 
-available are described uniformly in a VOTable format document which is 
-returned in response to the query. Finally, the client may retrieve selected 
-datasets for analysis. 
+
+.. pull-quote::
+
+    The Simple Spectral Access (SSA) Protocol (SSAP)
+    defines a uniform interface to remotely discover and access one 
+    dimensional spectra.
+
+    -- `Simple Spectral Access Protocol <https://www.ivoa.net/documents/SSA/>`_ 
 
 Access to (one-dimensional) spectra resembles image access, with some
 subtile differences:
@@ -350,12 +354,17 @@ SSA queries can be further constrained by the ``band`` and ``time`` parameters.
 
 Simple Cone Search
 ------------------
-The `Simple Cone Search (SCS) <https://www.ivoa.net/documents/latest/ConeSearch.html>`_ 
-API specification defines a simple query protocol for retrieving records from 
-a catalog of astronomical sources. The query describes sky position and 
-an angular distance, defining a cone on the sky. The response returns 
-a list of astronomical sources from the catalog whose positions 
-lie within the cone, formatted as a VOTable.
+
+.. pull-quote::
+
+    The Simple Cone Search (SCS) 
+    API specification defines a simple query protocol for retrieving records from 
+    a catalog of astronomical sources. The query describes sky position and 
+    an angular distance, defining a cone on the sky. The response returns 
+    a list of astronomical sources from the catalog whose positions 
+    lie within the cone, formatted as a VOTable.
+
+    -- `Simple Cone Search <https://www.ivoa.net/documents/latest/ConeSearch.html>`_ 
 
 The Simple Cone Search returns results – typically catalog entries –
 within a circular region on the sky defined by the parameters ``pos``
@@ -372,21 +381,15 @@ This service exposes the :ref:`verbosity <pyvo-verbosity>` parameter
 
 Simple Line Access
 ------------------
-The `Simple Line Access Protocol (SLAP) <https://www.ivoa.net/documents/SLAP/>`_ 
-is an IVOA data access protocol which defines a protocol for retrieving 
-spectral lines coming from various Spectral Line Data Collections through 
-a uniform interface within the VO framework. These lines can be either 
-observed or theoretical and will be typically used to identify emission 
-or absorption features in astronomical spectra. It makes use of the Simple 
-Spectral Line Data Model to characterize spectral lines through the use of 
-utypes. The SLAP interface is meant to be reasonably simple to implement by 
-service providers. A basic query will be done in a wavelength range for the 
-different services. The service returns a list of spectral lines formatted 
-as a VOTable. Thus, an implementation of the service may support additional 
-search parameters (some which may be custom to that particular service) to 
-more finely control the selection of spectral lines. The specification also 
-describes how the search on extra parameters has to be done, making use of 
-the support provided by the Simple Spectral Line Data Model
+
+.. pull-quote::
+
+    The Simple Line Access Protocol (SLAP) 
+    is an IVOA data access protocol which defines a protocol for retrieving 
+    spectral lines coming from various Spectral Line Data Collections through 
+    a uniform interface within the VO framework.
+
+    -- `Simple Line Access Protocol <https://www.ivoa.net/documents/SLAP/>`_ 
 
 This service let you query for spectral lines in a certain ``wavelength``
 range. The unit of the values is meters, but any unit may be specified using

--- a/docs/dal/index.rst
+++ b/docs/dal/index.rst
@@ -315,6 +315,8 @@ Available values:
 
 This service exposes the :ref:`verbosity <pyvo-verbosity>` parameter
 
+.. _pyvo-ssa:
+
 Simple Spectrum Access
 ----------------------
 The `Simple Spectral Access (SSA) Protocol (SSAP) <https://www.ivoa.net/documents/SSA/>`_ 
@@ -366,6 +368,8 @@ SSA queries can be further constrained by the ``band`` and ``time`` parameters.
     ... )
 
 
+.. _pyvo-scs:
+
 Simple Cone Search
 ------------------
 The `Simple Cone Search (SCS) <https://www.ivoa.net/documents/latest/ConeSearch.html>`_ 
@@ -385,6 +389,8 @@ within a circular region on the sky defined by the parameters ``pos``
     >>> scs_results = scs_srv.search(pos=pos, radius=size)
 
 This service exposes the :ref:`verbosity <pyvo-verbosity>` parameter
+
+.. _pyvo-slap:
 
 Simple Line Access
 ------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,15 +11,15 @@ PyVO lets you find and retrieve astronomical data available from archives that
 support standard `IVOA <http://www.ivoa.net/>`__ virtual observatory service
 protocols.
 
-* `Table Access Protocol (TAP) <http://www.ivoa.net/documents/TAP/>`_
+* `Table Access Protocol (TAP) <dal/index.html#table-access-protocol>`_
   -- accessing source catalogs using sql-ish queries.
-* `Simple Image Access (SIA) <http://www.ivoa.net/documents/SIA/>`_
+* `Simple Image Access (SIA) <dal/index.html#simple-image-access>`_
   -- finding images in an archive.
-* `Simple Spectral Access (SSA) <http://www.ivoa.net/documents/SSA/>`_
+* `Simple Spectral Access (SSA) <dal/index.html#simple-spectrum-access>`_
   -- finding spectra in an archive.
-* `Simple Cone Search (SCS) <http://www.ivoa.net/documents/latest/ConeSearch.html>`_
+* `Simple Cone Search (SCS) <dal/index.html#simple-cone-search>`_
   -- for positional searching a source catalog or an observation log.
-* `Simple Line Access (SLAP) <http://www.ivoa.net/documents/SLAP/>`_
+* `Simple Line Access (SLAP) <dal/index.html#simple-line-access>`_
   -- finding data about spectral lines, including their rest frequencies.
 
 .. note::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,15 +11,15 @@ PyVO lets you find and retrieve astronomical data available from archives that
 support standard `IVOA <http://www.ivoa.net/>`__ virtual observatory service
 protocols.
 
-* `Table Access Protocol (TAP) <dal/index.html#table-access-protocol>`_
+* :ref:`Table Access Protocol (TAP) <pyvo_tap>`
   -- accessing source catalogs using sql-ish queries.
-* `Simple Image Access (SIA) <dal/index.html#simple-image-access>`_
+* :ref:`Simple Image Access (SIA) <pyvo-sia>`
   -- finding images in an archive.
-* `Simple Spectral Access (SSA) <dal/index.html#simple-spectrum-access>`_
+* :ref:`Simple Spectral Access (SSA) <pyvo-ssa>`
   -- finding spectra in an archive.
-* `Simple Cone Search (SCS) <dal/index.html#simple-cone-search>`_
+* :ref:`Simple Cone Search (SCS) <pyvo-scs>`
   -- for positional searching a source catalog or an observation log.
-* `Simple Line Access (SLAP) <dal/index.html#simple-line-access>`_
+* :ref:`Simple Line Access (SLAP) <pyvo-slap>`
   -- finding data about spectral lines, including their rest frequencies.
 
 .. note::


### PR DESCRIPTION
Background: 
When I clicked on "TAP", for instance, on the opening page of the pyVO docs, I ended up at the IVOA documentation rather than the pyVO docs on how to use TAP, which is in my opinion not so convenient and straightforward.

Suggestion: 
This PR attempts to improve the user experience(for a newcomer like me) by changing the link target of each service protocol to the position in pyVO docs on how to use them; it also adds brief introductions as to what the protocols are, and that's also where the former links into the IVOA doc repo now reside.