### PR TITLE
Making SIA2 discoverable as intended by the standard.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,7 +18,7 @@
   ``SIA2_PARAMETERS_DESC``. The old names now issue an
   ``AstropyDeprecationWarning``. [#419]
 
-- Registry search now finds SIA v2 services. [#422]
+- Registry search now finds SIA v2 services. [#422, #428]
 
 
 1.4 (2022-09-26)

--- a/pyvo/dal/sia2.py
+++ b/pyvo/dal/sia2.py
@@ -150,6 +150,11 @@ def _tolist(value):
 class SIA2Service(DALService, AvailabilityMixin, CapabilityMixin):
     """
     a representation of an SIA2 service
+
+    Note that within pyVO, SIA2 services are associated with the
+    (non-existing) standard id ivo://ivoa.net/std/sia2 rather than
+    ivo://ivoa.net/std/sia#query-2.0 as in the standard; users should
+    generally not notice that, though.
     """
 
     def __init__(self, baseurl, session=None):

--- a/pyvo/registry/tests/test_regtap.py
+++ b/pyvo/registry/tests/test_regtap.py
@@ -638,6 +638,7 @@ class TestInterfaceRejection:
 def test_maxrec():
     with pytest.warns(DALOverflowWarning) as w:
         _ = regsearch(servicetype="tap", maxrec=1)
+    assert len(w) == 1
     assert str(w[0].message).startswith("Partial result set.")
 
 

--- a/pyvo/registry/tests/test_rtcons.py
+++ b/pyvo/registry/tests/test_rtcons.py
@@ -114,12 +114,24 @@ class TestServicetypeConstraint:
             rtcons.Servicetype("junk")
         assert str(excinfo.value) == ("Service type junk is neither"
                                       " a full standard URI nor one of the bespoke identifiers"
-                                      " image, sia, sia2, spectrum, ssap, ssa, scs, conesearch, line, slap,"
-                                      " table, tap")
+                                      " image, sia, spectrum, ssap, ssa, scs, conesearch, line, slap,"
+                                      " table, tap, sia2")
 
     def test_legacy_term(self):
         assert (rtcons.Servicetype("conesearch").get_search_condition()
                 == "standard_id IN ('ivo://ivoa.net/std/conesearch')")
+
+    def test_sia2(self):
+        assert (rtcons.Servicetype("conesearch", "sia2").get_search_condition()
+                == ("standard_id IN ('ivo://ivoa.net/std/conesearch')"
+                    " OR standard_id like 'ivo://ivoa.net/std/sia#query-2.%'"))
+
+    def test_sia2_aux(self):
+        constraint = rtcons.Servicetype("conesearch", "sia2").include_auxiliary_services()
+        assert (constraint.get_search_condition()
+                == ("standard_id IN ('ivo://ivoa.net/std/conesearch', 'ivo://ivoa.net/std/conesearch#aux')"
+                    " OR standard_id like 'ivo://ivoa.net/std/sia#query-2.%'"
+                    " OR standard_id like 'ivo://ivoa.net/std/sia#query-aux-2.%'"))
 
 
 @pytest.mark.usefixtures('messenger_vocabulary')

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ max-line-length = 110
 max-doc-length = 110
 exclude = __init__.py, conf.py, setup.py, version.py, conftest.py
 # W503 line break before operator
-ignore = W503
+ignore = W503,E128,E131
 
 
 [pycodestyle]


### PR DESCRIPTION
This introduces a new sort of syntax for the Servicetype constraint, as the "new-style" standard ids must be matched ignoring the minor version. *If* further standards follow SIA 2's pattern, we'll have to think about refactoring this.  For now, I'll argue for returning to the previous pattern.

With SIA2, there's the additional problem that the authors re-used the SIA1 main identifier.  That's a mortal sin as far as our standard id -> service class resolution is concerned.  We hence fix this on digesting the query results coming from the registry.  I'm pretty sure nothing like this will happen again.  Let's consider it a fluke on SIA2.

This commit as an integration test-type test at the end of test_regtap. Perhaps we should move this to test_sia2_remote and replace one of the rather slow tests there?  I'd like to leave that call to someone else.