### PR TITLE
Maxrec in regsearch

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@
 ================
 
 - registry.regsearch now accepts an optional maxrec argument rather than
-  automatically passing the service's hard limit.
+  automatically passing the service's hard limit. [#375]
 
 
 1.4 (2022-09-26)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,9 @@
 1.5 (unreleased)
 ================
 
+- registry.regsearch now accepts an optional maxrec argument rather than
+  automatically passing the service's hard limit.
+
 
 1.4 (2022-09-26)
 ================

--- a/docs/registry/index.rst
+++ b/docs/registry/index.rst
@@ -187,8 +187,8 @@ attribute, but you can take a shortcut and call a RegistryResource's
   >>> tables = resources["II/283"].get_tables()  # doctest: +IGNORE_WARNINGS
   >>> list(tables.keys())
   ['II/283/sncat']
-  >>> tables['II/283/sncat'].columns
-  [<BaseParam name="n_x"/>, <BaseParam name="t"/>, <BaseParam name="recno"/>, <BaseParam name="n_sn"/>, <BaseParam name="sn"/>, <BaseParam name="u_sn"/>, <BaseParam name="galaxy"/>, <BaseParam name="rag"/>, <BaseParam name="deg"/>, <BaseParam name="mtype"/>, <BaseParam name="i"/>, <BaseParam name="pa"/>, <BaseParam name="hrv"/>, <BaseParam name="z"/>, <BaseParam name="u_z"/>, <BaseParam name="n_bmag"/>, <BaseParam name="bmag"/>, <BaseParam name="logd25"/>, <BaseParam name="x"/>, <BaseParam name="y"/>, <BaseParam name="u_y"/>, <BaseParam name="n_y"/>, <BaseParam name="band"/>, <BaseParam name="maxmag"/>, <BaseParam name="u_maxmag"/>, <BaseParam name="type"/>, <BaseParam name="epmax"/>, <BaseParam name="u_epmax"/>, <BaseParam name="disc"/>, <BaseParam name="simbad"/>, <BaseParam name="ned"/>, <BaseParam name="raj2000"/>, <BaseParam name="dej2000"/>]
+  >>> sorted(c.name for c in tables['II/283/sncat'].columns)
+  ['band', 'bmag', 'deg', 'dej2000', 'disc', 'epmax', 'galaxy', 'hrv', 'i', 'logd25', 'maxmag', 'mtype', 'n_bmag', 'n_sn', 'n_x', 'n_y', 'ned', 'pa', 'rag', 'raj2000', 'recno', 'simbad', 'sn', 't', 'type', 'u_epmax', 'u_maxmag', 'u_sn', 'u_y', 'u_z', 'x', 'y', 'z']
 
 In this case, this is a table with one of VizieR's somewhat funky names.
 To run a TAP query based on this metadata, do something like:

--- a/pyvo/registry/regtap.py
+++ b/pyvo/registry/regtap.py
@@ -134,7 +134,8 @@ def search(*constraints:rtcons.Constraint,
     maxrec : int
         Overrides the RegTAP server's default limit on the number of rows to
         return.  You may need to use this if you want to retrieve more
-        than a few thousand matches.  Note that truncated search results
+        than a few thousand matches.  The server may also have a hard limit
+        that ``maxrec`` cannot override.  Note that truncated search results
         are not reproducible.
 
     **kwargs : strings, mostly

--- a/pyvo/registry/regtap.py
+++ b/pyvo/registry/regtap.py
@@ -100,7 +100,10 @@ def get_RegTAP_query(*constraints:rtcons.Constraint,
     return rtcons.build_regtap_query(constraints)
 
 
-def search(*constraints:rtcons.Constraint, includeaux=False, **kwargs):
+def search(*constraints:rtcons.Constraint,
+        includeaux:bool=False,
+        maxrec:int=None,
+        **kwargs):
     """
     execute a simple query to the RegTAP registry.
 
@@ -128,6 +131,12 @@ def search(*constraints:rtcons.Constraint, includeaux=False, **kwargs):
         This may result in duplicate capabilities being returned,
         especially if the servicetype is not specified.
 
+    maxrec : int
+        Overrides the RegTAP server's default limit on the number of rows to
+        return.  You may need to use this if you want to retrieve more
+        than a few thousand matches.  Note that truncated search results
+        are not reproducible.
+
     **kwargs : strings, mostly
         shorthands for `constraints`; see the documentation of
         a specific constraint for what keyword it uses and what literal
@@ -146,7 +155,7 @@ def search(*constraints:rtcons.Constraint, includeaux=False, **kwargs):
     query = RegistryQuery(
         service.baseurl,
         get_RegTAP_query(*constraints, includeaux=includeaux, **kwargs),
-        maxrec=service.hardlimit)
+        maxrec=maxrec)
     return query.execute()
 
 

--- a/pyvo/registry/tests/test_regtap.py
+++ b/pyvo/registry/tests/test_regtap.py
@@ -15,6 +15,7 @@ from pyvo.registry import regtap
 from pyvo.registry import rtcons
 from pyvo.registry.regtap import REGISTRY_BASEURL
 from pyvo.registry import search as regsearch
+from pyvo.dal import DALOverflowWarning
 from pyvo.dal import query as dalq
 from pyvo.dal import tap
 
@@ -548,6 +549,14 @@ class TestInterfaceRejection:
 
         assert str(excinfo.value) == (
             "No matching interface.")
+
+
+@pytest.mark.remote_data
+def test_maxrec():
+    with pytest.warns(DALOverflowWarning) as w:
+        _ = regsearch(servicetype="tap", maxrec=1)
+    assert len(w) == 1
+    assert str(w[0].message).startswith("Partial result set.")
 
 
 @pytest.mark.remote_data


### PR DESCRIPTION
registry.regsearch now accepts an optional maxrec argument
    
This addresses bug #373.  It *may* change results if people actually retrieved humungous amounts (by registry standards) of records (more than 20000 with the default server).  I'd say: Whoever does this kind of thing deserves a heads-up that they should be doing it differently.  Alternatively, they can pass in maxrec=10000000 manually.