### PR TITLE
ENH: Make regtap service aware

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,6 +45,10 @@
 - Adding support for the VODataService 1.2 nrows attribute on table
   elements [#503]
 
+- registry.search now introspects the TAP service's capabilities and
+  only offers extended functionality or optimisations if the required
+  features are present [#386]
+
 
 1.4.3 (unreleased)
 ==================

--- a/docs/registry/index.rst
+++ b/docs/registry/index.rst
@@ -155,9 +155,9 @@ And to look for tap resources *in* a specific cone, you would do
   ...                 registry.Spatial((SkyCoord("23d +3d"), 3), intersect="enclosed"),
   ...                 includeaux=True) # doctest: +IGNORE_OUTPUT
   <DALResultsTable length=1>
-              ivoid                   res_type       short_name                   res_title                  ...  intf_types  intf_roles          alt_identifier         
-                                                                                                             ...                                                         
-              object                   object          object                       object                   ...    object      object                object             
+              ivoid                   res_type       short_name                   res_title                  ...  intf_types  intf_roles          alt_identifier
+                                                                                                             ...
+              object                   object          object                       object                   ...    object      object                object
   ------------------------------ ----------------- ------------- ------------------------------------------- ... ------------ ---------- --------------------------------
   ivo://cds.vizier/j/apj/835/123 vs:catalogservice J/ApJ/835/123 Globular clusters in NGC 474 from CFHT obs. ... vs:paramhttp        std doi:10.26093/cds/vizier.18350123
 
@@ -546,7 +546,7 @@ RegTAP services using:
   ...   for r in res)))
   http://dc.zah.uni-heidelberg.de/tap
   http://gavo.aip.de/tap
-  http://voparis-rr.obspm.fr:80/tap
+  http://voparis-rr.obspm.fr/tap
   https://vao.stsci.edu/RegTAP/TapService.aspx
 
 

--- a/docs/registry/index.rst
+++ b/docs/registry/index.rst
@@ -546,8 +546,8 @@ RegTAP services using:
   ...   for r in res)))
   http://dc.zah.uni-heidelberg.de/tap
   http://gavo.aip.de/tap
-  http://vao.stsci.edu/RegTAP/TapService.aspx
   http://voparis-rr.obspm.fr:80/tap
+  https://vao.stsci.edu/RegTAP/TapService.aspx
 
 
 

--- a/docs/registry/index.rst
+++ b/docs/registry/index.rst
@@ -130,7 +130,7 @@ you would say:
   ...                             registry.Freetext("supernova"))
 
 After that, ``resources`` is an instance of
-:py:class:`pyvo.registry.RegistryResults`, which you can iterate over.  In
+:py:class:`pyvo.registry.regtap.RegistryResults`, which you can iterate over.  In
 interactive data discovery, however, it is usually preferable to use the
 ``to_table`` method for an overview of the resources available:
 
@@ -183,7 +183,7 @@ are not), but it is rather clunky, and in the real VO short name
 collisions should be very rare.
 
 Use the ``get_service`` method of
-:py:class:`pyvo.registry.RegistryResource` to obtain a DAL service
+:py:class:`pyvo.registry.regtap.RegistryResource` to obtain a DAL service
 object for a particular sort of interface.
 To query the fourth match using simple cone search, you would
 thus say:
@@ -511,6 +511,44 @@ and then you can run:
 
   >>> res.get_tables()  # doctest: +IGNORE_OUTPUT
   {'flashheros.data': <VODataServiceTable name="flashheros.data">... 29 columns ...</VODataServiceTable>, 'ivoa.obscore': <VODataServiceTable name="ivoa.obscore">... 0 columns ...</VODataServiceTable>}
+
+
+Alternative Registries
+======================
+
+There are several RegTAP services in the VO.  PyVO by default uses the
+one at the TAP access URL http://reg.g-vo.org/tap.  You can use
+alternative ones, for instance, because they are nearer to you or
+because the default endpoint is down.
+
+You can pre-select the URI by setting the ``IVOA_REGISTRY`` environment
+variable to the TAP access URL of the service you would like to use.  In
+a bash-like shell, you would say::
+
+  export IVOA_REGISTRY="http://vao.stsci.edu/RegTAP/TapService.aspx"
+
+before starting python (or the notebook processor).
+
+Within a Python session, you can use the
+`pyvo.registry.choose_RegTAP_service` function, which also takes the
+TAP access URL.
+
+As long as you have on working registry endpoint, you can find the other
+RegTAP services using:
+
+.. We probably shouldn't test the result of the next code block; this
+   will change every time someone registers a new RegTAP service...
+
+.. doctest-remote-data::
+
+  >>> res = registry.search(datamodel="regtap")
+  >>> print("\n".join(sorted(r.get_interface("tap").access_url
+  ...   for r in res)))
+  http://dc.zah.uni-heidelberg.de/tap
+  http://gavo.aip.de/tap
+  http://vao.stsci.edu/RegTAP/TapService.aspx
+  http://voparis-rr.obspm.fr:80/tap
+
 
 
 Reference/API

--- a/docs/registry/index.rst
+++ b/docs/registry/index.rst
@@ -521,7 +521,7 @@ one at the TAP access URL http://reg.g-vo.org/tap.  You can use
 alternative ones, for instance, because they are nearer to you or
 because the default endpoint is down.
 
-You can pre-select the URI by setting the ``IVOA_REGISTRY`` environment
+You can pre-select the URL by setting the ``IVOA_REGISTRY`` environment
 variable to the TAP access URL of the service you would like to use.  In
 a bash-like shell, you would say::
 

--- a/pyvo/dal/tap.py
+++ b/pyvo/dal/tap.py
@@ -127,13 +127,13 @@ class TAPService(DALService, AvailabilityMixin, CapabilityMixin):
         if hasattr(self._session, 'update_from_capabilities'):
             self._session.update_from_capabilities(self.capabilities)
 
-    def get_tap_cap(self):
+    def get_tap_capability(self):
         """
         returns the (first) TAP capability of this service.
 
         Returns
         -------
-        A `pyvo.io.vosi.TableAccess` instance.
+        A `~pyvo.io.vosi.tapregext.TableAccess` instance.
         """
         for capa in self.capabilities:
             if isinstance(capa, tr.TableAccess):
@@ -217,7 +217,7 @@ class TAPService(DALService, AvailabilityMixin, CapabilityMixin):
             if the property is not exposed by the service
         """
         try:
-            return self.get_tap_cap().outputlimit.default.content
+            return self.get_tap_capability().outputlimit.default.content
         except AttributeError:
             pass
         raise DALServiceError("Default limit not exposed by the service")
@@ -233,7 +233,7 @@ class TAPService(DALService, AvailabilityMixin, CapabilityMixin):
             if the property is not exposed by the service
         """
         try:
-            return self.get_tap_cap().outputlimit.hard.content
+            return self.get_tap_capability().outputlimit.hard.content
         except AttributeError:
             pass
         raise DALServiceError("Hard limit not exposed by the service")
@@ -244,7 +244,7 @@ class TAPService(DALService, AvailabilityMixin, CapabilityMixin):
         a list of upload methods in form of
         :py:class:`~pyvo.io.vosi.tapregext.UploadMethod` objects
         """
-        return self.get_tap_cap().uploadmethods
+        return self.get_tap_capability().uploadmethods
 
     def run_sync(
             self, query, language="ADQL", maxrec=None, uploads=None,

--- a/pyvo/dal/tap.py
+++ b/pyvo/dal/tap.py
@@ -127,6 +127,20 @@ class TAPService(DALService, AvailabilityMixin, CapabilityMixin):
         if hasattr(self._session, 'update_from_capabilities'):
             self._session.update_from_capabilities(self.capabilities)
 
+    def get_tap_cap(self):
+        """
+        returns the (first) TAP capability of this service.
+
+        Returns
+        -------
+        A `pyvo.io.vosi.TableAccess` instance.
+        """
+        for capa in self.capabilities:
+            if isinstance(capa, tr.TableAccess):
+                return capa
+        raise DALServiceError("Invalid TAP service: Does not"
+            " expose a tr:TableAccess capability")
+
     @property
     def tables(self):
         """
@@ -203,9 +217,7 @@ class TAPService(DALService, AvailabilityMixin, CapabilityMixin):
             if the property is not exposed by the service
         """
         try:
-            for capa in self.capabilities:
-                if isinstance(capa, tr.TableAccess):
-                    return capa.outputlimit.default.content
+            return self.get_tap_cap().outputlimit.default.content
         except AttributeError:
             pass
         raise DALServiceError("Default limit not exposed by the service")
@@ -221,9 +233,7 @@ class TAPService(DALService, AvailabilityMixin, CapabilityMixin):
             if the property is not exposed by the service
         """
         try:
-            for capa in self.capabilities:
-                if isinstance(capa, tr.TableAccess):
-                    return capa.outputlimit.hard.content
+            return self.get_tap_cap().outputlimit.hard.content
         except AttributeError:
             pass
         raise DALServiceError("Hard limit not exposed by the service")
@@ -234,11 +244,7 @@ class TAPService(DALService, AvailabilityMixin, CapabilityMixin):
         a list of upload methods in form of
         :py:class:`~pyvo.io.vosi.tapregext.UploadMethod` objects
         """
-        upload_methods = []
-        for capa in self.capabilities:
-            if isinstance(capa, tr.TableAccess):
-                upload_methods += capa.uploadmethods
-        return upload_methods
+        return self.get_tap_cap().uploadmethods
 
     def run_sync(
             self, query, language="ADQL", maxrec=None, uploads=None,

--- a/pyvo/dal/tests/test_tap.py
+++ b/pyvo/dal/tests/test_tap.py
@@ -14,10 +14,11 @@ import pytest
 import requests_mock
 
 from pyvo.dal.tap import escape, search, AsyncTAPJob, TAPService
-from pyvo.dal import DALQueryError
+from pyvo.dal import DALQueryError, DALServiceError
 
 from pyvo.io.uws import JobFile
 from pyvo.io.uws.tree import Parameter, Result, ErrorSummary, Message
+from pyvo.io.vosi.exceptions import VOSIError
 from pyvo.utils import prototype
 
 from astropy.time import Time, TimeDelta
@@ -411,6 +412,17 @@ def capabilities(mocker):
         yield matcher
 
 
+@pytest.fixture()
+def tapservice(capabilities):
+    """
+    preferably use this fixture when you need a generic TAP service;
+    it saves a bit of parsing overhead.
+
+    (but of course make sure you don't modify it).
+    """
+    return TAPService('http://example.com/tap')
+
+
 def test_escape():
     query = 'SELECT * FROM ivoa.obscore WHERE dataproduct_type = {}'
     query = query.format(escape("'image'"))
@@ -717,3 +729,61 @@ class TestTAPService:
                                              unique=True)
         finally:
             prototype.deactivate_features('cadc-tb-upload')
+
+
+@pytest.mark.usefixtures("tapservice")
+class TestTAPCapabilities:
+    def test_no_tap_cap(self):
+        svc = TAPService('http://example.com/tap')
+        svc.capabilities = []
+        with pytest.raises(DALServiceError) as excinfo:
+            svc.get_tap_cap()
+        assert str(excinfo.value) == ("Invalid TAP service:"
+            " Does not expose a tr:TableAccess capability")
+
+    def test_no_adql(self):
+        svc = TAPService('http://example.com/tap')
+        svc.get_tap_cap()._languages = []
+        with pytest.raises(VOSIError) as excinfo:
+            svc.get_tap_cap().get_adql()
+        assert str(excinfo.value) == ("Invalid TAP service:"
+            " Does not declare an ADQL language")
+
+    def test_get_adql(self, tapservice):
+        assert tapservice.get_tap_cap().get_adql().name == "ADQL"
+
+    def test_missing_featurelist(self, tapservice):
+        assert (
+            tapservice.get_tap_cap().get_adql().get_feature_list("fump")
+            == [])
+
+    def test_get_featurelist(self, tapservice):
+        features = tapservice.get_tap_cap().get_adql().get_feature_list(
+                "ivo://ivoa.net/std/TAPRegExt#features-adqlgeo")
+        assert set(f.form for f in features) == {
+                'CENTROID', 'CONTAINS', 'COORD1', 'POLYGON',
+                'INTERSECTS', 'COORD2', 'BOX', 'AREA', 'DISTANCE',
+                'REGION', 'CIRCLE', 'POINT'}
+
+    def test_get_missing_feature(self, tapservice):
+        assert tapservice.get_tap_cap().get_adql().get_feature(
+                "ivo://ivoa.net/std/TAPRegExt#features-adqlgeo",
+                "Garage") == None
+
+    def test_get_feature(self, tapservice):
+        feature = tapservice.get_tap_cap().get_adql().get_feature(
+                "ivo://ivoa.net/std/TAPRegExt#features-adqlgeo",
+                "AREA")
+        assert feature.form == "AREA"
+        assert feature.description == None
+
+    def test_missing_udf(self, tapservice):
+        assert (tapservice.get_tap_cap().get_adql(
+            ).get_udf("duff function")
+            == None)
+
+    def test_get_udf(self, tapservice):
+        func = tapservice.get_tap_cap().get_adql(
+            ).get_udf("IVO_hasword") # case insensitive!
+        assert (func.form
+            == "ivo_hasword(haystack TEXT, needle TEXT) -> INTEGER")

--- a/pyvo/dal/tests/test_tap.py
+++ b/pyvo/dal/tests/test_tap.py
@@ -759,21 +759,21 @@ class TestTAPCapabilities:
 
     def test_get_featurelist(self, tapservice):
         features = tapservice.get_tap_cap().get_adql().get_feature_list(
-                "ivo://ivoa.net/std/TAPRegExt#features-adqlgeo")
+            "ivo://ivoa.net/std/TAPRegExt#features-adqlgeo")
         assert set(f.form for f in features) == {
-                'CENTROID', 'CONTAINS', 'COORD1', 'POLYGON',
-                'INTERSECTS', 'COORD2', 'BOX', 'AREA', 'DISTANCE',
-                'REGION', 'CIRCLE', 'POINT'}
+            'CENTROID', 'CONTAINS', 'COORD1', 'POLYGON',
+            'INTERSECTS', 'COORD2', 'BOX', 'AREA', 'DISTANCE',
+            'REGION', 'CIRCLE', 'POINT'}
 
     def test_get_missing_feature(self, tapservice):
         assert tapservice.get_tap_cap().get_adql().get_feature(
-                "ivo://ivoa.net/std/TAPRegExt#features-adqlgeo",
-                "Garage") == None
+            "ivo://ivoa.net/std/TAPRegExt#features-adqlgeo",
+            "Garage") == None
 
     def test_get_feature(self, tapservice):
         feature = tapservice.get_tap_cap().get_adql().get_feature(
-                "ivo://ivoa.net/std/TAPRegExt#features-adqlgeo",
-                "AREA")
+            "ivo://ivoa.net/std/TAPRegExt#features-adqlgeo",
+            "AREA")
         assert feature.form == "AREA"
         assert feature.description == None
 

--- a/pyvo/dal/tests/test_tap.py
+++ b/pyvo/dal/tests/test_tap.py
@@ -737,28 +737,28 @@ class TestTAPCapabilities:
         svc = TAPService('http://example.com/tap')
         svc.capabilities = []
         with pytest.raises(DALServiceError) as excinfo:
-            svc.get_tap_cap()
+            svc.get_tap_capability()
         assert str(excinfo.value) == ("Invalid TAP service:"
             " Does not expose a tr:TableAccess capability")
 
     def test_no_adql(self):
         svc = TAPService('http://example.com/tap')
-        svc.get_tap_cap()._languages = []
+        svc.get_tap_capability()._languages = []
         with pytest.raises(VOSIError) as excinfo:
-            svc.get_tap_cap().get_adql()
+            svc.get_tap_capability().get_adql()
         assert str(excinfo.value) == ("Invalid TAP service:"
             " Does not declare an ADQL language")
 
     def test_get_adql(self, tapservice):
-        assert tapservice.get_tap_cap().get_adql().name == "ADQL"
+        assert tapservice.get_tap_capability().get_adql().name == "ADQL"
 
     def test_missing_featurelist(self, tapservice):
         assert (
-            tapservice.get_tap_cap().get_adql().get_feature_list("fump")
+            tapservice.get_tap_capability().get_adql().get_feature_list("fump")
             == [])
 
     def test_get_featurelist(self, tapservice):
-        features = tapservice.get_tap_cap().get_adql().get_feature_list(
+        features = tapservice.get_tap_capability().get_adql().get_feature_list(
             "ivo://ivoa.net/std/TAPRegExt#features-adqlgeo")
         assert set(f.form for f in features) == {
             'CENTROID', 'CONTAINS', 'COORD1', 'POLYGON',
@@ -766,20 +766,20 @@ class TestTAPCapabilities:
             'REGION', 'CIRCLE', 'POINT'}
 
     def test_get_missing_feature(self, tapservice):
-        assert tapservice.get_tap_cap().get_adql().get_feature(
+        assert tapservice.get_tap_capability().get_adql().get_feature(
             "ivo://ivoa.net/std/TAPRegExt#features-adqlgeo",
             "Garage") is None
 
     def test_get_feature(self, tapservice):
-        feature = tapservice.get_tap_cap().get_adql().get_feature(
+        feature = tapservice.get_tap_capability().get_adql().get_feature(
             "ivo://ivoa.net/std/TAPRegExt#features-adqlgeo",
             "AREA")
         assert feature.form == "AREA"
         assert feature.description is None
 
     def test_missing_udf(self, tapservice):
-        assert tapservice.get_tap_cap().get_adql().get_udf("duff function") is None
+        assert tapservice.get_tap_capability().get_adql().get_udf("duff function") is None
 
     def test_get_udf(self, tapservice):
-        func = tapservice.get_tap_cap().get_adql().get_udf("IVO_hasword")  # case insensitive!
+        func = tapservice.get_tap_capability().get_adql().get_udf("IVO_hasword")  # case insensitive!
         assert func.form == "ivo_hasword(haystack TEXT, needle TEXT) -> INTEGER"

--- a/pyvo/dal/tests/test_tap.py
+++ b/pyvo/dal/tests/test_tap.py
@@ -460,6 +460,9 @@ class TestTAPService:
 
         assert list(vositables.keys()) == ['test.table1', 'test.table2']
 
+        assert "test.table1" in vositables
+        assert "any.random.stuff" not in vositables
+
         table1, table2 = list(vositables)
         self._test_tables(table1, table2)
 

--- a/pyvo/dal/tests/test_tap.py
+++ b/pyvo/dal/tests/test_tap.py
@@ -768,22 +768,18 @@ class TestTAPCapabilities:
     def test_get_missing_feature(self, tapservice):
         assert tapservice.get_tap_cap().get_adql().get_feature(
             "ivo://ivoa.net/std/TAPRegExt#features-adqlgeo",
-            "Garage") == None
+            "Garage") is None
 
     def test_get_feature(self, tapservice):
         feature = tapservice.get_tap_cap().get_adql().get_feature(
             "ivo://ivoa.net/std/TAPRegExt#features-adqlgeo",
             "AREA")
         assert feature.form == "AREA"
-        assert feature.description == None
+        assert feature.description is None
 
     def test_missing_udf(self, tapservice):
-        assert (tapservice.get_tap_cap().get_adql(
-            ).get_udf("duff function")
-            == None)
+        assert tapservice.get_tap_cap().get_adql().get_udf("duff function") is None
 
     def test_get_udf(self, tapservice):
-        func = tapservice.get_tap_cap().get_adql(
-            ).get_udf("IVO_hasword") # case insensitive!
-        assert (func.form
-            == "ivo_hasword(haystack TEXT, needle TEXT) -> INTEGER")
+        func = tapservice.get_tap_cap().get_adql().get_udf("IVO_hasword")  # case insensitive!
+        assert func.form == "ivo_hasword(haystack TEXT, needle TEXT) -> INTEGER"

--- a/pyvo/dal/vosi.py
+++ b/pyvo/dal/vosi.py
@@ -161,6 +161,9 @@ class VOSITables:
         for tablename in self.keys():
             yield self._get_table(tablename)
 
+    def __contains__(self, tablename):
+        return tablename in self.keys()
+
     def _get_table(self, name):
         if name in self._cache:
             return self._cache[name]

--- a/pyvo/io/vosi/exceptions.py
+++ b/pyvo/io/vosi/exceptions.py
@@ -463,3 +463,10 @@ class E10(VOSIWarning, XMLWarning, ValueError):
     Raised when then file doesn't appear to be valid capabilities xml
     """
     message_template = "File does not appear to be a VOSICapabilities file"
+
+
+class VOSIError(Exception):
+    """
+    Raised for non-XML VOSI errors
+    """
+    pass

--- a/pyvo/io/vosi/tapregext.py
+++ b/pyvo/io/vosi/tapregext.py
@@ -265,7 +265,7 @@ class Language(Element):
         """
         ivoid = ivoid.lower()
         for features in self.languagefeaturelists:
-            if features.type.lower()==ivoid:
+            if features.type.lower() == ivoid:
                 return features
         return []
 
@@ -295,7 +295,7 @@ class Language(Element):
         A `LanguageFeature` or None.
         """
         for feature in self.get_feature_list(ivoid):
-            if feature.form==form:
+            if feature.form == form:
                 return feature
 
         return None

--- a/pyvo/io/vosi/tapregext.py
+++ b/pyvo/io/vosi/tapregext.py
@@ -254,7 +254,10 @@ class Language(Element):
         """
         returns a list of features groupd with the features id ivoid.
 
-        ivoid (regrettably) has to be compared case-insensitively.
+        Parameters
+        ----------
+        ivoid : the ivoid of a TAPRegExt feature list.  It is compared
+            case-insensitively against the service's ivoids.
 
         Returns
         -------

--- a/pyvo/io/vosi/tapregext.py
+++ b/pyvo/io/vosi/tapregext.py
@@ -261,7 +261,7 @@ class Language(Element):
 
         Returns
         -------
-        A (possibly empty) list of `LanguageFeature` elements
+        A (possibly empty) list of `~pyvo.io.vosi.tapregext.LanguageFeature` elements
         """
         ivoid = ivoid.lower()
         for features in self.languagefeaturelists:
@@ -271,7 +271,7 @@ class Language(Element):
 
     def get_feature(self, ivoid, form):
         """
-        returns the `LanguageFeature` with ivoid and form if present.
+        returns the `~pyvo.io.vosi.tapregext.LanguageFeature` with ivoid and form if present.
 
         We return None rather than raising an error because we expect
         the normal pattern of usage here will be "if feature is present",
@@ -292,7 +292,7 @@ class Language(Element):
 
         Returns
         -------
-        A `LanguageFeature` or None.
+        A `~pyvo.io.vosi.tapregext.LanguageFeature` or None.
         """
         for feature in self.get_feature_list(ivoid):
             if feature.form == form:
@@ -302,7 +302,7 @@ class Language(Element):
 
     def get_udf(self, function_name):
         """
-        returns a `LanguageFeature` corresponding to an ADQL user defined
+        returns a `~pyvo.io.vosi.tapregext.LanguageFeature` corresponding to an ADQL user defined
         function on the server, on None if the UDF is not available.
 
         This is a bit heuristic in that it tries to parse the form, which
@@ -315,7 +315,7 @@ class Language(Element):
             names case-insensitively, as guided by ADQL's case insensitivity.
 
         Returns:
-            A `LanguageFeature` instance or None.
+            A `~pyvo.io.vosi.tapregext.LanguageFeature` instance or None.
         """
         function_name = function_name.lower()
         for udf in self.get_feature_list(

--- a/pyvo/registry/__init__.py
+++ b/pyvo/registry/__init__.py
@@ -4,7 +4,9 @@ a package for interacting with registries.
 
 The regtap module supports access to the IVOA Registries
 """
-from .regtap import search, ivoid2service, get_RegTAP_query
+
+from .regtap import (search, ivoid2service, get_RegTAP_query,
+    choose_RegTAP_service)
 
 from .rtcons import (Constraint,
     Freetext, Author, Servicetype, Waveband, Datamodel, Ivoid,
@@ -12,4 +14,5 @@ from .rtcons import (Constraint,
 
 __all__ = ["search", "get_RegTAP_query", "Freetext", "Author",
     "Servicetype", "Waveband", "Datamodel", "Ivoid", "UCD",
-    "Spatial", "Spectral", "Temporal"]
+    "Spatial", "Spectral", "Temporal",
+    "choose_RegTAP_service"]

--- a/pyvo/registry/regtap.py
+++ b/pyvo/registry/regtap.py
@@ -105,7 +105,7 @@ def get_RegTAP_service():
     tables, etc.
 
     To switch to a different RegTAP service, use
-    :py:func:`change_RegTAP_service`.
+    :py:func:`choose_RegTAP_service`.
     """
     return tap.TAPService(REGISTRY_BASEURL)
 
@@ -749,7 +749,7 @@ class RegistryResource(dalq.Record):
         Returns
         -------
 
-        ~`pyvo.registry.regtap.Interface`
+        `~pyvo.registry.regtap.Interface`
         """
         if service_type == "web":
             # this works very much differently in the Registry

--- a/pyvo/registry/regtap.py
+++ b/pyvo/registry/regtap.py
@@ -100,21 +100,54 @@ def get_RegTAP_service():
     """
     a lazily created TAP service offering the RegTAP services.
 
-    This uses regtap.REGISTRY_BASEURL.  Always get the TAP service
-    there using this function to avoid re-creating the server
-    and profit from caching of capabilties, tables, etc.
+    Always get the TAP service there using this function to avoid
+    re-creating the server and profit from caching of capabilties,
+    tables, etc.
+
+    To switch to a different RegTAP service, use
+    :py:func:`change_RegTAP_service`.
     """
     return tap.TAPService(REGISTRY_BASEURL)
 
 
+def choose_RegTAP_service(access_url):
+    """
+    changes the RegTAP service used by :py:func:`search`
+    to the one at access_url.
+
+    By default, pyVO uses whatever is given in the environment variable
+    ``IVOA_REGISTRY``, defaulting to GAVO's TAP service.  In order to
+    change the service used on the fly, always use this function in order
+    to clear caches that need clearing.
+
+    Parameters
+    ----------
+    access_url : str
+        The TAP access URL of the new RegTAP endpoints.
+        To find alternate endpoints, try ``regsearch(datamodel='regtap')``
+        and look at ``.get_interface("tap").access_url`` of the results.
+    """
+    global REGISTRY_BASEURL
+    get_RegTAP_service.cache_clear()
+    REGISTRY_BASEURL = access_url
+
+
 def get_RegTAP_query(*constraints: rtcons.Constraint,
-                     includeaux=False, **kwargs):
+                     includeaux=False,
+                     service=None,
+                     **kwargs):
     """returns SQL for a RegTAP query for constraints and keywords.
 
     This function's parameters are as for search; this is basically
     a wrapper for rtcons.build_regtap_query maintaining the legacy
     keyword-based interface.
     """
+    # we don't document the service parameter -- it's probably not useful
+    # to users and is just the conscequence of having retrofitted service
+    # sensing into the API.
+    if service is None:
+        service = get_RegTAP_service()
+
     constraints = list(constraints) + rtcons.keywords_to_constraints(kwargs)
 
     # maintain legacy includeaux by locating any Servicetype constraints
@@ -124,10 +157,13 @@ def get_RegTAP_query(*constraints: rtcons.Constraint,
             if isinstance(constraint, rtcons.Servicetype):
                 constraints[index] = constraint.include_auxiliary_services()
 
-    return rtcons.build_regtap_query(constraints)
+    return rtcons.build_regtap_query(constraints, service)
 
 
-def search(*constraints: rtcons.Constraint, includeaux: bool = False, maxrec: int = None, **kwargs):
+def search(*constraints: rtcons.Constraint,
+        includeaux: bool = False,
+        maxrec: int = None,
+        **kwargs):
 
     """
     execute a simple query to the RegTAP registry.
@@ -208,7 +244,10 @@ def search(*constraints: rtcons.Constraint, includeaux: bool = False, maxrec: in
     service = get_RegTAP_service()
     query = RegistryQuery(
         service.baseurl,
-        get_RegTAP_query(*constraints, includeaux=includeaux, **kwargs),
+        get_RegTAP_query(*constraints,
+            includeaux=includeaux,
+            service=service,
+            **kwargs),
         maxrec=maxrec)
     return query.execute()
 
@@ -676,18 +715,41 @@ class RegistryResource(dalq.Record):
                       std_only: bool = False):
         """returns a regtap.Interface class for service_type.
 
-        Parameters
-        ----------
-
         The meaning of the parameters is as for get_service.  This
         method does not return services, though, so you can use it to
         obtain access URLs and such for interfaces that pyVO does
-        not (directly) support. In addition,
+        not (directly) support.
+
+        Parameters
+        ----------
+
+        service_type : str
+            If you leave out ``service_type``, this will return a service
+            for "the" standard interface of the resource.  If a resource
+            has multiple standard capabilities (e.g., both TAP and SSAP
+            endpoints), this will raise a DALQueryError.
+
+            Otherwise, a service of the given service type will be returned.
+            Pass in an ivoid of a standard or one of the shorthands from
+            rtcons.SERVICE_TYPE_MAP, or "web" for a web page (the "service"
+            for this will be an object opening a web browser when you call
+            its query method).
+
+        lax : bool
+            If there are multiple capabilities for service_type, the
+            function choose the first matching capability by default
+            Pass lax=False to instead raise a DALQueryError.
 
         std_only : bool
             Only return interfaces declared as "std".  This is what you
             want when you want to construct pyVO service objects later.
             This parameter is ignored for the "web" service type.
+
+
+        Returns
+        -------
+
+        `~pyvo.registry.regtap.Interface`
         """
         if service_type == "web":
             # this works very much differently in the Registry

--- a/pyvo/registry/regtap.py
+++ b/pyvo/registry/regtap.py
@@ -749,7 +749,7 @@ class RegistryResource(dalq.Record):
         Returns
         -------
 
-        `~pyvo.registry.regtap.Interface`
+        ~`pyvo.registry.regtap.Interface`
         """
         if service_type == "web":
             # this works very much differently in the Registry

--- a/pyvo/registry/rtcons.py
+++ b/pyvo/registry/rtcons.py
@@ -178,6 +178,13 @@ class Constraint:
         as an argument because constraints may be written differently
         depending on the service's features or refuse to run altogether.
 
+        Parameters
+        ----------
+        service : `dal.tap.TAPService`
+            The RegTAP service the query is supposed to be run on
+            (that is relevant because we adapt to the features available
+            on given services).
+
         Returns
         -------
         str
@@ -211,7 +218,7 @@ class Freetext(Constraint):
 
         Parameters
         ----------
-        *words: tuple of str
+        *words : tuple of str
             It is recommended to pass multiple words in multiple strings
             arguments.  You can pass in phrases (i.e., multiple words
             separated by space), but behaviour might then vary quite
@@ -291,7 +298,7 @@ class Author(Constraint):
 
         Parameters
         ----------
-        name: str
+        name : str
             Note that regrettably there are no guarantees as to how authors
             are written in the VO.  This means that you will generally have
             to write things like ``%Hubble%`` (% being “zero or more
@@ -345,7 +352,7 @@ class Servicetype(Constraint):
 
         Parameters
         ----------
-        *stds: tuple of str
+        *stds : tuple of str
             one or more standards identifiers.  The constraint will
             match records that have any of them.
         """
@@ -420,7 +427,7 @@ class Waveband(Constraint):
 
         Parameters
         ----------
-        *bands: tuple of strings
+        *bands : tuple of strings
             One or more of the terms given in http://www.ivoa.net/rdf/messenger.
             The constraint matches when a resource declares at least
             one of the messengers listed.
@@ -875,12 +882,12 @@ def build_regtap_query(constraints, service):
 
     Parameters
     ----------
-    constraints: sequence of `Constraint`-s
+    constraints : sequence of `Constraint`-s
         A sequence of constraints for a RegTAP query.  All of them
         will become part of a conjunction (i.e., all of them have
         to be satisfied for a record to match).
 
-    service: `dal.tap.TAPService`
+    service : `dal.tap.TAPService`
         The RegTAP service the query is supposed to be run on
         (that is relevant because we adapt to the features available
         on given services).

--- a/pyvo/registry/rtcons.py
+++ b/pyvo/registry/rtcons.py
@@ -777,6 +777,13 @@ class Spectral(Constraint):
 
         raise ValueError(f"Cannot make a spectral quantity out of {quant}")
 
+    def get_search_condition(self, service):
+        if not "rr.stc_spectral" in service.tables:
+                raise RegTAPFeatureMissing("stc_spectral missing on"
+                    " current RegTAP service")
+
+        return super().get_search_condition(service)
+
 
 class Temporal(Constraint):
     """
@@ -848,6 +855,13 @@ class Temporal(Constraint):
             raise ValueError("RegTAP time constraints must be made from"
                              " single time instants.")
         return val
+
+    def get_search_condition(self, service):
+        if not "rr.stc_temporal" in service.tables:
+                raise RegTAPFeatureMissing("stc_temporal missing on"
+                    " current RegTAP service")
+
+        return super().get_search_condition(service)
 
 
 # NOTE: If you add new Contraint-s, don't forget to add them in

--- a/pyvo/registry/rtcons.py
+++ b/pyvo/registry/rtcons.py
@@ -236,6 +236,7 @@ class Freetext(Constraint):
                 "ivo://ivoa.net/std/TAPRegExt#features-adql-sets", "UNION"):
             return self._get_union_condition(service)
         else:
+            self._extra_tables = ["rr.res_subject"]
             return self._get_or_condition(service)
 
     def _get_union_condition(self, service):

--- a/pyvo/registry/rtcons.py
+++ b/pyvo/registry/rtcons.py
@@ -245,7 +245,7 @@ class Freetext(Constraint):
             "SELECT ivoid FROM rr.resource WHERE"
             " 1=ivo_hasword(res_title, {{{parname}}})",
             "SELECT ivoid FROM rr.res_subject WHERE"
-            " res_subject ILIKE {{{parpatname}}}"]
+            " rr.res_subject.res_subject ILIKE {{{parpatname}}}"]
         self._fillers, subqueries = {}, []
 
         for index, word in enumerate(self.words):
@@ -266,7 +266,7 @@ class Freetext(Constraint):
         base_queries = [
             " 1=ivo_hasword(res_description, {{{parname}}})",
             " 1=ivo_hasword(res_title, {{{parname}}})",
-            " res_subject ILIKE {{{parpatname}}}"]
+            " rr.res_subject.res_subject ILIKE {{{parpatname}}}"]
         self._fillers, conditions = {}, []
 
         for index, word in enumerate(self.words):
@@ -681,7 +681,7 @@ class Spatial(Constraint):
         # something as esoteric as a server that understands
         # MOC-based geometries but does not have a MOC function.
         if not service.get_tap_cap().get_adql().get_feature(
-                    "ivo://org.gavo.dc/std/exts#extra-adql-keywords", "MOC"):
+                "ivo://org.gavo.dc/std/exts#extra-adql-keywords", "MOC"):
                 raise RegTAPFeatureMissing("Current RegTAP service"
                     " does not support MOC.")
 

--- a/pyvo/registry/rtcons.py
+++ b/pyvo/registry/rtcons.py
@@ -58,8 +58,8 @@ class RegTAPFeatureMissing(dalq.DALQueryError):
     to write that constraint, or because it is missing a table or column.
 
     To recover, choose another RegTAP service. Search constraining
-    ``datamodel="regtap"``, and then use `pyvo.registry.switch_RegTAP_service`
-    with a TAP access URL discoveredin this way.
+    ``datamodel="regtap"``, and then use `pyvo.registry.choose_RegTAP_service`
+    with a TAP access URL discovered in this way.
     """
 
 
@@ -232,7 +232,7 @@ class Freetext(Constraint):
         # of subqueries if we can (i.e., the service has UNION);
         # It may look as if this has to be really slow, but in fact it's almost
         # always a lot faster than direct ORs.
-        if service.get_tap_cap().get_adql().get_feature(
+        if service.get_tap_capability().get_adql().get_feature(
                 "ivo://ivoa.net/std/TAPRegExt#features-adql-sets", "UNION"):
             return self._get_union_condition(service)
         else:
@@ -680,7 +680,7 @@ class Spatial(Constraint):
         # have to depend on pymoc, and that's too high a price for
         # something as esoteric as a server that understands
         # MOC-based geometries but does not have a MOC function.
-        if not service.get_tap_cap().get_adql().get_feature(
+        if not service.get_tap_capability().get_adql().get_feature(
                 "ivo://org.gavo.dc/std/exts#extra-adql-keywords", "MOC"):
             raise RegTAPFeatureMissing("Current RegTAP service does not support MOC.")
 
@@ -878,12 +878,12 @@ def build_regtap_query(constraints, service):
 
     Parameters
     ----------
-    constraints : sequence of `Constraint`-s
+    constraints : sequence of ``Constraint``-s
         A sequence of constraints for a RegTAP query.  All of them
         will become part of a conjunction (i.e., all of them have
         to be satisfied for a record to match).
 
-    service : `dal.tap.TAPService`
+    service : `~pyvo.dal.tap.TAPService`
         The RegTAP service the query is supposed to be run on
         (that is relevant because we adapt to the features available
         on given services).

--- a/pyvo/registry/rtcons.py
+++ b/pyvo/registry/rtcons.py
@@ -682,15 +682,13 @@ class Spatial(Constraint):
         # MOC-based geometries but does not have a MOC function.
         if not service.get_tap_cap().get_adql().get_feature(
                 "ivo://org.gavo.dc/std/exts#extra-adql-keywords", "MOC"):
-                raise RegTAPFeatureMissing("Current RegTAP service"
-                    " does not support MOC.")
+            raise RegTAPFeatureMissing("Current RegTAP service does not support MOC.")
 
         # We should compare case-insensitively here, but then we don't
         # with delimited identifiers -- in the end, that would have to
         # be handled in dal.vosi.VOSITables.
-        if not "rr.stc_spatial" in service.tables:
-                raise RegTAPFeatureMissing("stc_spatial missing on"
-                    " current RegTAP service")
+        if "rr.stc_spatial" not in service.tables:
+            raise RegTAPFeatureMissing("stc_spatial missing on current RegTAP service")
 
         return super().get_search_condition(service)
 
@@ -785,9 +783,8 @@ class Spectral(Constraint):
         raise ValueError(f"Cannot make a spectral quantity out of {quant}")
 
     def get_search_condition(self, service):
-        if not "rr.stc_spectral" in service.tables:
-                raise RegTAPFeatureMissing("stc_spectral missing on"
-                    " current RegTAP service")
+        if "rr.stc_spectral" not in service.tables:
+            raise RegTAPFeatureMissing("stc_spectral missing on current RegTAP service")
 
         return super().get_search_condition(service)
 
@@ -864,9 +861,8 @@ class Temporal(Constraint):
         return val
 
     def get_search_condition(self, service):
-        if not "rr.stc_temporal" in service.tables:
-                raise RegTAPFeatureMissing("stc_temporal missing on"
-                    " current RegTAP service")
+        if "rr.stc_temporal" not in service.tables:
+            raise RegTAPFeatureMissing("stc_temporal missing on current RegTAP service")
 
         return super().get_search_condition(service)
 

--- a/pyvo/registry/tests/commonfixtures.py
+++ b/pyvo/registry/tests/commonfixtures.py
@@ -60,7 +60,7 @@ class _FakeTAPService:
                 return adql_lang
         self.tap_cap = _()
 
-    def get_tap_cap(self):
+    def get_tap_capability(self):
         return self.tap_cap
 
 

--- a/pyvo/registry/tests/commonfixtures.py
+++ b/pyvo/registry/tests/commonfixtures.py
@@ -24,3 +24,17 @@ def messenger_vocabulary(mocker):
         get_pkg_data_filename(
             'data/messenger.desise',
             package=__package__))
+
+
+# We need an object standing in for TAP services for query generation.
+# It would perhaps be nice to pull up a real TAPService instance from
+# capabilities and tables, but that's a non-trivial amount of XML.
+# Let's see how far we get with faking it.
+
+
+class _FakeTAPService:
+    def __init__(self):
+        pass
+
+
+FAKE_GAVO = _FakeTAPService()

--- a/pyvo/registry/tests/commonfixtures.py
+++ b/pyvo/registry/tests/commonfixtures.py
@@ -66,6 +66,9 @@ class _FakeTAPService:
 
 FAKE_GAVO = _FakeTAPService({
         ("ivo://ivoa.net/std/TAPRegExt#features-adql-sets", "UNION"),
-        ("ivo://org.gavo.dc/std/exts#extra-adql-keywords", "MOC"),},
-        {"rr.stc_spatial": None})
+        ("ivo://org.gavo.dc/std/exts#extra-adql-keywords", "MOC"),
+    }, {
+        "rr.stc_spatial": None,
+        "rr.stc_spectral": None,
+        "rr.stc_temporal": None,})
 FAKE_PLAIN = _FakeTAPService(frozenset(), {})

--- a/pyvo/registry/tests/commonfixtures.py
+++ b/pyvo/registry/tests/commonfixtures.py
@@ -66,9 +66,8 @@ class _FakeTAPService:
 
 FAKE_GAVO = _FakeTAPService({
     ("ivo://ivoa.net/std/TAPRegExt#features-adql-sets", "UNION"),
-        ("ivo://org.gavo.dc/std/exts#extra-adql-keywords", "MOC"),
-    }, {
+    ("ivo://org.gavo.dc/std/exts#extra-adql-keywords", "MOC"), }, {
         "rr.stc_spatial": None,
         "rr.stc_spectral": None,
-        "rr.stc_temporal": None,})
+        "rr.stc_temporal": None, })
 FAKE_PLAIN = _FakeTAPService(frozenset(), {})

--- a/pyvo/registry/tests/commonfixtures.py
+++ b/pyvo/registry/tests/commonfixtures.py
@@ -39,7 +39,7 @@ class _FakeLanguage:
     def __init__(self, features):
         self.features = features
 
-    def has_feature(self, type, form):
+    def get_feature(self, type, form):
         return (type, form) in self.features
 
 
@@ -48,8 +48,11 @@ class _FakeTAPService:
     A stand-in for a TAP service intended for rtcons.Constraints.
 
     features is a set of (type, form) tuples for now.
+    tables is a dict with table names as keys (let's worry about the values
+    later).
     """
-    def __init__(self, features={}):
+    def __init__(self, features, tables):
+        self.tables = tables
         adql_lang = _FakeLanguage(features)
 
         class _:
@@ -61,6 +64,8 @@ class _FakeTAPService:
         return self.tap_cap
 
 
-FAKE_GAVO = _FakeTAPService(features={
-        ("ivo://ivoa.net/std/TAPRegExt#features-adql-sets", "UNION")})
-FAKE_PLAIN = _FakeTAPService({})
+FAKE_GAVO = _FakeTAPService({
+        ("ivo://ivoa.net/std/TAPRegExt#features-adql-sets", "UNION"),
+        ("ivo://org.gavo.dc/std/exts#extra-adql-keywords", "MOC"),},
+        {"rr.stc_spatial": None})
+FAKE_PLAIN = _FakeTAPService(frozenset(), {})

--- a/pyvo/registry/tests/commonfixtures.py
+++ b/pyvo/registry/tests/commonfixtures.py
@@ -65,7 +65,7 @@ class _FakeTAPService:
 
 
 FAKE_GAVO = _FakeTAPService({
-        ("ivo://ivoa.net/std/TAPRegExt#features-adql-sets", "UNION"),
+    ("ivo://ivoa.net/std/TAPRegExt#features-adql-sets", "UNION"),
         ("ivo://org.gavo.dc/std/exts#extra-adql-keywords", "MOC"),
     }, {
         "rr.stc_spatial": None,

--- a/pyvo/registry/tests/commonfixtures.py
+++ b/pyvo/registry/tests/commonfixtures.py
@@ -32,9 +32,35 @@ def messenger_vocabulary(mocker):
 # Let's see how far we get with faking it.
 
 
+class _FakeLanguage:
+    """
+    a stand-in for vosi.tapregext.Language for rtcons.Constrants.
+    """
+    def __init__(self, features):
+        self.features = features
+
+    def has_feature(self, type, form):
+        return (type, form) in self.features
+
+
 class _FakeTAPService:
-    def __init__(self):
-        pass
+    """
+    A stand-in for a TAP service intended for rtcons.Constraints.
+
+    features is a set of (type, form) tuples for now.
+    """
+    def __init__(self, features={}):
+        adql_lang = _FakeLanguage(features)
+
+        class _:
+            def get_adql(otherself):
+                return adql_lang
+        self.tap_cap = _()
+
+    def get_tap_cap(self):
+        return self.tap_cap
 
 
-FAKE_GAVO = _FakeTAPService()
+FAKE_GAVO = _FakeTAPService(features={
+        ("ivo://ivoa.net/std/TAPRegExt#features-adql-sets", "UNION")})
+FAKE_PLAIN = _FakeTAPService({})

--- a/pyvo/registry/tests/data/capabilities.xml
+++ b/pyvo/registry/tests/data/capabilities.xml
@@ -50,6 +50,16 @@
           <form>POINT</form>
         </feature>
       </languageFeatures>
+      <languageFeatures type="ivo://org.gavo.dc/std/exts#extra-adql-keywords">
+        <feature>
+          <form>TABLESAMPLE</form>
+          <description>Written after a table reference, ...</description>
+        </feature>
+        <feature>
+          <form>MOC</form>
+          <description>A geometry function creating MOCs...</description>
+        </feature>
+      </languageFeatures>
     </language>
     <outputFormat ivo-id="ivo://ivoa.net/std/TAPRegExt#output-votable-binary">
       <mime>text/xml</mime>

--- a/pyvo/registry/tests/test_regtap.py
+++ b/pyvo/registry/tests/test_regtap.py
@@ -88,8 +88,8 @@ def single_keyword_fixture(mocker):
         data = dict(parse_qsl(request.body))
         query = data['QUERY']
 
-        assert "WHERE res_subject ILIKE '%single%'" in query
-        assert "WHERE 1=ivo_hasword(res_description, 'single') UNION" in query
+        assert "OR  res_subject ILIKE '%single%'" in query
+        assert "1=ivo_hasword(res_description, 'single') " in query
         assert "1=ivo_hasword(res_title, 'single')" in query
 
         return get_pkg_data_contents('data/regtap.xml')

--- a/pyvo/registry/tests/test_regtap.py
+++ b/pyvo/registry/tests/test_regtap.py
@@ -69,7 +69,7 @@ def keywords_fixture(mocker):
         assert "ivo_hasword(res_description, 'vizier')" in query
         assert "1=ivo_hasword(res_title, 'vizier')" in query
 
-        assert " res_subject ILIKE '%pulsar%'" in query
+        assert ".res_subject ILIKE '%pulsar%'" in query
         assert "1=ivo_hasword(res_description, 'pulsar')" in query
         assert "1=ivo_hasword(res_title, 'pulsar')" in query
 
@@ -88,7 +88,7 @@ def single_keyword_fixture(mocker):
         data = dict(parse_qsl(request.body))
         query = data['QUERY']
 
-        assert "OR  res_subject ILIKE '%single%'" in query
+        assert "OR  rr.res_subject.res_subject ILIKE '%single%'" in query
         assert "1=ivo_hasword(res_description, 'single') " in query
         assert "1=ivo_hasword(res_title, 'single')" in query
 
@@ -886,6 +886,7 @@ def test_sia2_service_operation():
     assert "s_dec" in res.to_table().columns
 
 
+@pytest.mark.remote_data
 def test_endpoint_switching():
     alt_svc = "http://vao.stsci.edu/RegTAP/TapService.aspx"
     previous_url = regtap.REGISTRY_BASEURL

--- a/pyvo/registry/tests/test_regtap.py
+++ b/pyvo/registry/tests/test_regtap.py
@@ -892,9 +892,9 @@ def test_endpoint_switching():
     previous_url = regtap.REGISTRY_BASEURL
     try:
         regtap.choose_RegTAP_service(alt_svc)
-        assert (regtap.get_RegTAP_service()._baseurl
-            == alt_svc)
+        assert regtap.get_RegTAP_service()._baseurl == alt_svc
 
         res = regtap.search(keywords="wirr")
+        assert len(res) > 0
     finally:
         regtap.choose_RegTAP_service(previous_url)

--- a/pyvo/registry/tests/test_regtap.py
+++ b/pyvo/registry/tests/test_regtap.py
@@ -893,5 +893,8 @@ def test_endpoint_switching():
         regtap.choose_RegTAP_service(alt_svc)
         assert (regtap.get_RegTAP_service()._baseurl
             == alt_svc)
+
+        res = regtap.search(keywords="wirr")
+        import pdb;pdb.set_trace()
     finally:
         regtap.choose_RegTAP_service(previous_url)

--- a/pyvo/registry/tests/test_regtap.py
+++ b/pyvo/registry/tests/test_regtap.py
@@ -23,7 +23,7 @@ from pyvo.dal import tap, sia2
 
 from astropy.utils.data import get_pkg_data_contents
 
-from .commonfixtures import messenger_vocabulary  # noqa: F401
+from .commonfixtures import messenger_vocabulary, FAKE_GAVO  # noqa: F401
 
 
 get_pkg_data_contents = partial(
@@ -348,13 +348,13 @@ def get_regtap_results(**kwargs):
 
 def test_spatial():
     assert (rtcons.keywords_to_constraints({
-            "spatial": (23, -40)})[0].get_search_condition()
+            "spatial": (23, -40)})[0].get_search_condition(FAKE_GAVO)
             == "1 = CONTAINS(MOC(6, POINT(23, -40)), coverage)")
 
 
 def test_spectral():
     assert (rtcons.keywords_to_constraints({
-            "spectral": (1e-17, 2e-17)})[0].get_search_condition()
+            "spectral": (1e-17, 2e-17)})[0].get_search_condition(FAKE_GAVO)
             == "1 = ivo_interval_overlaps(spectral_start, spectral_end, 1e-17, 2e-17)")
 
 
@@ -884,3 +884,14 @@ def test_sia2_service_operation():
             time.Time(58795, format="mjd")))
     assert len(res) > 10
     assert "s_dec" in res.to_table().columns
+
+
+def test_endpoint_switching():
+    alt_svc = "http://vao.stsci.edu/RegTAP/TapService.aspx"
+    previous_url = regtap.REGISTRY_BASEURL
+    try:
+        regtap.choose_RegTAP_service(alt_svc)
+        assert (regtap.get_RegTAP_service()._baseurl
+            == alt_svc)
+    finally:
+        regtap.choose_RegTAP_service(previous_url)

--- a/pyvo/registry/tests/test_regtap.py
+++ b/pyvo/registry/tests/test_regtap.py
@@ -895,6 +895,5 @@ def test_endpoint_switching():
             == alt_svc)
 
         res = regtap.search(keywords="wirr")
-        import pdb;pdb.set_trace()
     finally:
         regtap.choose_RegTAP_service(previous_url)

--- a/pyvo/registry/tests/test_rtcons.py
+++ b/pyvo/registry/tests/test_rtcons.py
@@ -78,30 +78,30 @@ class TestFreetextConstraint:
         assert rtcons.Freetext("star").get_search_condition(FAKE_GAVO) == (
             "ivoid IN (SELECT ivoid FROM rr.resource WHERE 1=ivo_hasword(res_description, 'star') "
             "UNION SELECT ivoid FROM rr.resource WHERE 1=ivo_hasword(res_title, 'star') "
-            "UNION SELECT ivoid FROM rr.res_subject WHERE res_subject ILIKE '%star%')")
+            "UNION SELECT ivoid FROM rr.res_subject WHERE rr.res_subject.res_subject ILIKE '%star%')")
 
     def test_interesting_literal(self):
         assert rtcons.Freetext("α Cen's planets").get_search_condition(FAKE_GAVO) == (
             "ivoid IN (SELECT ivoid FROM rr.resource WHERE 1=ivo_hasword(res_description, 'α Cen''s planets')"
             " UNION SELECT ivoid FROM rr.resource WHERE 1=ivo_hasword(res_title, 'α Cen''s planets')"
-            " UNION SELECT ivoid FROM rr.res_subject WHERE res_subject ILIKE '%α Cen''s planets%')")
+            " UNION SELECT ivoid FROM rr.res_subject WHERE rr.res_subject.res_subject ILIKE '%α Cen''s planets%')")
 
     def test_multipleLiterals(self):
         assert rtcons.Freetext("term1", "term2"
             ).get_search_condition(FAKE_GAVO) == (
             "ivoid IN (SELECT ivoid FROM rr.resource WHERE 1=ivo_hasword(res_description, 'term1')"
             " UNION SELECT ivoid FROM rr.resource WHERE 1=ivo_hasword(res_title, 'term1')"
-            " UNION SELECT ivoid FROM rr.res_subject WHERE res_subject ILIKE '%term1%')"
+            " UNION SELECT ivoid FROM rr.res_subject WHERE rr.res_subject.res_subject ILIKE '%term1%')"
         " AND "
         "ivoid IN (SELECT ivoid FROM rr.resource WHERE 1=ivo_hasword(res_description, 'term2')"
         " UNION SELECT ivoid FROM rr.resource WHERE 1=ivo_hasword(res_title, 'term2')"
-        " UNION SELECT ivoid FROM rr.res_subject WHERE res_subject ILIKE '%term2%')")
+        " UNION SELECT ivoid FROM rr.res_subject WHERE rr.res_subject.res_subject ILIKE '%term2%')")
 
     def test_adaption_to_service(self):
         assert rtcons.Freetext("term1", "term2"
             ).get_search_condition(FAKE_PLAIN) == (
-            "( 1=ivo_hasword(res_description, 'term1') OR  1=ivo_hasword(res_title, 'term1') OR  res_subject ILIKE '%term1%')"
-            " AND ( 1=ivo_hasword(res_description, 'term2') OR  1=ivo_hasword(res_title, 'term2') OR  res_subject ILIKE '%term2%')")
+            "( 1=ivo_hasword(res_description, 'term1') OR  1=ivo_hasword(res_title, 'term1') OR  rr.res_subject.res_subject ILIKE '%term1%')"
+            " AND ( 1=ivo_hasword(res_description, 'term2') OR  1=ivo_hasword(res_title, 'term2') OR  rr.res_subject.res_subject ILIKE '%term2%')")
 
 
 class TestAuthorConstraint:
@@ -323,7 +323,7 @@ class TestSpectralConstraint:
                 " 5.830941732e-26, 6.758591553e-26)")
 
     def test_no_spectral(self):
-        cons = registry.Spectral((88 * units.MHz, 102 * units.MHz))
+        cons = registry.Spectral((88 * u.MHz, 102 * u.MHz))
         with pytest.raises(rtcons.RegTAPFeatureMissing) as excinfo:
             cons.get_search_condition(FAKE_PLAIN)
         assert (str(excinfo.value)
@@ -354,13 +354,12 @@ class TestTemporalConstraint:
                 " be made from single time instants.")
 
     def test_no_temporal(self):
-        cons = registry.Temporal((time.Time(2459000, format='jd'),
-                                  time.Time(59002, format='mjd')))
+        cons = registry.Temporal((Time(2459000, format='jd'),
+                                  Time(59002, format='mjd')))
         with pytest.raises(rtcons.RegTAPFeatureMissing) as excinfo:
             cons.get_search_condition(FAKE_PLAIN)
         assert (str(excinfo.value)
             == "stc_temporal missing on current RegTAP service")
-
 
 
 class TestWhereClauseBuilding:
@@ -414,11 +413,11 @@ class TestWhereClauseBuilding:
             '(ivoid IN (SELECT ivoid FROM rr.resource WHERE '
             "1=ivo_hasword(res_description, 'plain') UNION SELECT ivoid FROM rr.resource "
             "WHERE 1=ivo_hasword(res_title, 'plain') UNION SELECT ivoid FROM "
-            "rr.res_subject WHERE res_subject ILIKE '%plain%'))\n"
+            "rr.res_subject WHERE rr.res_subject.res_subject ILIKE '%plain%'))\n"
             '  AND (ivoid IN (SELECT ivoid FROM rr.resource WHERE '
             "1=ivo_hasword(res_description, 'string') UNION SELECT ivoid FROM rr.resource "
             "WHERE 1=ivo_hasword(res_title, 'string') UNION SELECT ivoid FROM "
-            "rr.res_subject WHERE res_subject ILIKE '%string%'))")
+            "rr.res_subject WHERE rr.res_subject.res_subject ILIKE '%string%'))")
 
 
 class TestSelectClause:

--- a/pyvo/registry/tests/test_rtcons.py
+++ b/pyvo/registry/tests/test_rtcons.py
@@ -322,6 +322,13 @@ class TestSpectralConstraint:
                 == "1 = ivo_interval_overlaps(spectral_start, spectral_end,"
                 " 5.830941732e-26, 6.758591553e-26)")
 
+    def test_no_spectral(self):
+        cons = registry.Spectral((88 * units.MHz, 102 * units.MHz))
+        with pytest.raises(rtcons.RegTAPFeatureMissing) as excinfo:
+            cons.get_search_condition(FAKE_PLAIN)
+        assert (str(excinfo.value)
+            == "stc_spectral missing on current RegTAP service")
+
 
 class TestTemporalConstraint:
     def test_plain_float(self):
@@ -345,6 +352,15 @@ class TestTemporalConstraint:
             registry.Temporal(Time(['1999-01-01', '2010-01-01']))
         assert (str(excinfo.value) == "RegTAP time constraints must"
                 " be made from single time instants.")
+
+    def test_no_temporal(self):
+        cons = registry.Temporal((time.Time(2459000, format='jd'),
+                                  time.Time(59002, format='mjd')))
+        with pytest.raises(rtcons.RegTAPFeatureMissing) as excinfo:
+            cons.get_search_condition(FAKE_PLAIN)
+        assert (str(excinfo.value)
+            == "stc_temporal missing on current RegTAP service")
+
 
 
 class TestWhereClauseBuilding:

--- a/pyvo/registry/tests/test_rtcons.py
+++ b/pyvo/registry/tests/test_rtcons.py
@@ -16,7 +16,7 @@ from pyvo import registry
 from pyvo.registry import rtcons
 from pyvo.dal import query as dalq
 
-from .commonfixtures import messenger_vocabulary, FAKE_GAVO  # noqa: F401
+from .commonfixtures import messenger_vocabulary, FAKE_GAVO, FAKE_PLAIN  # noqa: F401
 
 
 def _build_regtap_query_with_fake(
@@ -85,6 +85,23 @@ class TestFreetextConstraint:
             "ivoid IN (SELECT ivoid FROM rr.resource WHERE 1=ivo_hasword(res_description, 'α Cen''s planets')"
             " UNION SELECT ivoid FROM rr.resource WHERE 1=ivo_hasword(res_title, 'α Cen''s planets')"
             " UNION SELECT ivoid FROM rr.res_subject WHERE res_subject ILIKE '%α Cen''s planets%')")
+
+    def test_multipleLiterals(self):
+        assert rtcons.Freetext("term1", "term2"
+            ).get_search_condition(FAKE_GAVO) == (
+            "ivoid IN (SELECT ivoid FROM rr.resource WHERE 1=ivo_hasword(res_description, 'term1')"
+            " UNION SELECT ivoid FROM rr.resource WHERE 1=ivo_hasword(res_title, 'term1')"
+            " UNION SELECT ivoid FROM rr.res_subject WHERE res_subject ILIKE '%term1%')"
+        " AND "
+        "ivoid IN (SELECT ivoid FROM rr.resource WHERE 1=ivo_hasword(res_description, 'term2')"
+        " UNION SELECT ivoid FROM rr.resource WHERE 1=ivo_hasword(res_title, 'term2')"
+        " UNION SELECT ivoid FROM rr.res_subject WHERE res_subject ILIKE '%term2%')")
+
+    def test_adaption_to_service(self):
+        assert rtcons.Freetext("term1", "term2"
+            ).get_search_condition(FAKE_PLAIN) == (
+            "( 1=ivo_hasword(res_description, 'term1') OR  1=ivo_hasword(res_title, 'term1') OR  res_subject ILIKE '%term1%')"
+            " AND ( 1=ivo_hasword(res_description, 'term2') OR  1=ivo_hasword(res_title, 'term2') OR  res_subject ILIKE '%term2%')")
 
 
 class TestAuthorConstraint:

--- a/pyvo/registry/tests/test_rtcons.py
+++ b/pyvo/registry/tests/test_rtcons.py
@@ -255,11 +255,11 @@ class TestSpatialConstraint:
 
     def test_enclosed(self):
         cons = registry.Spatial("0/1-3", intersect="enclosed")
-        assert cons.get_search_condition() == "1 = CONTAINS(coverage, MOC('0/1-3'))"
+        assert cons.get_search_condition(FAKE_GAVO) == "1 = CONTAINS(coverage, MOC('0/1-3'))"
 
     def test_overlaps(self):
         cons = registry.Spatial("0/1-3", intersect="overlaps")
-        assert cons.get_search_condition() == "1 = INTERSECTS(coverage, MOC('0/1-3'))"
+        assert cons.get_search_condition(FAKE_GAVO) == "1 = INTERSECTS(coverage, MOC('0/1-3'))"
 
     def test_not_an_intersect_mode(self):
         with pytest.raises(ValueError, match="'intersect' should be one of 'covers', 'enclosed',"
@@ -471,5 +471,5 @@ class TestSelectClause:
                     "source_format, "
                     "source_value, "
                     "region_of_regard, "
-                    "alt_identifier, "
-                    "waveband"))
+                    "waveband, "
+                    "alt_identifier"))

--- a/pyvo/registry/tests/test_rtcons.py
+++ b/pyvo/registry/tests/test_rtcons.py
@@ -265,6 +265,24 @@ class TestSpatialConstraint:
                            " or 'overlaps' but its current value is 'wrong'."):
             registry.Spatial("0/1-3", intersect="wrong")
 
+    def test_no_MOC(self):
+        cons = registry.Spatial((SkyCoord(3 * u.deg, -30 * u.deg), 3))
+        with pytest.raises(rtcons.RegTAPFeatureMissing) as excinfo:
+            cons.get_search_condition(FAKE_PLAIN)
+        assert (str(excinfo.value)
+            == "Current RegTAP service does not support MOC.")
+
+    def test_no_spatial_table(self):
+        cons = registry.Spatial((SkyCoord(3 * u.deg, -30 * u.deg), 3))
+        previous = FAKE_GAVO.tables.pop("rr.stc_spatial")
+        try:
+            with pytest.raises(rtcons.RegTAPFeatureMissing) as excinfo:
+                cons.get_search_condition(FAKE_GAVO)
+            assert (str(excinfo.value)
+                == "stc_spatial missing on current RegTAP service")
+        finally:
+            FAKE_GAVO.tables["rr.spatial"] = previous
+
 
 class TestSpectralConstraint:
     # These tests might need some float literal fuzziness.  I'm just

--- a/pyvo/registry/tests/test_rtcons.py
+++ b/pyvo/registry/tests/test_rtcons.py
@@ -24,7 +24,7 @@ def _build_regtap_query_with_fake(
         service=FAKE_GAVO,
         **kwargs):
     return rtcons.build_regtap_query(
-        *args,  service=service, **kwargs)
+        *args, service=service, **kwargs)
 
 
 class TestAbstractConstraint:
@@ -84,24 +84,25 @@ class TestFreetextConstraint:
         assert rtcons.Freetext("α Cen's planets").get_search_condition(FAKE_GAVO) == (
             "ivoid IN (SELECT ivoid FROM rr.resource WHERE 1=ivo_hasword(res_description, 'α Cen''s planets')"
             " UNION SELECT ivoid FROM rr.resource WHERE 1=ivo_hasword(res_title, 'α Cen''s planets')"
-            " UNION SELECT ivoid FROM rr.res_subject WHERE rr.res_subject.res_subject ILIKE '%α Cen''s planets%')")
+            " UNION SELECT ivoid FROM rr.res_subject WHERE rr.res_subject.res_subject"
+            " ILIKE '%α Cen''s planets%')")
 
     def test_multipleLiterals(self):
-        assert rtcons.Freetext("term1", "term2"
-            ).get_search_condition(FAKE_GAVO) == (
+        assert rtcons.Freetext("term1", "term2").get_search_condition(FAKE_GAVO) == (
             "ivoid IN (SELECT ivoid FROM rr.resource WHERE 1=ivo_hasword(res_description, 'term1')"
             " UNION SELECT ivoid FROM rr.resource WHERE 1=ivo_hasword(res_title, 'term1')"
             " UNION SELECT ivoid FROM rr.res_subject WHERE rr.res_subject.res_subject ILIKE '%term1%')"
-        " AND "
-        "ivoid IN (SELECT ivoid FROM rr.resource WHERE 1=ivo_hasword(res_description, 'term2')"
-        " UNION SELECT ivoid FROM rr.resource WHERE 1=ivo_hasword(res_title, 'term2')"
-        " UNION SELECT ivoid FROM rr.res_subject WHERE rr.res_subject.res_subject ILIKE '%term2%')")
+            " AND "
+            "ivoid IN (SELECT ivoid FROM rr.resource WHERE 1=ivo_hasword(res_description, 'term2')"
+            " UNION SELECT ivoid FROM rr.resource WHERE 1=ivo_hasword(res_title, 'term2')"
+            " UNION SELECT ivoid FROM rr.res_subject WHERE rr.res_subject.res_subject ILIKE '%term2%')")
 
     def test_adaption_to_service(self):
-        assert rtcons.Freetext("term1", "term2"
-            ).get_search_condition(FAKE_PLAIN) == (
-            "( 1=ivo_hasword(res_description, 'term1') OR  1=ivo_hasword(res_title, 'term1') OR  rr.res_subject.res_subject ILIKE '%term1%')"
-            " AND ( 1=ivo_hasword(res_description, 'term2') OR  1=ivo_hasword(res_title, 'term2') OR  rr.res_subject.res_subject ILIKE '%term2%')")
+        assert rtcons.Freetext("term1", "term2").get_search_condition(FAKE_PLAIN) == (
+            "( 1=ivo_hasword(res_description, 'term1') OR  1=ivo_hasword(res_title, 'term1')"
+            " OR  rr.res_subject.res_subject ILIKE '%term1%')"
+            " AND ( 1=ivo_hasword(res_description, 'term2') OR  1=ivo_hasword(res_title, 'term2')"
+            " OR  rr.res_subject.res_subject ILIKE '%term2%')")
 
 
 class TestAuthorConstraint:
@@ -150,7 +151,7 @@ class TestServicetypeConstraint:
         assert (
             rtcons.Servicetype("conesearch", "sia2").get_search_condition(FAKE_GAVO)
             == ("standard_id IN ('ivo://ivoa.net/std/conesearch')"
-                    " OR standard_id like 'ivo://ivoa.net/std/sia#query-2.%'"))
+                " OR standard_id like 'ivo://ivoa.net/std/sia#query-2.%'"))
 
     def test_sia2_aux(self):
         constraint = rtcons.Servicetype("conesearch", "sia2").include_auxiliary_services()
@@ -294,7 +295,8 @@ class TestSpectralConstraint:
 
     def test_energy_eV(self):
         cons = registry.Spectral(5 * u.eV)
-        assert cons.get_search_condition(FAKE_GAVO) == "8.01088317e-19 BETWEEN spectral_start AND spectral_end"
+        assert (cons.get_search_condition(FAKE_GAVO)
+                == "8.01088317e-19 BETWEEN spectral_start AND spectral_end")
 
     def test_energy_interval(self):
         cons = registry.Spectral((1e-10 * u.erg, 2e-10 * u.erg))
@@ -303,7 +305,8 @@ class TestSpectralConstraint:
 
     def test_wavelength(self):
         cons = registry.Spectral(5000 * u.Angstrom)
-        assert cons.get_search_condition(FAKE_GAVO) == "3.9728917142978567e-19 BETWEEN spectral_start AND spectral_end"
+        assert (cons.get_search_condition(FAKE_GAVO)
+                == "3.9728917142978567e-19 BETWEEN spectral_start AND spectral_end")
 
     def test_wavelength_interval(self):
         cons = registry.Spectral((20 * u.cm, 22 * u.cm))
@@ -366,8 +369,7 @@ class TestWhereClauseBuilding:
     @staticmethod
     def where_clause_for(*args, **kwargs):
         cons = list(args) + rtcons.keywords_to_constraints(kwargs)
-        return _build_regtap_query_with_fake(cons
-            ).split("\nWHERE\n", 1)[1].split("\nGROUP BY\n")[0]
+        return _build_regtap_query_with_fake(cons).split("\nWHERE\n", 1)[1].split("\nGROUP BY\n")[0]
 
     @pytest.mark.usefixtures('messenger_vocabulary')
     def test_from_constraints(self):
@@ -469,5 +471,5 @@ class TestSelectClause:
                     "source_format, "
                     "source_value, "
                     "region_of_regard, "
-                    "waveband, "
-                    "alt_identifier"))
+                    "alt_identifier, "
+                    "waveband"))

--- a/pyvo/registry/tests/test_rtcons.py
+++ b/pyvo/registry/tests/test_rtcons.py
@@ -16,13 +16,21 @@ from pyvo import registry
 from pyvo.registry import rtcons
 from pyvo.dal import query as dalq
 
-from .commonfixtures import messenger_vocabulary  # noqa: F401
+from .commonfixtures import messenger_vocabulary, FAKE_GAVO  # noqa: F401
+
+
+def _build_regtap_query_with_fake(
+        *args,
+        service=FAKE_GAVO,
+        **kwargs):
+    return rtcons.build_regtap_query(
+        *args,  service=service, **kwargs)
 
 
 class TestAbstractConstraint:
     def test_no_search_condition(self):
         with pytest.raises(NotImplementedError):
-            rtcons.Constraint().get_search_condition()
+            rtcons.Constraint().get_search_condition(FAKE_GAVO)
 
 
 class TestSQLLiterals:
@@ -67,13 +75,13 @@ class TestSQLLiterals:
 
 class TestFreetextConstraint:
     def test_basic(self):
-        assert rtcons.Freetext("star").get_search_condition() == (
+        assert rtcons.Freetext("star").get_search_condition(FAKE_GAVO) == (
             "ivoid IN (SELECT ivoid FROM rr.resource WHERE 1=ivo_hasword(res_description, 'star') "
             "UNION SELECT ivoid FROM rr.resource WHERE 1=ivo_hasword(res_title, 'star') "
             "UNION SELECT ivoid FROM rr.res_subject WHERE res_subject ILIKE '%star%')")
 
     def test_interesting_literal(self):
-        assert rtcons.Freetext("α Cen's planets").get_search_condition() == (
+        assert rtcons.Freetext("α Cen's planets").get_search_condition(FAKE_GAVO) == (
             "ivoid IN (SELECT ivoid FROM rr.resource WHERE 1=ivo_hasword(res_description, 'α Cen''s planets')"
             " UNION SELECT ivoid FROM rr.resource WHERE 1=ivo_hasword(res_title, 'α Cen''s planets')"
             " UNION SELECT ivoid FROM rr.res_subject WHERE res_subject ILIKE '%α Cen''s planets%')")
@@ -81,29 +89,29 @@ class TestFreetextConstraint:
 
 class TestAuthorConstraint:
     def test_basic(self):
-        assert (rtcons.Author("%Hubble%").get_search_condition()
+        assert (rtcons.Author("%Hubble%").get_search_condition(FAKE_GAVO)
                 == "role_name LIKE '%Hubble%' AND base_role='creator'")
 
 
 class TestServicetypeConstraint:
     def test_standardmap(self):
-        assert (rtcons.Servicetype("scs").get_search_condition()
+        assert (rtcons.Servicetype("scs").get_search_condition(FAKE_GAVO)
                 == "standard_id IN ('ivo://ivoa.net/std/conesearch')")
 
     def test_fulluri(self):
         assert (rtcons.Servicetype("http://extstandards/invention"
-                                   ).get_search_condition()
+                                   ).get_search_condition(FAKE_GAVO)
                 == "standard_id IN ('http://extstandards/invention')")
 
     def test_multi(self):
         assert (rtcons.Servicetype("http://extstandards/invention", "image"
-                                   ).get_search_condition()
+                                   ).get_search_condition(FAKE_GAVO)
                 == "standard_id IN ('http://extstandards/invention',"
                 " 'ivo://ivoa.net/std/sia')")
 
     def test_includeaux(self):
         assert (rtcons.Servicetype("http://extstandards/invention", "image"
-                                   ).include_auxiliary_services().get_search_condition()
+                                   ).include_auxiliary_services().get_search_condition(FAKE_GAVO)
                 == "standard_id IN ('http://extstandards/invention',"
                 " 'http://extstandards/invention#aux',"
                 " 'ivo://ivoa.net/std/sia',"
@@ -118,17 +126,18 @@ class TestServicetypeConstraint:
                                       " table, tap, sia2")
 
     def test_legacy_term(self):
-        assert (rtcons.Servicetype("conesearch").get_search_condition()
+        assert (rtcons.Servicetype("conesearch").get_search_condition(FAKE_GAVO)
                 == "standard_id IN ('ivo://ivoa.net/std/conesearch')")
 
     def test_sia2(self):
-        assert (rtcons.Servicetype("conesearch", "sia2").get_search_condition()
-                == ("standard_id IN ('ivo://ivoa.net/std/conesearch')"
+        assert (
+            rtcons.Servicetype("conesearch", "sia2").get_search_condition(FAKE_GAVO)
+            == ("standard_id IN ('ivo://ivoa.net/std/conesearch')"
                     " OR standard_id like 'ivo://ivoa.net/std/sia#query-2.%'"))
 
     def test_sia2_aux(self):
         constraint = rtcons.Servicetype("conesearch", "sia2").include_auxiliary_services()
-        assert (constraint.get_search_condition()
+        assert (constraint.get_search_condition(FAKE_GAVO)
                 == ("standard_id IN ('ivo://ivoa.net/std/conesearch', 'ivo://ivoa.net/std/conesearch#aux')"
                     " OR standard_id like 'ivo://ivoa.net/std/sia#query-2.%'"
                     " OR standard_id like 'ivo://ivoa.net/std/sia#query-aux-2.%'"))
@@ -137,7 +146,7 @@ class TestServicetypeConstraint:
 @pytest.mark.usefixtures('messenger_vocabulary')
 class TestWavebandConstraint:
     def test_basic(self):
-        assert (rtcons.Waveband("Infrared", "EUV").get_search_condition()
+        assert (rtcons.Waveband("Infrared", "EUV").get_search_condition(FAKE_GAVO)
                 == "1 = ivo_hashlist_has(rr.resource.waveband, 'infrared')"
                 " OR 1 = ivo_hashlist_has(rr.resource.waveband, 'euv')")
 
@@ -148,7 +157,7 @@ class TestWavebandConstraint:
             "Waveband junk is not in the IVOA messenger vocabulary http://www.ivoa.net/rdf/messenger.")
 
     def test_normalisation(self):
-        assert (rtcons.Waveband("oPtIcAl").get_search_condition()
+        assert (rtcons.Waveband("oPtIcAl").get_search_condition(FAKE_GAVO)
                 == "1 = ivo_hashlist_has(rr.resource.waveband, 'optical')")
 
 
@@ -161,7 +170,7 @@ class TestDatamodelConstraint:
 
     def test_obscore(self):
         cons = rtcons.Datamodel("ObsCore")
-        assert (cons.get_search_condition()
+        assert (cons.get_search_condition(FAKE_GAVO)
                 == "detail_xpath = '/capability/dataModel/@ivo-id'"
                 " AND 1 = ivo_nocasematch(detail_value,"
                 " 'ivo://ivoa.net/std/obscore%')")
@@ -169,14 +178,14 @@ class TestDatamodelConstraint:
 
     def test_epntap(self):
         cons = rtcons.Datamodel("epntap")
-        assert (cons.get_search_condition()
+        assert (cons.get_search_condition(FAKE_GAVO)
                 == "table_utype LIKE 'ivo://vopdc.obspm/std/epncore#schema-2.%'"
                 " OR table_utype LIKE 'ivo://ivoa.net/std/epntap#table-2.%'")
         assert (cons._extra_tables == ["rr.res_table"])
 
     def test_regtap(self):
         cons = rtcons.Datamodel("regtap")
-        assert (cons.get_search_condition()
+        assert (cons.get_search_condition(FAKE_GAVO)
                 == "detail_xpath = '/capability/dataModel/@ivo-id'"
                 " AND 1 = ivo_nocasematch(detail_value,"
                 " 'ivo://ivoa.net/std/RegTAP#1.%')")
@@ -186,44 +195,44 @@ class TestDatamodelConstraint:
 class TestIvoidConstraint:
     def test_basic(self):
         cons = rtcons.Ivoid("ivo://example/some_path")
-        assert (cons.get_search_condition()
+        assert (cons.get_search_condition(FAKE_GAVO)
                 == "ivoid = 'ivo://example/some_path'")
 
 
 class TestUCDConstraint:
     def test_basic(self):
         cons = rtcons.UCD("phot.mag;em.opt.%", "phot.mag;em.ir.%")
-        assert (cons.get_search_condition()
+        assert (cons.get_search_condition(FAKE_GAVO)
                 == "ucd LIKE 'phot.mag;em.opt.%' OR ucd LIKE 'phot.mag;em.ir.%'")
 
 
 class TestSpatialConstraint:
     def test_point(self):
         cons = registry.Spatial([23, -40])
-        assert cons.get_search_condition() == "1 = CONTAINS(MOC(6, POINT(23, -40)), coverage)"
+        assert cons.get_search_condition(FAKE_GAVO) == "1 = CONTAINS(MOC(6, POINT(23, -40)), coverage)"
         assert cons._extra_tables == ["rr.stc_spatial"]
 
     def test_circle_and_order(self):
         cons = registry.Spatial([23, -40, 0.25], order=7)
-        assert cons.get_search_condition() == "1 = CONTAINS(MOC(7, CIRCLE(23, -40, 0.25)), coverage)"
+        assert cons.get_search_condition(FAKE_GAVO) == "1 = CONTAINS(MOC(7, CIRCLE(23, -40, 0.25)), coverage)"
 
     def test_polygon(self):
         cons = registry.Spatial([23, -40, 26, -39, 25, -43])
-        assert cons.get_search_condition() == (
+        assert cons.get_search_condition(FAKE_GAVO) == (
             "1 = CONTAINS(MOC(6, POLYGON(23, -40, 26, -39, 25, -43)), coverage)")
 
     def test_moc(self):
         cons = registry.Spatial("0/1-3 3/")
-        assert cons.get_search_condition() == "1 = CONTAINS(MOC('0/1-3 3/'), coverage)"
+        assert cons.get_search_condition(FAKE_GAVO) == "1 = CONTAINS(MOC('0/1-3 3/'), coverage)"
 
     def test_SkyCoord(self):
         cons = registry.Spatial(SkyCoord(3 * u.deg, -30 * u.deg))
-        assert cons.get_search_condition() == "1 = CONTAINS(MOC(6, POINT(3.0, -30.0)), coverage)"
+        assert cons.get_search_condition(FAKE_GAVO) == "1 = CONTAINS(MOC(6, POINT(3.0, -30.0)), coverage)"
         assert cons._extra_tables == ["rr.stc_spatial"]
 
     def test_SkyCoord_Circle(self):
         cons = registry.Spatial((SkyCoord(3 * u.deg, -30 * u.deg), 3))
-        assert cons.get_search_condition() == "1 = CONTAINS(MOC(6, CIRCLE(3.0, -30.0, 3)), coverage)"
+        assert cons.get_search_condition(FAKE_GAVO) == "1 = CONTAINS(MOC(6, CIRCLE(3.0, -30.0, 3)), coverage)"
         assert cons._extra_tables == ["rr.stc_spatial"]
 
     def test_enclosed(self):
@@ -246,35 +255,35 @@ class TestSpectralConstraint:
     # that would be useful there.
     def test_energy_float(self):
         cons = registry.Spectral(1e-19)
-        assert cons.get_search_condition() == "1e-19 BETWEEN spectral_start AND spectral_end"
+        assert cons.get_search_condition(FAKE_GAVO) == "1e-19 BETWEEN spectral_start AND spectral_end"
 
     def test_energy_eV(self):
         cons = registry.Spectral(5 * u.eV)
-        assert cons.get_search_condition() == "8.01088317e-19 BETWEEN spectral_start AND spectral_end"
+        assert cons.get_search_condition(FAKE_GAVO) == "8.01088317e-19 BETWEEN spectral_start AND spectral_end"
 
     def test_energy_interval(self):
         cons = registry.Spectral((1e-10 * u.erg, 2e-10 * u.erg))
-        assert cons.get_search_condition() == (
+        assert cons.get_search_condition(FAKE_GAVO) == (
             "1 = ivo_interval_overlaps(spectral_start, spectral_end, 1e-17, 2e-17)")
 
     def test_wavelength(self):
         cons = registry.Spectral(5000 * u.Angstrom)
-        assert cons.get_search_condition() == "3.9728917142978567e-19 BETWEEN spectral_start AND spectral_end"
+        assert cons.get_search_condition(FAKE_GAVO) == "3.9728917142978567e-19 BETWEEN spectral_start AND spectral_end"
 
     def test_wavelength_interval(self):
         cons = registry.Spectral((20 * u.cm, 22 * u.cm))
-        assert (cons.get_search_condition()
+        assert (cons.get_search_condition(FAKE_GAVO)
                 == "1 = ivo_interval_overlaps(spectral_start, spectral_end,"
                 " 9.932229285744642e-25, 9.029299350676949e-25)")
 
     def test_frequency(self):
         cons = registry.Spectral(2 * u.GHz)
-        assert (cons.get_search_condition()
+        assert (cons.get_search_condition(FAKE_GAVO)
                 == "1.32521403e-24 BETWEEN spectral_start AND spectral_end")
 
     def test_frequency_interval(self):
         cons = registry.Spectral((88 * u.MHz, 102 * u.MHz))
-        assert (cons.get_search_condition()
+        assert (cons.get_search_condition(FAKE_GAVO)
                 == "1 = ivo_interval_overlaps(spectral_start, spectral_end,"
                 " 5.830941732e-26, 6.758591553e-26)")
 
@@ -282,18 +291,18 @@ class TestSpectralConstraint:
 class TestTemporalConstraint:
     def test_plain_float(self):
         cons = registry.Temporal((54130, 54200))
-        assert (cons.get_search_condition()
+        assert (cons.get_search_condition(FAKE_GAVO)
                 == "1 = ivo_interval_overlaps(time_start, time_end, 54130, 54200)")
 
     def test_single_time(self):
         cons = registry.Temporal(Time('2022-01-10'))
-        assert (cons.get_search_condition()
+        assert (cons.get_search_condition(FAKE_GAVO)
                 == "59589.0 BETWEEN time_start AND time_end")
 
     def test_time_interval(self):
         cons = registry.Temporal((Time(2459000, format='jd'),
                                   Time(59002, format='mjd')))
-        assert (cons.get_search_condition()
+        assert (cons.get_search_condition(FAKE_GAVO)
                 == "1 = ivo_interval_overlaps(time_start, time_end, 58999.5, 59002.0)")
 
     def test_multi_times_rejected(self):
@@ -307,7 +316,8 @@ class TestWhereClauseBuilding:
     @staticmethod
     def where_clause_for(*args, **kwargs):
         cons = list(args) + rtcons.keywords_to_constraints(kwargs)
-        return rtcons.build_regtap_query(cons).split("\nWHERE\n", 1)[1].split("\nGROUP BY\n")[0]
+        return _build_regtap_query_with_fake(cons
+            ).split("\nWHERE\n", 1)[1].split("\nGROUP BY\n")[0]
 
     @pytest.mark.usefixtures('messenger_vocabulary')
     def test_from_constraints(self):
@@ -335,7 +345,7 @@ class TestWhereClauseBuilding:
 
     def test_bad_keyword(self):
         with pytest.raises(TypeError) as excinfo:
-            rtcons.build_regtap_query(
+            _build_regtap_query_with_fake(
                 *rtcons.keywords_to_constraints({"foo": "bar"}))
         # the following assertion will fail when new constraints are
         # defined (or old ones vanish).  I'd say that's a convenient
@@ -364,7 +374,7 @@ class TestSelectClause:
     def test_expected_columns(self):
         # This will break as regtap.RegistryResource.expected_columns
         # is changed.  Just update the assertion then.
-        assert rtcons.build_regtap_query(
+        assert _build_regtap_query_with_fake(
             rtcons.keywords_to_constraints({"author": "%Hubble%"})
         ).split("\nFROM\nrr.resource\n")[0] == (
             "SELECT\n"
@@ -393,22 +403,21 @@ class TestSelectClause:
     def test_group_by_columns(self):
         # Again, this will break as regtap.RegistryResource.expected_columns
         # is changed.  Just update the assertion then.
-        assert rtcons.build_regtap_query([rtcons.Author("%Hubble%")]
-                                         ).split("\nGROUP BY\n")[-1] == (
-            "ivoid, "
-            "res_type, "
-            "short_name, "
-            "res_title, "
-            "content_level, "
-            "res_description, "
-            "reference_url, "
-            "creator_seq, "
-            "created, "
-            "updated, "
-            "rights, "
-            "content_type, "
-            "source_format, "
-            "source_value, "
-            "region_of_regard, "
-            "waveband, "
-            "alt_identifier")
+        assert (_build_regtap_query_with_fake([rtcons.Author("%Hubble%")]).split("\nGROUP BY\n")[-1]
+                == ("ivoid, "
+                    "res_type, "
+                    "short_name, "
+                    "res_title, "
+                    "content_level, "
+                    "res_description, "
+                    "reference_url, "
+                    "creator_seq, "
+                    "created, "
+                    "updated, "
+                    "rights, "
+                    "content_type, "
+                    "source_format, "
+                    "source_value, "
+                    "region_of_regard, "
+                    "waveband, "
+                    "alt_identifier"))

--- a/pyvo/utils/xml/tests/test_elements.py
+++ b/pyvo/utils/xml/tests/test_elements.py
@@ -5,6 +5,7 @@ Tests for pyvo.utils.xml.elements
 """
 
 import io
+import pytest
 
 from astropy.utils.xml import iterparser
 
@@ -86,7 +87,6 @@ class TestXSIType:
         ).tbase.__class__
         assert found_type.__name__ == "TOther2"
 
-    def test_bad_type(self, recwarn):
-        self._parse_string(b'<tbase xsi:type="ns1:NoSuchType"/>')
-        assert recwarn.pop().message.args == (
-            'Unknown xsi:type ns1:NoSuchType ignored',)
+    def test_bad_type(self):
+        with pytest.warns(match='Unknown xsi:type ns1:NoSuchType ignored'):
+            self._parse_string(b'<tbase xsi:type="ns1:NoSuchType"/>')


### PR DESCRIPTION
This PR contains a set of changes addressing the fixable but not yet
fixed issues raised by Tom in
https://wiki.ivoa.net/internal/IVOA/InterOpOct2022Reg/PyVOandNAVORegTAP.pdf

PyVO now properly checks whether the server can do something not in
RegTAP 1.0 before trying it.  This concerns the optimisation of the
Freetext constraint as well as the STC constraints.

To make this reasonably easy to write, this retrofits some methods to
non-registry code:

* get_tap_cap to TAPService
* get_adql to tr.TableAccesss
* get_feature_list, get_feature, and get_udf to tr.Language