### PR TITLE
MAINT: deprecate AvailabilityMixin

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,10 @@
 
 - Registry search now finds SIA v2 services. [#422, #428]
 
+- Deprecate VOSI ``AvailabilityMixin``, this mean the deprecation of the
+  inherited ``availability``, ``available``, and ``up_since`` properties
+  of DAL service classes, too. [#413]
+
 
 1.4.1 (2023-03-07)
 ==================

--- a/docs/dal/index.rst
+++ b/docs/dal/index.rst
@@ -92,16 +92,12 @@ set of columns”, 2 means “columns most users can work with” and 3 ”every
 including exotic items”.  Query functions accept these values in the
 ``verbosity`` parameter. The exact semantics are service-specific.
 
-Availability and capabilities
------------------------------
+Capabilities
+------------
 
 VO services should offer some standard ”support” interfaces specified in
 VOSI.  In pyVO, the information obtained from these endpoints can be
 obtained from some service attributes.
-
-For availability (i.e., is the service up and running?),
-this is :py:attr:`~pyvo.dal.mixin.AvailabilityMixin.available`
-and :py:attr:`~pyvo.dal.mixin.AvailabilityMixin.up_since`
 
 Capabilities describe specific pieces of functionality (such as “this is a
 spectral search”) and further metadata (such as ”this service will never
@@ -130,18 +126,18 @@ Table Access Protocol
 
 .. pull-quote::
 
-    This protocol defines a service protocol for accessing 
-    general table data, including astronomical catalogs as well as general 
-    database tables. Access is provided for both database and table metadata 
+    This protocol defines a service protocol for accessing
+    general table data, including astronomical catalogs as well as general
+    database tables. Access is provided for both database and table metadata
     as well as for actual table data. This protocol supports the query language
-    `Astronomical Data Query Language (ADQL) <https://www.ivoa.net/documents/ADQL/>`_ 
-    within an integrated interface. 
-    It also includes support for both synchronous and asynchronous queries. 
-    Special support is provided for spatially indexed queries using the 
-    spatial extensions in ADQL. A multi-position query capability permits 
-    queries against an arbitrarily large list of astronomical targets, 
-    providing a simple spatial cross-matching capability. 
-    More sophisticated distributed cross-matching capabilities are possible by 
+    `Astronomical Data Query Language (ADQL) <https://www.ivoa.net/documents/ADQL/>`_
+    within an integrated interface.
+    It also includes support for both synchronous and asynchronous queries.
+    Special support is provided for spatially indexed queries using the
+    spatial extensions in ADQL. A multi-position query capability permits
+    queries against an arbitrarily large list of astronomical targets,
+    providing a simple spatial cross-matching capability.
+    More sophisticated distributed cross-matching capabilities are possible by
     orchestrating a distributed query across multiple TAP services.
 
     -- `Table Access Protocol <https://www.ivoa.net/documents/TAP/>`_
@@ -264,14 +260,14 @@ Simple Image Access
 
 .. pull-quote::
 
-    The Simple Image Access (SIA) protocol 
-    provides capabilities for the discovery, description, access, and retrieval 
-    of multi-dimensional image datasets, including 2-D images as well as datacubes 
-    of three or more dimensions. SIA data discovery is based on the 
-    `ObsCore Data Model <https://www.ivoa.net/documents/ObsCore/>`_, 
-    which primarily describes data products by the physical axes (spatial, spectral, 
-    time, and polarization). Image datasets with dimension greater than 2 are often 
-    referred to as datacubes, cube or image cube datasets and may be considered examples 
+    The Simple Image Access (SIA) protocol
+    provides capabilities for the discovery, description, access, and retrieval
+    of multi-dimensional image datasets, including 2-D images as well as datacubes
+    of three or more dimensions. SIA data discovery is based on the
+    `ObsCore Data Model <https://www.ivoa.net/documents/ObsCore/>`_,
+    which primarily describes data products by the physical axes (spatial, spectral,
+    time, and polarization). Image datasets with dimension greater than 2 are often
+    referred to as datacubes, cube or image cube datasets and may be considered examples
     of hypercube or n-cube data. PyVO supports both versions of SIA.
 
     -- `Simple IMage Access <https://www.ivoa.net/documents/SIA/>`_
@@ -324,10 +320,10 @@ Simple Spectrum Access
 .. pull-quote::
 
     The Simple Spectral Access (SSA) Protocol (SSAP)
-    defines a uniform interface to remotely discover and access one 
+    defines a uniform interface to remotely discover and access one
     dimensional spectra.
 
-    -- `Simple Spectral Access Protocol <https://www.ivoa.net/documents/SSA/>`_ 
+    -- `Simple Spectral Access Protocol <https://www.ivoa.net/documents/SSA/>`_
 
 Access to (one-dimensional) spectra resembles image access, with some
 subtile differences:
@@ -357,14 +353,14 @@ Simple Cone Search
 
 .. pull-quote::
 
-    The Simple Cone Search (SCS) 
-    API specification defines a simple query protocol for retrieving records from 
-    a catalog of astronomical sources. The query describes sky position and 
-    an angular distance, defining a cone on the sky. The response returns 
-    a list of astronomical sources from the catalog whose positions 
+    The Simple Cone Search (SCS)
+    API specification defines a simple query protocol for retrieving records from
+    a catalog of astronomical sources. The query describes sky position and
+    an angular distance, defining a cone on the sky. The response returns
+    a list of astronomical sources from the catalog whose positions
     lie within the cone, formatted as a VOTable.
 
-    -- `Simple Cone Search <https://www.ivoa.net/documents/latest/ConeSearch.html>`_ 
+    -- `Simple Cone Search <https://www.ivoa.net/documents/latest/ConeSearch.html>`_
 
 The Simple Cone Search returns results – typically catalog entries –
 within a circular region on the sky defined by the parameters ``pos``
@@ -384,12 +380,12 @@ Simple Line Access
 
 .. pull-quote::
 
-    The Simple Line Access Protocol (SLAP) 
-    is an IVOA data access protocol which defines a protocol for retrieving 
-    spectral lines coming from various Spectral Line Data Collections through 
+    The Simple Line Access Protocol (SLAP)
+    is an IVOA data access protocol which defines a protocol for retrieving
+    spectral lines coming from various Spectral Line Data Collections through
     a uniform interface within the VO framework.
 
-    -- `Simple Line Access Protocol <https://www.ivoa.net/documents/SLAP/>`_ 
+    -- `Simple Line Access Protocol <https://www.ivoa.net/documents/SLAP/>`_
 
 This service let you query for spectral lines in a certain ``wavelength``
 range. The unit of the values is meters, but any unit may be specified using

--- a/pyvo/dal/tests/test_sia2_remote.py
+++ b/pyvo/dal/tests/test_sia2_remote.py
@@ -20,10 +20,6 @@ class TestSIACadc():
 
     def test_service(self):
         cadc = SIA2Service(baseurl=CADC_SIA_URL)
-        assert cadc.availability
-        assert cadc.availability.available
-        assert cadc.availability.notes
-        assert cadc.availability.notes[0] == 'service is accepting queries'
         assert cadc.capabilities
 
     @pytest.mark.xfail(reason="https://github.com/astropy/pyvo/issues/361")

--- a/pyvo/dal/tests/test_sia2_remote.py
+++ b/pyvo/dal/tests/test_sia2_remote.py
@@ -6,10 +6,12 @@ Tests for pyvo.dal.sia2 against remote services
 
 import pytest
 
+import astropy.units as u
+from astropy.utils.exceptions import AstropyDeprecationWarning
+
 from pyvo.dal.sia2 import search, SIA2Service
 from pyvo.dal.adhoc import DatalinkResults
 
-import astropy.units as u
 
 CADC_SIA_URL = 'https://ws.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/sia'
 
@@ -20,6 +22,19 @@ class TestSIACadc():
 
     def test_service(self):
         cadc = SIA2Service(baseurl=CADC_SIA_URL)
+
+        with pytest.raises(AstropyDeprecationWarning):
+            assert cadc.availability
+
+        with pytest.raises(AstropyDeprecationWarning):
+            assert cadc.availability.available
+
+        with pytest.raises(AstropyDeprecationWarning):
+            assert cadc.availability.notes
+
+        with pytest.raises(AstropyDeprecationWarning):
+            assert cadc.availability.notes[0] == 'service is accepting queries'
+
         assert cadc.capabilities
 
     @pytest.mark.xfail(reason="https://github.com/astropy/pyvo/issues/361")

--- a/pyvo/dal/vosi.py
+++ b/pyvo/dal/vosi.py
@@ -5,7 +5,7 @@ VOSI classes and mixins
 from itertools import chain
 import requests
 
-from astropy.utils.decorators import lazyproperty
+from astropy.utils.decorators import lazyproperty, deprecated
 
 from .exceptions import DALServiceError
 from ..io import vosi
@@ -13,8 +13,7 @@ from ..utils.url import url_sibling
 from ..utils.decorators import stream_decode_content, response_decode_content
 from ..utils.http import use_session
 
-__all__ = [
-    'AvailabilityMixin', 'CapabilityMixin', 'VOSITables']
+__all__ = ['CapabilityMixin', 'VOSITables']
 
 
 class EndpointMixin():
@@ -44,10 +43,12 @@ class EndpointMixin():
         return response.raw
 
 
+@deprecated(since="1.5")
 class AvailabilityMixin(EndpointMixin):
     """
     Mixing for VOSI availability
     """
+    @deprecated(since="1.5")
     @stream_decode_content
     def _availability(self):
         """
@@ -57,10 +58,12 @@ class AvailabilityMixin(EndpointMixin):
         return self._get_endpoint('availability')
 
     @lazyproperty
+    @deprecated(since="1.5")
     def availability(self):
         return vosi.parse_availability(self._availability().read)
 
     @property
+    @deprecated(since="1.5")
     def available(self):
         """
         True if the service is available, False otherwise
@@ -68,6 +71,7 @@ class AvailabilityMixin(EndpointMixin):
         return self.availability.available
 
     @property
+    @deprecated(since="1.5")
     def up_since(self):
         """
         datetime the service was started


### PR DESCRIPTION
This is to close #214

~The class wasn't exposed to the user documentation so it's borderline whether this needs a deprecation and a changelog, but it was part of the modules's ``__all__``, so I treat it as it was part of the public API (as #411 revealed that a few API docs  are mistakenly missing from the rendered documentation)~

[edit]: it was in fact mentioned in the narrative docs, it was only the API docs that wasn't exposed. So I've now removed that narrative, too.