### PR TITLE
UWS error messages now sit on errorsummary.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,10 @@
 
 - Registry search now finds SIA v2 services. [#422]
 
+- Error messages from uws jobs are now in job.errorsummary.message
+  rather than job.message (where one wouldn't expect them given the UWS
+  schema). [#432]
+
 
 1.4 (2022-09-26)
 ================

--- a/pyvo/dal/tap.py
+++ b/pyvo/dal/tap.py
@@ -951,7 +951,10 @@ class AsyncTAPJob:
             if theres an error
         """
         if self.phase in {"ERROR", "ABORTED"}:
-            msg = self._job._message if self._job and self._job._message else ''
+            msg = ""
+            if self._job and self._job.errorsummary:
+                msg = self._job.errorsummary.message.content
+            msg = msg or "<No useful error from server>"
             raise DALQueryError("Query Error: " + msg, self.url)
 
     def fetch_result(self):

--- a/pyvo/dal/tests/test_tap.py
+++ b/pyvo/dal/tests/test_tap.py
@@ -17,7 +17,7 @@ from pyvo.dal.tap import escape, search, AsyncTAPJob, TAPService
 from pyvo.dal import DALQueryError
 
 from pyvo.io.uws import JobFile
-from pyvo.io.uws.tree import Parameter, Result
+from pyvo.io.uws.tree import Parameter, Result, ErrorSummary, Message
 from pyvo.utils import prototype
 
 from astropy.time import Time, TimeDelta
@@ -180,7 +180,10 @@ class MockAsyncTAPServer:
         job.jobid = newid
         if 'test_erroneus_submit.non_existent' in request.text:
             job.phase = 'ERROR'
-            job.message = 'test_erroneus_submit.non_existent not found'
+            job._errorsummary = ErrorSummary()
+            job.errorsummary.message = Message()
+            job.errorsummary.message.content =\
+                'test_erroneus_submit.non_existent not found'
         else:
             job.phase = 'PENDING'
         job.quote = Time.now() + TimeDelta(1, format='sec')

--- a/pyvo/io/uws/tests/test_job.py
+++ b/pyvo/io/uws/tests/test_job.py
@@ -3,6 +3,7 @@
 """
 Tests for pyvo.io.vosi
 """
+
 import pyvo.io.uws as uws
 
 from astropy.utils.data import get_pkg_data_filename
@@ -30,4 +31,4 @@ class TestJob:
 
         assert not job.errorsummary.has_detail
         assert job.errorsummary.type_ == 'fatal'
-        assert job.message == 'We have problem'
+        assert job.errorsummary.message.content == 'We have problem'

--- a/pyvo/io/uws/tree.py
+++ b/pyvo/io/uws/tree.py
@@ -265,17 +265,9 @@ class JobSummary(Element):
 
     @errorsummary.adder
     def errorsummary(self, iterator, tag, data, config, pos):
-        self._errorsummary = ErrorSummary(config, pos,
-                                          'errorSummary', **data)
-
-    @uwselement(plain=True)
-    def message(self):
-        """the error message"""
-        return self._message
-
-    @message.setter
-    def message(self, message):
-        self._message = message
+        res = ErrorSummary(config, pos, 'errorSummary', **data)
+        res.parse(iterator, config)
+        self._errorsummary = res
 
 
 class Jobs(HomogeneousList, UWSElement):


### PR DESCRIPTION
Previously, they were parsed into job.message, which was probably unintended, as there were message attributes on errorsummary that just were never filled because errorsummary would not parse its children itself.

The alternative would be to preserve the previous behaviour, where message sits on the job element; but that's against the UWS schema, and if we did that, we'd have to take away the extra attributes on errorsummary (and revert the change to raise_if_error in the TAPJob).

If we do it like this, that would fix Bug #431.