### PR TITLE
Avoid `AttributeError` in `DALServiceError.from_except`

### DIFF
--- a/pyvo/dal/exceptions.py
+++ b/pyvo/dal/exceptions.py
@@ -181,12 +181,15 @@ class DALServiceError(DALProtocolError):
             except AttributeError:
                 response = None
             code = 0
+            message = str(exc)
+
+            # if there is a response, refine the error message
             if response is not None:
                 code = response.status_code
-            message = str(exc)
-            content_type = response.headers.get('content-type', None)
-            if content_type and 'text/plain' in content_type:
-                message = '{} for {}'.format(response.text, url)
+                content_type = response.headers.get('content-type', None)
+                if content_type and 'text/plain' in content_type:
+                    message = '{} for {}'.format(response.text, url)
+
             # TODO votable handling
 
             return DALServiceError(message, code, exc, url)


### PR DESCRIPTION
If the response is `None` we get the `AttributeError` from [L.187](https://github.com/astropy/pyvo/blob/2ada6363f2d873b104c53dc0c9f6e270688114c5/pyvo/dal/exceptions.py#L187) in `pyvo.dal.exceptions`.
This is related to #376 .