### PR TITLE
Make all-vo example work

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -113,7 +113,7 @@ observational datasets through TAP tables), you can write:
 .. doctest-remote-data::
 
     >>> for service in vo.regsearch(datamodel="obscore"):
-    ...   print(service['ivoid'])
+    ...   print(service['ivoid'])  # doctest: +IGNORE_OUTPUT
     ivo://aip.gavo.org/tap
     ivo://archive.stsci.edu/caomtap
     ivo://astro.ucl.ac.uk/tap

--- a/docs/registry/index.rst
+++ b/docs/registry/index.rst
@@ -359,7 +359,7 @@ run all-VO queries without reading at least this sentence)::
     from astropy import table
     from pyvo import registry
 
-    QUERY = "SELECT TOP 1 dataproduct_type from ivoa.obscore"
+    QUERY = "SELECT TOP 1 s_ra, s_dec from ivoa.obscore"
 
     results = []
     for svc_rec in registry.search(


### PR DESCRIPTION
Querying for dataproduct_type was a bad idea as we get back all kinds
of strings (and sometimes NULLs, too), which vstack() refuses to
merge.

We're now using a query with floats, which should be a lot less fragile.
At least for the first few services, this now runs.  It will probably
fail when a service returns NULLs for s_ra and s_dec, though.