### PR TITLE
MAINT: cleanup outer scope shadowing

### DIFF
--- a/pyvo/auth/tests/conftest.py
+++ b/pyvo/auth/tests/conftest.py
@@ -25,5 +25,5 @@ class ContextAdapter(requests_mock.Adapter):
 def mocker():
     with requests_mock.Mocker(
         adapter=ContextAdapter(case_sensitive=True)
-    ) as mocker:
-        yield mocker
+    ) as mocker_ins:
+        yield mocker_ins

--- a/pyvo/auth/tests/test_auth.py
+++ b/pyvo/auth/tests/test_auth.py
@@ -17,8 +17,8 @@ from pyvo.auth.authsession import AuthSession
 from pyvo.dal.tests.test_tap import MockAsyncTAPServer
 
 
-@pytest.fixture()
-def security_methods():
+@pytest.fixture(name='security_methods')
+def _security_methods():
     return [None]
 
 

--- a/pyvo/dal/adhoc.py
+++ b/pyvo/dal/adhoc.py
@@ -23,8 +23,7 @@ from astropy.utils.collections import HomogeneousList
 
 from ..utils.decorators import stream_decode_content
 from ..utils import vocabularies
-from .params import PosQueryParam, IntervalQueryParam, TimeQueryParam,\
-    EnumQueryParam
+from .params import PosQueryParam, IntervalQueryParam, TimeQueryParam, EnumQueryParam
 from ..dam.obscore import POLARIZATION_STATES
 
 # calls to DataLink from the results pages are batched for performance
@@ -216,10 +215,10 @@ class DatalinkResultsMixin(AdhocServiceResultsMixin):
                             'Could not retrieve datalinks for: {}'.format(
                                 ', '.join([_ for _ in remaining_ids])))
                     batch_size = len(current_ids)
-                id = current_ids.pop(0)
-                processed_ids.append(id)
-                remaining_ids.remove(id)
-                yield current_batch.clone_byid(id)
+                id1 = current_ids.pop(0)
+                processed_ids.append(id1)
+                remaining_ids.remove(id1)
+                yield current_batch.clone_byid(id1)
             elif row.access_format == DATALINK_MIME_TYPE:
                 yield DatalinkResults.from_result_url(row.getdataurl())
             else:

--- a/pyvo/dal/query.py
+++ b/pyvo/dal/query.py
@@ -26,10 +26,8 @@ import os
 import shutil
 import re
 import requests
-try:
-    from collections.abc import Mapping
-except ImportError:
-    from collections import Mapping
+from collections.abc import Mapping
+
 import collections
 
 from warnings import warn

--- a/pyvo/dal/sia2.py
+++ b/pyvo/dal/sia2.py
@@ -11,7 +11,7 @@ endpoint.
 """
 
 from astropy import units as u
-from astropy import time
+from astropy.time import Time
 
 from .query import DALResults, DALQuery, DALService, Record
 from .adhoc import DatalinkResultsMixin, AxisParamMixin, SodaRecordMixin,\
@@ -622,7 +622,7 @@ class ObsCoreRecord(SodaRecordMixin, DatalinkRecordMixin, Record,
         Date when the dataset was created
         """
         cd = self.get('obs_create_date', default=None)
-        return cd if not cd else time.Time(cd)
+        return cd if not cd else Time(cd)
 
     @property
     def obs_creator_name(self):
@@ -645,7 +645,7 @@ class ObsCoreRecord(SodaRecordMixin, DatalinkRecordMixin, Record,
         Observation release date
         """
         rt = self.get('obs_release_date', default=None, decode=True)
-        return rt if not rt else time.Time(rt)
+        return rt if not rt else Time(rt)
 
     @property
     def obs_publisher_did(self):
@@ -867,7 +867,7 @@ class ObsCoreRecord(SodaRecordMixin, DatalinkRecordMixin, Record,
         products result of the combination of multiple frames, min time must
         be the minimum of the start times
         """
-        return time.Time(self.get('t_min'), format='mjd')
+        return Time(self.get('t_min'), format='mjd')
 
     @property
     def t_max(self):
@@ -876,7 +876,7 @@ class ObsCoreRecord(SodaRecordMixin, DatalinkRecordMixin, Record,
         products result of the combination of multiple frames, t_max must
         be the maximum of the stop times
         """
-        return time.Time(self.get('t_min'), format='mjd')
+        return Time(self.get('t_min'), format='mjd')
 
     @property
     def t_exptime(self):

--- a/pyvo/dal/tap.py
+++ b/pyvo/dal/tap.py
@@ -612,10 +612,10 @@ class AsyncTAPJob:
         session : object
            optional session to use for network requests
         """
-        query = TAPQuery(
+        tapquery = TAPQuery(
             baseurl, query, mode="async", language=language, maxrec=maxrec,
             uploads=uploads, session=session, **keywords)
-        response = query.submit()
+        response = tapquery.submit()
         job = cls(response.url, session=session)
         return job
 

--- a/pyvo/dal/tests/conftest.py
+++ b/pyvo/dal/tests/conftest.py
@@ -25,5 +25,5 @@ class ContextAdapter(requests_mock.Adapter):
 def mocker():
     with requests_mock.Mocker(
         adapter=ContextAdapter(case_sensitive=True)
-    ) as mocker:
-        yield mocker
+    ) as mocker_ins:
+        yield mocker_ins

--- a/pyvo/dal/tests/make_testdata.py
+++ b/pyvo/dal/tests/make_testdata.py
@@ -17,83 +17,83 @@ def _votablefile():
 
     table['2'].meta['utype'] = 'foobar'
 
-    votablefile = VOTableFile.from_table(table)
+    votable_file = VOTableFile.from_table(table)
 
     info = Info(name='QUERY_STATUS', value='OK')
     info.content = 'OK'
-    votablefile.resources[0].infos.append(info)
+    votable_file.resources[0].infos.append(info)
 
-    return votablefile
+    return votable_file
 
 
 def votablefile():
-    votablefile = _votablefile()
-    return votablefile
+    votable_file = _votablefile()
+    return votable_file
 
 
 def votablefile_errorstatus():
-    votablefile = _votablefile()
+    votable_file = _votablefile()
 
     info = Info(name='QUERY_STATUS', value='ERROR')
     info.content = 'ERROR'
-    votablefile.resources[0].infos[0] = info
+    votable_file.resources[0].infos[0] = info
 
-    return votablefile
+    return votable_file
 
 
 def votablefile_overflowstatus():
-    votablefile = _votablefile()
+    votable_file = _votablefile()
 
     info_ok = Info(name='QUERY_STATUS', value='OK')
     info_overflow = Info(name='QUERY_STATUS', value='OVERFLOW')
-    votablefile.resources[0].infos[0] = info_ok
-    votablefile.resources[0].infos.append(info_overflow)
+    votable_file.resources[0].infos[0] = info_ok
+    votable_file.resources[0].infos.append(info_overflow)
 
-    return votablefile
+    return votable_file
 
 
 def votablefile_missingtable():
-    votablefile = _votablefile()
-    del votablefile.resources[0].tables[0]
-    return votablefile
+    votable_file = _votablefile()
+    del votable_file.resources[0].tables[0]
+    return votable_file
 
 
 def votablefile_missingresource():
-    votablefile = _votablefile()
-    del votablefile.resources[0]
-    return votablefile
+    votable_file = _votablefile()
+    del votable_file.resources[0]
+    return votable_file
 
 
 def votablefile_missingcolumns():
-    votablefile = _votablefile()
-    del votablefile.resources[0].tables[0].fields[:]
-    return votablefile
+    votable_file = _votablefile()
+    del votable_file.resources[0].tables[0].fields[:]
+    return votable_file
 
 
 def votablefile_firstresource():
-    votablefile = _votablefile()
-    votablefile.resources[0]._type = 'results'
-    return votablefile
+    votable_file = _votablefile()
+    votable_file.resources[0]._type = 'results'
+    return votable_file
 
 
 def votablefile_tableinfo():
-    votablefile = _votablefile()
-    votablefile.resources[0].tables[0].infos[:] = (
-        votablefile.resources[0].infos[:])
+    votable_file = _votablefile()
+    votable_file.resources[0].tables[0].infos[:] = (
+        votable_file.resources[0].infos[:])
 
-    del votablefile.resources[0].infos[:]
+    del votable_file.resources[0].infos[:]
 
-    return votablefile
+    return votable_file
 
 
 def votablefile_rootinfo():
-    votablefile = _votablefile()
-    votablefile.infos[:] = (
-        votablefile.resources[0].infos[:])
+    votable_file = _votablefile()
+    votable_file.infos[:] = (
+        votable_file.resources[0].infos[:])
 
-    del votablefile.resources[0].infos[:]
+    del votable_file.resources[0].infos[:]
 
-    return votablefile
+    return votable_file
 
 
 def votablefile_dataset():
@@ -114,13 +114,13 @@ def votablefile_dataset():
     table['dataurl'].meta['utype'] = 'Access.Reference'
     table['dataurl'].meta['ucd'] = 'meta.dataset;meta.ref.url'
 
-    votablefile = VOTableFile.from_table(table)
+    votable_file = VOTableFile.from_table(table)
 
     info = Info(name='QUERY_STATUS', value='OK')
     info.content = 'OK'
-    votablefile.resources[0].infos.append(info)
+    votable_file.resources[0].infos.append(info)
 
-    return votablefile
+    return votable_file
 
 
 def dataset_fits():

--- a/pyvo/dal/tests/test_datalink.py
+++ b/pyvo/dal/tests/test_datalink.py
@@ -108,18 +108,18 @@ def test_datalink():
     results = vo.spectrumsearch(
         'http://example.com/ssa_datalink', (30, 30))
 
-    datalink = next(results.iter_datalinks())
+    datalinks = next(results.iter_datalinks())
 
-    row = datalink[0]
+    row = datalinks[0]
     assert row.semantics == "#progenitor"
 
-    row = datalink[1]
+    row = datalinks[1]
     assert row.semantics == "#proc"
 
-    row = datalink[2]
+    row = datalinks[2]
     assert row.semantics == "#this"
 
-    row = datalink[3]
+    row = datalinks[3]
     assert row.semantics == "#preview"
 
 
@@ -142,47 +142,47 @@ def test_datalink_batch():
 @pytest.mark.filterwarnings("ignore::astropy.io.votable.exceptions.E02")
 class TestSemanticsRetrieval:
     def test_access_with_string(self):
-        datalink = DatalinkResults.from_result_url('http://example.com/proc')
-        res = [r["access_url"] for r in datalink.bysemantics("#this")]
+        datalinks = DatalinkResults.from_result_url('http://example.com/proc')
+        res = [r["access_url"] for r in datalinks.bysemantics("#this")]
         assert len(res) == 1
         assert res[0].endswith("eq010000ms/20100927.comb_avg.0001.fits.fz")
 
     def test_access_with_list(self):
-        datalink = DatalinkResults.from_result_url('http://example.com/proc')
+        datalinks = DatalinkResults.from_result_url('http://example.com/proc')
         res = [r["access_url"]
-               for r in datalink.bysemantics(["#this", "#preview-image"])]
+               for r in datalinks.bysemantics(["#this", "#preview-image"])]
         assert len(res) == 2
         assert res[0].endswith("eq010000ms/20100927.comb_avg.0001.fits.fz")
         assert res[1].endswith("20100927.comb_avg.0001.fits.fz?preview=True")
 
     def test_access_with_expansion(self):
-        datalink = DatalinkResults.from_result_url('http://example.com/proc')
+        datalinks = DatalinkResults.from_result_url('http://example.com/proc')
         res = [r["access_url"]
-               for r in datalink.bysemantics(["#this", "#preview"])]
+               for r in datalinks.bysemantics(["#this", "#preview"])]
         assert len(res) == 3
         assert res[0].endswith("eq010000ms/20100927.comb_avg.0001.fits.fz")
         assert res[1].endswith("20100927.comb_avg.0001.fits.fz?preview=True")
         assert res[2].endswith("http://dc.zah.uni-heidelberg.de/wider.dat")
 
     def test_access_without_expansion(self):
-        datalink = DatalinkResults.from_result_url('http://example.com/proc')
-        res = [r["access_url"] for r in datalink.bysemantics(
+        datalinks = DatalinkResults.from_result_url('http://example.com/proc')
+        res = [r["access_url"] for r in datalinks.bysemantics(
             ["#this", "#preview"], include_narrower=False)]
         assert len(res) == 2
         assert res[0].endswith("eq010000ms/20100927.comb_avg.0001.fits.fz")
         assert res[1].endswith("http://dc.zah.uni-heidelberg.de/wider.dat")
 
     def test_with_full_url(self):
-        datalink = DatalinkResults.from_result_url('http://example.com/proc')
+        datalinks = DatalinkResults.from_result_url('http://example.com/proc')
         res = [r["access_url"]
-               for r in datalink.bysemantics("urn:example:rdf/dlext#oracle")]
+               for r in datalinks.bysemantics("urn:example:rdf/dlext#oracle")]
         assert len(res) == 1
         assert res[0].endswith("when-will-it-be-back")
 
     def test_all_mixed(self):
-        datalink = DatalinkResults.from_result_url('http://example.com/proc')
+        datalinks = DatalinkResults.from_result_url('http://example.com/proc')
         res = [r["access_url"]
-               for r in datalink.bysemantics([
+               for r in datalinks.bysemantics([
                    "urn:example:rdf/dlext#oracle",
                    'http://www.ivoa.net/rdf/datalink/core#preview',
                    '#this',

--- a/pyvo/dal/tests/test_params.py
+++ b/pyvo/dal/tests/test_params.py
@@ -106,8 +106,8 @@ def proc_inf_ds(mocker):
 @pytest.mark.filterwarnings("ignore::astropy.io.votable.exceptions.E02")
 def test_find_param_by_keyword():
     datalink = DatalinkResults.from_result_url('http://example.com/proc')
-    proc = datalink[0]
-    input_params = {param.name: param for param in proc.input_params}
+    proc_dl = datalink[0]
+    input_params = {param.name: param for param in proc_dl.input_params}
 
     polygon_lower = find_param_by_keyword('polygon', input_params)
     polygon_upper = find_param_by_keyword('POLYGON', input_params)
@@ -125,8 +125,8 @@ def test_find_param_by_keyword():
 @pytest.mark.filterwarnings("ignore::astropy.io.votable.exceptions.E02")
 def test_serialize():
     datalink = DatalinkResults.from_result_url('http://example.com/proc')
-    proc = datalink[0]
-    input_params = {param.name: param for param in proc.input_params}
+    proc_dl = datalink[0]
+    input_params = {param.name: param for param in proc_dl.input_params}
 
     polygon_conv = get_converter(
         find_param_by_keyword('polygon', input_params))
@@ -152,8 +152,8 @@ def test_serialize():
 @pytest.mark.filterwarnings("ignore::astropy.io.votable.exceptions.E02")
 def test_serialize_exceptions():
     datalink = DatalinkResults.from_result_url('http://example.com/proc')
-    proc = datalink[0]
-    input_params = {param.name: param for param in proc.input_params}
+    proc_dl = datalink[0]
+    input_params = {param.name: param for param in proc_dl.input_params}
 
     polygon_conv = get_converter(
         find_param_by_keyword('polygon', input_params))
@@ -177,9 +177,9 @@ def test_serialize_exceptions():
 @pytest.mark.filterwarnings("ignore::astropy.io.votable.exceptions.E02")
 def test_units():
     datalink = DatalinkResults.from_result_url('http://example.com/proc_units')
-    proc = datalink[0]
+    proc_dl = datalink[0]
 
-    proc.process(band=(6000 * u.Angstrom, 80000 * u.Angstrom))
+    proc_dl.process(band=(6000 * u.Angstrom, 80000 * u.Angstrom))
 
 
 @pytest.mark.usefixtures('proc_inf')
@@ -187,9 +187,9 @@ def test_units():
 @pytest.mark.filterwarnings("ignore::astropy.io.votable.exceptions.E02")
 def test_inf():
     datalink = DatalinkResults.from_result_url('http://example.com/proc_inf')
-    proc = datalink[0]
+    proc_dl = datalink[0]
 
-    proc.process(band=(6000, +np.inf) * u.Angstrom)
+    proc_dl.process(band=(6000, +np.inf) * u.Angstrom)
 
 
 def test_dal_query_param():

--- a/pyvo/dal/tests/test_tap.py
+++ b/pyvo/dal/tests/test_tap.py
@@ -437,11 +437,11 @@ class TestTAPService:
     @pytest.mark.usefixtures('tables')
     def test_tables(self):
         service = TAPService('http://example.com/tap')
-        tables = service.tables
+        vositables = service.tables
 
-        assert list(tables.keys()) == ['test.table1', 'test.table2']
+        assert list(vositables.keys()) == ['test.table1', 'test.table2']
 
-        table1, table2 = list(tables)
+        table1, table2 = list(vositables)
         self._test_tables(table1, table2)
 
     def _test_examples(self, exampleXHTML):
@@ -450,9 +450,9 @@ class TestTAPService:
     @pytest.mark.usefixtures('examples')
     def test_examples(self):
         service = TAPService('http://example.com/tap')
-        examples = service.examples
+        service_examples = service.examples
 
-        self._test_examples(examples)
+        self._test_examples(service_examples)
 
     @pytest.mark.usefixtures('capabilities')
     def test_maxrec(self):

--- a/pyvo/io/uws/endpoint.py
+++ b/pyvo/io/uws/endpoint.py
@@ -115,8 +115,8 @@ class JobFile(JobSummary):
         return super().parse(iterator, config)
 
     def to_xml(self, fd):
-        with convert_to_writable_filelike(fd) as fd:
-            w = XMLWriter(fd)
+        with convert_to_writable_filelike(fd) as _fd:
+            w = XMLWriter(_fd)
 
             xml_header = (
                 '<?xml version="1.0" encoding="utf-8"?>\n'

--- a/pyvo/io/vosi/tests/test_capabilities.py
+++ b/pyvo/io/vosi/tests/test_capabilities.py
@@ -16,8 +16,8 @@ from pyvo.io.vosi.exceptions import W06
 from astropy.utils.data import get_pkg_data_filename
 
 
-@pytest.fixture()
-def parsed_caps():
+@pytest.fixture(name='parsed_caps')
+def _parsed_caps():
     return vosi.parse_capabilities(get_pkg_data_filename(
         "data/capabilities.xml"))
 
@@ -175,8 +175,8 @@ class TestInterface:
                 == 'QUERY=SELECT%20*%20FROM%20tap_schema.tables&LANG=ADQL')
 
 
-@pytest.fixture()
-def cap_with_free_prefix(recwarn):
+@pytest.fixture(name='cap_with_free_prefix')
+def _cap_with_free_prefix(recwarn):
     caps = vosi.parse_capabilities(io.BytesIO(b"""
 <ns2:capabilities xmlns:ns2="http://www.ivoa.net/xml/VOSICapabilities/v1.0">
   <capability

--- a/pyvo/registry/rtcons.py
+++ b/pyvo/registry/rtcons.py
@@ -12,7 +12,7 @@ classes.
 
 import datetime
 
-from astropy import units
+from astropy import units as u
 from astropy import constants
 from astropy.coordinates import SkyCoord
 import numpy
@@ -590,16 +590,17 @@ class Spectral(Constraint):
 
     To find resources covering the messenger particle energy 5 eV::
 
+        >>> from astropy import units as u
         >>> from pyvo import registry
-        >>> resources =  registry.Spectral(5*units.eV)
+        >>> resources =  registry.Spectral(5*u.eV)
 
     To find resources overlapping the band between 5000 and 6000 Ångström::
 
-        >>> resources =  registry.Spectral((5000*units.Angstrom, 6000*units.Angstrom))
+        >>> resources =  registry.Spectral((5000*u.Angstrom, 6000*u.Angstrom))
 
     To find resources having data in the FM band::
 
-        >>> resources =  registry.Spectral((88*units.MHz, 102*units.MHz))
+        >>> resources =  registry.Spectral((88*u.MHz, 102*u.MHz))
     """
     _keyword = "spectral"
     _extra_tables = ["rr.stc_spectral"]
@@ -640,20 +641,20 @@ class Spectral(Constraint):
 
         try:
             # is it an energy?
-            return quant.to(units.Joule).value
-        except units.UnitConversionError:
+            return quant.to(u.Joule).value
+        except u.UnitConversionError:
             pass  # try next
 
         try:
             # is it a wavelength?
-            return (constants.h * constants.c / quant.to(units.m)).value
-        except units.UnitConversionError:
+            return (constants.h * constants.c / quant.to(u.m)).value
+        except u.UnitConversionError:
             pass  # try next
 
         try:
             # is it a frequency?
-            return (constants.h * quant.to(units.Hz)).value
-        except units.UnitConversionError:
+            return (constants.h * quant.to(u.Hz)).value
+        except u.UnitConversionError:
             pass  # fall through to give up
 
         raise ValueError(f"Cannot make a spectral quantity out of {quant}")

--- a/pyvo/registry/tests/conftest.py
+++ b/pyvo/registry/tests/conftest.py
@@ -25,5 +25,5 @@ class ContextAdapter(requests_mock.Adapter):
 def mocker():
     with requests_mock.Mocker(
         adapter=ContextAdapter(case_sensitive=True)
-    ) as mocker:
-        yield mocker
+    ) as mocker_ins:
+        yield mocker_ins

--- a/pyvo/registry/tests/test_regtap.py
+++ b/pyvo/registry/tests/test_regtap.py
@@ -28,8 +28,8 @@ get_pkg_data_contents = partial(
     get_pkg_data_contents, package=__package__, encoding='binary')
 
 
-@pytest.fixture()
-def capabilities(mocker):
+@pytest.fixture(name='capabilities')
+def _capabilities(mocker):
     def callback(request, context):
         return get_pkg_data_contents('data/capabilities.xml')
 
@@ -49,8 +49,8 @@ def capabilities(mocker):
 # 		"QUERY": regtap.get_RegTAP_query(keywords="pulsar", ucd=["pos.distance"])}).content)
 
 
-@pytest.fixture()
-def regtap_pulsar_distance_response(mocker):
+@pytest.fixture(name='regtap_pulsar_distance_response')
+def _regtap_pulsar_distance_response(mocker):
     with mocker.register_uri(
         'POST', REGISTRY_BASEURL + '/sync',
             content=get_pkg_data_contents('data/regtap.xml')) as matcher:
@@ -176,8 +176,8 @@ def aux_fixture(mocker):
         yield matcher
 
 
-@pytest.fixture()
-def multi_interface_fixture(mocker):
+@pytest.fixture(name='multi_interface_fixture')
+def _multi_interface_fixture(mocker):
     # to update this, run
     # import requests
     # from pyvo.registry import regtap
@@ -194,8 +194,8 @@ def multi_interface_fixture(mocker):
         yield matcher
 
 
-@pytest.fixture()
-def flash_service(multi_interface_fixture):
+@pytest.fixture(name='flash_service')
+def _flash_service(multi_interface_fixture):
     return regtap.search(
         ivoid="ivo://org.gavo.dc/flashheros/q/ssa")[0]
 
@@ -363,8 +363,8 @@ def test_to_table(multi_interface_fixture, capabilities):
             == 'datalink#links-1.0, soda#sync-1.0, ssa, tap#aux, web')
 
 
-@pytest.fixture()
-def rt_pulsar_distance(regtap_pulsar_distance_response, capabilities):
+@pytest.fixture(name='rt_pulsar_distance')
+def _rt_pulsar_distance(regtap_pulsar_distance_response, capabilities):
     return regsearch(keywords="pulsar", ucd=["pos.distance"])
 
 
@@ -715,8 +715,8 @@ class TestExtraResourceMethods:
 # I think we should can the network responses involved in the following;
 # the stuff might change upstream any time and then break our unit tests.
 @pytest.mark.remote_data
-@pytest.fixture()
-def flash_tables():
+@pytest.fixture(name='flash_tables')
+def _flash_tables():
     rsc = _makeRegistryRecord(
         {"ivoid": "ivo://org.gavo.dc/flashheros/q/ssa"})
     return rsc.get_tables()

--- a/pyvo/registry/tests/test_rtcons.py
+++ b/pyvo/registry/tests/test_rtcons.py
@@ -6,8 +6,8 @@ Tests for pyvo.registry.rtcons, i.e. RegTAP constraints and query building.
 
 import datetime
 
-from astropy import time
-from astropy import units
+from astropy.time import Time
+from astropy import units as u
 from astropy.coordinates import SkyCoord
 import numpy
 import pytest
@@ -205,12 +205,12 @@ class TestSpatialConstraint:
         assert cons.get_search_condition() == "1 = CONTAINS(MOC('0/1-3 3/'), coverage)"
 
     def test_SkyCoord(self):
-        cons = registry.Spatial(SkyCoord(3 * units.deg, -30 * units.deg))
+        cons = registry.Spatial(SkyCoord(3 * u.deg, -30 * u.deg))
         assert cons.get_search_condition() == "1 = CONTAINS(MOC(6, POINT(3.0, -30.0)), coverage)"
         assert cons._extra_tables == ["rr.stc_spatial"]
 
     def test_SkyCoord_Circle(self):
-        cons = registry.Spatial((SkyCoord(3 * units.deg, -30 * units.deg), 3))
+        cons = registry.Spatial((SkyCoord(3 * u.deg, -30 * u.deg), 3))
         assert cons.get_search_condition() == "1 = CONTAINS(MOC(6, CIRCLE(3.0, -30.0, 3)), coverage)"
         assert cons._extra_tables == ["rr.stc_spatial"]
 
@@ -224,31 +224,31 @@ class TestSpectralConstraint:
         assert cons.get_search_condition() == "1e-19 BETWEEN spectral_start AND spectral_end"
 
     def test_energy_eV(self):
-        cons = registry.Spectral(5 * units.eV)
+        cons = registry.Spectral(5 * u.eV)
         assert cons.get_search_condition() == "8.01088317e-19 BETWEEN spectral_start AND spectral_end"
 
     def test_energy_interval(self):
-        cons = registry.Spectral((1e-10 * units.erg, 2e-10 * units.erg))
+        cons = registry.Spectral((1e-10 * u.erg, 2e-10 * u.erg))
         assert cons.get_search_condition() == (
             "1 = ivo_interval_overlaps(spectral_start, spectral_end, 1e-17, 2e-17)")
 
     def test_wavelength(self):
-        cons = registry.Spectral(5000 * units.Angstrom)
+        cons = registry.Spectral(5000 * u.Angstrom)
         assert cons.get_search_condition() == "3.9728917142978567e-19 BETWEEN spectral_start AND spectral_end"
 
     def test_wavelength_interval(self):
-        cons = registry.Spectral((20 * units.cm, 22 * units.cm))
+        cons = registry.Spectral((20 * u.cm, 22 * u.cm))
         assert (cons.get_search_condition()
                 == "1 = ivo_interval_overlaps(spectral_start, spectral_end,"
                 " 9.932229285744642e-25, 9.029299350676949e-25)")
 
     def test_frequency(self):
-        cons = registry.Spectral(2 * units.GHz)
+        cons = registry.Spectral(2 * u.GHz)
         assert (cons.get_search_condition()
                 == "1.32521403e-24 BETWEEN spectral_start AND spectral_end")
 
     def test_frequency_interval(self):
-        cons = registry.Spectral((88 * units.MHz, 102 * units.MHz))
+        cons = registry.Spectral((88 * u.MHz, 102 * u.MHz))
         assert (cons.get_search_condition()
                 == "1 = ivo_interval_overlaps(spectral_start, spectral_end,"
                 " 5.830941732e-26, 6.758591553e-26)")
@@ -261,19 +261,19 @@ class TestTemporalConstraint:
                 == "1 = ivo_interval_overlaps(time_start, time_end, 54130, 54200)")
 
     def test_single_time(self):
-        cons = registry.Temporal(time.Time('2022-01-10'))
+        cons = registry.Temporal(Time('2022-01-10'))
         assert (cons.get_search_condition()
                 == "59589.0 BETWEEN time_start AND time_end")
 
     def test_time_interval(self):
-        cons = registry.Temporal((time.Time(2459000, format='jd'),
-                                  time.Time(59002, format='mjd')))
+        cons = registry.Temporal((Time(2459000, format='jd'),
+                                  Time(59002, format='mjd')))
         assert (cons.get_search_condition()
                 == "1 = ivo_interval_overlaps(time_start, time_end, 58999.5, 59002.0)")
 
     def test_multi_times_rejected(self):
         with pytest.raises(ValueError) as excinfo:
-            registry.Temporal(time.Time(['1999-01-01', '2010-01-01']))
+            registry.Temporal(Time(['1999-01-01', '2010-01-01']))
         assert (str(excinfo.value) == "RegTAP time constraints must"
                 " be made from single time instants.")
 

--- a/pyvo/utils/tests/test_prototype.py
+++ b/pyvo/utils/tests/test_prototype.py
@@ -7,8 +7,8 @@ from pyvo.utils import prototype_feature, activate_features, prototype
 from pyvo.utils.prototype import PrototypeError, PrototypeWarning, Feature
 
 
-@pytest.fixture
-def prototype_function(features):
+@pytest.fixture(name='prototype_function')
+def _prototype_function(features):
     features({
         'my-feature': Feature('my-feature', url='http://somewhere/else')
     })
@@ -20,8 +20,8 @@ def prototype_function(features):
     return i_am_prototype
 
 
-@pytest.fixture
-def features():
+@pytest.fixture(name='features')
+def _features():
     previous_available = deepcopy(prototype.features)
     prototype.features.clear()
 

--- a/pyvo/utils/xml/elements.py
+++ b/pyvo/utils/xml/elements.py
@@ -262,7 +262,9 @@ def make_add_simplecontent(
     This means elements with no child elements.
     If exc_class is given, warn or raise if element was already set.
     """
-    def add_simplecontent(iterator, tag, data, config, pos):
+    def add_simplecontent(iterator, tag_ignored, data_ignored, config, pos_ignored):
+        # Ignored parameters are kept in the API signature to be compatible
+        # with other functions.
         for start, tag, data, pos in iterator:
             if not start and tag == element_name:
                 attr = getattr(self, attr_name)


### PR DESCRIPTION
Cleanup redefining outer-scope variables. I've also added consistency in imports from astropy as some of them were causing these redefinitions.


There are still a few redefined-builtin cases, but fixing those would involve API modifications (as it involves arguments named e.g. `format`, `range`, `id`)


closes #390 


(there is still a ~2000 line long pylint report, most of which are cosmetic, rather than functional suggestions, but some may touch real issues (e.g. pyvo/dal/tests/test_sia2_remote.py lists all attributes without any asserts, so those lines would trick tools like coverage to think the attributes are covered by tests).