### PR TITLE
Remove use of hardlimit in regsearch()

### DIFF
--- a/pyvo/registry/regtap.py
+++ b/pyvo/registry/regtap.py
@@ -145,8 +145,7 @@ def search(*constraints:rtcons.Constraint, includeaux=False, **kwargs):
     service = get_RegTAP_service()
     query = RegistryQuery(
         service.baseurl,
-        get_RegTAP_query(*constraints, includeaux=includeaux, **kwargs),
-        maxrec=service.hardlimit)
+        get_RegTAP_query(*constraints, includeaux=includeaux, **kwargs))
     return query.execute()
 
 


### PR DESCRIPTION
Fixes #373 

Since the `<outputLimit><hard>` element is not required in `capabilites` I removed its use in `regsearch()`.  It would be possible to check for the presence of the hardlimit in the capabilities and use it only if present, but I don't think that's worth the complication.  The registry so far is a fairly small database, so a `RegTAP` service would likely not have an `outputLimit` lower than the largest reasonable registry query results.