### PR TITLE
ENH: registry to find SIA v2 services

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,8 @@
   ``SIA2_PARAMETERS_DESC``. The old names now issue an
   ``AstropyDeprecationWarning``. [#419]
 
+- Registry search now finds SIA v2 services. [#422]
+
 
 1.4 (2022-09-26)
 ================

--- a/pyvo/registry/regtap.py
+++ b/pyvo/registry/regtap.py
@@ -25,7 +25,7 @@ from astropy import table
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
 from . import rtcons
-from ..dal import scs, sia, ssa, sla, tap, query as dalq
+from ..dal import scs, sia, sia2, ssa, sla, tap, query as dalq
 from ..io.vosi import vodataservice
 from ..utils.formatting import para_format_desc
 
@@ -284,6 +284,7 @@ class Interface:
     service_for_standardid = {
         "ivo://ivoa.net/std/conesearch": scs.SCSService,
         "ivo://ivoa.net/std/sia": sia.SIAService,
+        "ivo://ivoa.net/std/sia#query-2.0": sia2.SIA2Service,
         "ivo://ivoa.net/std/ssa": ssa.SSAService,
         "ivo://ivoa.net/std/sla": sla.SLAService,
         "ivo://ivoa.net/std/tap": tap.TAPService}
@@ -874,7 +875,7 @@ def ivoid2service(ivoid, servicetype=None):
     return service(s) for a given IVOID.
 
     The servicetype option specifies the kind of service requested
-    (conesearch, sia, ssa, slap, or tap).  By default, if none is
+    (conesearch, sia, sia2, ssa, slap, or tap).  By default, if none is
     given, a list of all matching services is returned.
 
     """

--- a/pyvo/registry/rtcons.py
+++ b/pyvo/registry/rtcons.py
@@ -35,6 +35,7 @@ SERVICE_TYPE_MAP = dict((k, "ivo://ivoa.net/std/" + v)
                         for k, v in [
     ("image", "sia"),
     ("sia", "sia"),
+    ("sia2", "sia#query-2.0"),
     ("spectrum", "ssa"),
     ("ssap", "ssa"),
     ("ssa", "ssa"),
@@ -257,6 +258,7 @@ class Servicetype(Constraint):
     * ``image`` (image services; at this point equivalent to sia, but
       scheduled to include sia2, too)
     * ``sia`` (SIAP version 1 services)
+    * ``sia2`` (SIAP version 2 services)
     * ``spectrum``, ``ssa``, ``ssap`` (all synonymous for spectral
       services, prefer ``spectrum``)
     * ``scs``, ``conesearch`` (synonymous for cone search services, prefer

--- a/pyvo/registry/tests/test_regtap.py
+++ b/pyvo/registry/tests/test_regtap.py
@@ -776,3 +776,15 @@ class TestGetTables:
 
         assert (getflashcol("ssa_fluxcalib").description
                 == "Type of flux calibration")
+
+
+@pytest.mark.remote_data
+def test_sia_registry_searches():
+    # SIA2 services, e.g. Spitzer SEIP were originally not found by the registry search
+    image_services_v1 = regsearch(servicetype='sia')
+    image_services_v2 = regsearch(servicetype='sia2')
+
+    assert image_services_v1 != image_services_v2
+
+    assert len([s.ivoid for s in image_services_v2 if 'spitzer/images/seip' in s.ivoid]) > 0
+    assert len([s.ivoid for s in image_services_v1 if 'spitzer/images/seip' in s.ivoid]) == 0

--- a/pyvo/registry/tests/test_rtcons.py
+++ b/pyvo/registry/tests/test_rtcons.py
@@ -114,7 +114,7 @@ class TestServicetypeConstraint:
             rtcons.Servicetype("junk")
         assert str(excinfo.value) == ("Service type junk is neither"
                                       " a full standard URI nor one of the bespoke identifiers"
-                                      " image, sia, spectrum, ssap, ssa, scs, conesearch, line, slap,"
+                                      " image, sia, sia2, spectrum, ssap, ssa, scs, conesearch, line, slap,"
                                       " table, tap")
 
     def test_legacy_term(self):


### PR DESCRIPTION
So, this does the bare minimum, e.g. making it possible to search for SIA v2 services (the tricky part was to figure out the case sensitivity for the spelling of the service type, anyway).

The missing part from this PR is to make `servicetype='image'` to return both SIA and SIA2 services. As currently there is a one-on-one mapping in SERVICE_TYPE_MAP, I'm waiting for input if you have suggestions on how to resolve this without going brute force and start looping through them if there are multiple values provided.

```
In [1]: import pyvo

In [2]: image_services_v2 = pyvo.regsearch(servicetype='sia2')

In [3]: image_services_v1 = pyvo.regsearch(servicetype='sia')

In [4]: len([s for s in image_services_v1 if 'irsa' in s.ivoid])
Out[4]: 33

In [5]: len([s for s in image_services_v2 if 'irsa' in s.ivoid])
Out[5]: 58
```
Closes https://github.com/astropy/pyvo/issues/397