### PR TITLE
No longer discarding single untyped interfaces.

### DIFF
--- a/pyvo/registry/regtap.py
+++ b/pyvo/registry/regtap.py
@@ -17,6 +17,7 @@ standardized TAP-based services.
 """
 
 import functools
+import itertools
 import os
 import warnings
 
@@ -394,7 +395,7 @@ class RegistryResource(dalq.Record):
                       ] = self._parse_pseudo_array(self._mapping["intf_roles"])
 
         self.interfaces = [Interface(*props)
-                           for props in zip(
+                           for props in itertools.zip_longest(
             self["access_urls"],
             self["standard_ids"],
             self["intf_types"],


### PR DESCRIPTION
This fixes an (unreported) bug where, when there is just a single interface of a single capability of a service and that is missing either a type or a role, it would get discarded as a consequence of the way we work around VOTable's lack of proper string arrays.

Not sure if this (minor -- the services pyVO actually cares about all have types and roles) bug fix warrants a changelog entry.  Let me know if you want one.