### PR TITLE
DOC: Improvements on doc for TAP service and other minor changes

### DIFF
--- a/docs/dal/index.rst
+++ b/docs/dal/index.rst
@@ -414,6 +414,7 @@ Finally, tables and their content can be removed:
 
     >>> tap_service.remove_table(name='test_schema.test_table')
 
+For further information about the service's parameters, see :py:class:`~pyvo.dal.TAPService`.
 
 .. _pyvo-sia:
 
@@ -432,7 +433,7 @@ Simple Image Access
     referred to as datacubes, cube or image cube datasets and may be considered examples 
     of hypercube or n-cube data. PyVO supports both versions of SIA.
 
-    -- `Simple IMage Access <https://www.ivoa.net/documents/SIA/>`_
+    -- `Simple Image Access <https://www.ivoa.net/documents/SIA/>`_
 
 Basic queries are done with the ``pos`` and ``size`` parameters described in
 :ref:`pyvo-astro-params`, with ``size`` being the rectangular region around
@@ -474,6 +475,8 @@ Available values:
 
 This service exposes the :ref:`verbosity <pyvo-verbosity>` parameter
 
+For further information about the service's parameters, see :py:class:`~pyvo.dal.SIAService`.
+
 .. _pyvo-ssa:
 
 Simple Spectrum Access
@@ -507,6 +510,7 @@ SSA queries can be further constrained by the ``band`` and ``time`` parameters.
     ...     time=time, band=Quantity((1e-13, 1e-12), unit="meter")
     ... )
 
+For further information about the service's parameters, see :py:class:`~pyvo.dal.SSAService`.
 
 .. _pyvo-scs:
 
@@ -533,7 +537,8 @@ within a circular region on the sky defined by the parameters ``pos``
     >>> scs_srv = vo.dal.SCSService('http://dc.zah.uni-heidelberg.de/arihip/q/cone/scs.xml')
     >>> scs_results = scs_srv.search(pos=pos, radius=size)
 
-This service exposes the :ref:`verbosity <pyvo-verbosity>` parameter
+This service exposes the :ref:`verbosity <pyvo-verbosity>` parameter.
+For further information about the service's parameters, see :py:class:`~pyvo.dal.SCSService`.
 
 .. _pyvo-slap:
 
@@ -552,6 +557,7 @@ Simple Line Access
 This service let you query for spectral lines in a certain ``wavelength``
 range. The unit of the values is meters, but any unit may be specified using
 `~astropy.units.Quantity`.
+For further information about the service's parameters, see :py:class:`~pyvo.dal.SLAService`.
 
 Jobs
 ====
@@ -569,7 +575,7 @@ to run several queries in parallel from one script.
 .. note::
     It is good practice to test the query with a maxrec constraint first.
 
-When you invoke ``submit job`` you will get a job object.
+When you invoke ``submit_job`` you will get a job object.
 
 .. doctest-remote-data::
 

--- a/docs/dal/index.rst
+++ b/docs/dal/index.rst
@@ -176,11 +176,12 @@ mean G-band magnitude between 19 - 20:
     2180349528028140800  310.5233961869657   50.3486391034819            19.0
 
 If you know a TAP service's access URL, you can directly pass it to
-:py:class:`~pyvo.dal.TAPService` to obtain a service object (see
-:ref:`pyvo.registry <pyvo-registry>` for when you do not know this access URL). 
-Here we use the `GAVO DC TAP <http://dc.g-vo.org/tap>`_ service to demonstrate. 
-To perform a query using ADQL, the ``search()`` method is used (note 
-that this method performs the synchronous query by default). 
+:py:class:`~pyvo.dal.TAPService` to obtain a service object. 
+Sometimes, such URLs are published in papers or passed around through
+other channels. Most commonly, you will discover them in the VO 
+registry (cf. :ref:`pyvo.registry<pyvo-registry>`).
+
+To perform a query using ADQL, the ``search()`` method is used. 
 TAPService instances have several methods to inspect the metadata
 of the service - in particular, what tables with what columns are
 available - discussed below.  Note that for exploratory query

--- a/docs/dal/index.rst
+++ b/docs/dal/index.rst
@@ -151,22 +151,28 @@ Getting started
 
 Let's start with a quick example using PyVO to perform a TAP/ADQL query.
 For instance we want to retrieve 5 objects from the GAIA DR3 database, 
-showing their id, position and mean G-band magnitude.
+showing their id, position and mean G-band magnitude between 19 - 20.
 
 .. doctest-remote-data::
     >>> import pyvo as vo
     >>> tap_service = vo.dal.TAPservice("http://dc.g-vo.org/tap")
-    >>> tap_service.search("SELECT TOP 5 source_id, ra, dec, phot_g_mean_mag FROM gaia.dr3lite")
+    >>> tap_service.search(
+            """ SELECT TOP 5 
+            source_id, ra, dec, phot_g_mean_mag 
+            FROM gaia.dr3lite
+            WHERE phot_g_mean_mag BETWEEN 19 AND 20
+            ORDER BY phot_g_mean_mag
+            """)
     <Table length=5>
         source_id              ra                dec         phot_g_mean_mag
                             deg                deg               mag      
         int64             float64            float64           float32    
     ------------------- ------------------ ------------------ ---------------
-    2165092154924732928 319.82640223047326 49.371803949190934       19.633097
-    2165092159226514688  319.8317684883249  49.37350866387902       20.997982
-    2165092159225251200   319.836141859182  49.37380423843978       20.928877
-    2165092159226252416  319.8357919050182  49.37715751142902       20.565428
-    2165092159224999296 319.82331035942707  49.37621068543158       20.367767
+    2162809607452221440 315.96596187101636 45.945474015208106            19.0
+    2000273643933171456  337.1829026565382   50.7218533537033            19.0
+    2171530448339798784  323.9151025188806  51.27690705826792            19.0
+    2171810342771336704 323.25913736080776  51.94305655940998            19.0
+    2180349528028140800  310.5233961869657   50.3486391034819            19.0
 
 Using the class :py:class:`~pyvo.dal.TAPService` we can instantiate an available 
 TAP service by inserting their URL. Here we use the 
@@ -193,7 +199,7 @@ the results. Since the next query can only start once the previous one
 is done. In this case it is advantageous to use the asynchronous 
 query instead. This allows you to assign multiple queries to the 
 TAP server and returns controls inmmediately with a promise to execute 
-all the queries and notify you the result later.
+all the queries and notify you the result later. 
 
 The asynchronous query is indeed slower but it is convenient when you 
 have to run many queries since you don't have to wait for each query 
@@ -203,6 +209,10 @@ faster and often used for one simpler query. It depends on the situation.
 Note that the ``search()`` method performs the synchronous query by default.
 To specify the query mode, you can use either ``run_sync()`` for 
 synchronous query or ``run_async()`` for asynchronous query.
+
+#
+Here explain how run_async() works witn submit_jobs etc.. 
+#
 
 Query limit
 ^^^^^^^^^^^

--- a/docs/dal/index.rst
+++ b/docs/dal/index.rst
@@ -146,8 +146,6 @@ Table Access Protocol
 
     -- `Table Access Protocol <https://www.ivoa.net/documents/TAP/>`_
 
-Getting started
-^^^^^^^^^^^^^^^
 
 Consider the following example for using TAP and ADQL, retrieving 5
 objects from the GAIA DR3 database, showing their id, position and
@@ -158,12 +156,12 @@ mean G-band magnitude between 19 - 20:
     >>> import pyvo as vo
     >>> tap_service = vo.dal.TAPService("http://dc.g-vo.org/tap")
     >>> tap_service.search(
-    >>>        """ SELECT TOP 5 
-    >>>        source_id, ra, dec, phot_g_mean_mag 
-    >>>        FROM gaia.dr3lite
-    >>>        WHERE phot_g_mean_mag BETWEEN 19 AND 20
-    >>>        ORDER BY phot_g_mean_mag
-    >>>        """)
+    ...        """ SELECT TOP 5 
+    ...        source_id, ra, dec, phot_g_mean_mag 
+    ...        FROM gaia.dr3lite
+    ...        WHERE phot_g_mean_mag BETWEEN 19 AND 20
+    ...        ORDER BY phot_g_mean_mag
+    ...        """)
     <Table length=5>
         source_id              ra                dec         phot_g_mean_mag
                             deg                deg               mag      
@@ -184,11 +182,7 @@ registry (cf. :ref:`pyvo.registry<pyvo-registry>`).
 To perform a query using ADQL, the ``search()`` method is used. 
 TAPService instances have several methods to inspect the metadata
 of the service - in particular, what tables with what columns are
-available - discussed below.  Note that for exploratory query
-construction, you can also use interactive TAP clients such as
-TOPCAT_, which include table browsers.
-
-.. _TOPCAT: http://www.star.bris.ac.uk/~mbt/topcat/ 
+available - discussed below.
 
 To get an idea of how to write queries in ADQL, have a look at
 `GAVO's ADQL course`_; it is basically a standardised subset of SQL
@@ -236,8 +230,7 @@ starting it, it creates a new object :py:class:`~pyvo.dal.AsyncTAPJob`.
     >>> job.url
     (...)
 
-The job URL mentioned before is available in the ``url`` attribute;
-you can use that URL later to resume the job even from clients like TOPCAT. 
+The job URL mentioned before is available in the ``url`` attribute. 
 Clicking on the URL leads you to the query itself, where you can check 
 the status(phase) of the query and decide to run, modify or delete 
 the job. You can also do it via various attributes:

--- a/docs/dal/index.rst
+++ b/docs/dal/index.rst
@@ -158,12 +158,12 @@ mean G-band magnitude between 19 - 20:
     >>> import pyvo as vo
     >>> tap_service = vo.dal.TAPService("http://dc.g-vo.org/tap")
     >>> tap_service.search(
-            """ SELECT TOP 5 
-            source_id, ra, dec, phot_g_mean_mag 
-            FROM gaia.dr3lite
-            WHERE phot_g_mean_mag BETWEEN 19 AND 20
-            ORDER BY phot_g_mean_mag
-            """)
+    >>>        """ SELECT TOP 5 
+    >>>        source_id, ra, dec, phot_g_mean_mag 
+    >>>        FROM gaia.dr3lite
+    >>>        WHERE phot_g_mean_mag BETWEEN 19 AND 20
+    >>>        ORDER BY phot_g_mean_mag
+    >>>        """)
     <Table length=5>
         source_id              ra                dec         phot_g_mean_mag
                             deg                deg               mag      

--- a/docs/dal/index.rst
+++ b/docs/dal/index.rst
@@ -196,6 +196,7 @@ with some extensions to make it work better for astronomy.
 
 Synchronous vs. asynchronous query
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 In synchronous (“sync”) mode, the client keeps a connection for the
 entire runtime of the query, and query processing generally starts
 when the request is submitted.  This is convenient but becomes
@@ -286,7 +287,7 @@ After the job ends up in COMPLETED, you can retrieve the result:
 
     >>> job.phase
     'COMPLETED'
-    >>> job.result
+    >>> job.fetch_result()
     (...table object)
 
 Eventually, it is friendly to clean up the job rather than relying

--- a/docs/dal/index.rst
+++ b/docs/dal/index.rst
@@ -146,10 +146,66 @@ Table Access Protocol
 
     -- `Table Access Protocol <https://www.ivoa.net/documents/TAP/>`_
 
-.. doctest-remote-data::
+Getting started
+^^^^^^^^^^^^^^^
 
-    >>> tap_service = vo.dal.TAPService("http://dc.g-vo.org/tap")
-    >>> tap_results = tap_service.search("SELECT TOP 10 * FROM ivoa.obscore")
+Let's start with a quick example using PyVO to perform a TAP/ADQL query.
+For instance we want to retrieve 5 objects from the GAIA DR3 database, 
+showing their id, position and mean G-band magnitude.
+
+.. doctest-remote-data::
+    >>> import pyvo as vo
+    >>> tap_service = vo.dal.TAPservice("http://dc.g-vo.org/tap")
+    >>> tap_service.search("SELECT TOP 5 source_id, ra, dec, phot_g_mean_mag FROM gaia.dr3lite")
+    <Table length=5>
+        source_id              ra                dec         phot_g_mean_mag
+                            deg                deg               mag      
+        int64             float64            float64           float32    
+    ------------------- ------------------ ------------------ ---------------
+    2165092154924732928 319.82640223047326 49.371803949190934       19.633097
+    2165092159226514688  319.8317684883249  49.37350866387902       20.997982
+    2165092159225251200   319.836141859182  49.37380423843978       20.928877
+    2165092159226252416  319.8357919050182  49.37715751142902       20.565428
+    2165092159224999296 319.82331035942707  49.37621068543158       20.367767
+
+Using the class :py:class:`~pyvo.dal.TAPService` we can instantiate an available 
+TAP service by inserting their URL. Here we use the 
+`GAVO DC TAP <http://dc.g-vo.org/tap>`_ service to demonstrate. To perform a query using 
+ADQL, the ``search()`` method is used. You should know from which metadata you 
+want to query your objects and also the name of the parameters, after running 
+these code you would obtain a table that displays your desired data. 
+
+# 
+how do you know the column description of a metadata? I would like to insert 
+a tutorial on how to check the column description with pyvo 
+#
+
+To get an idea how to use ADQL in further detail, read this 
+`documentation <https://www.ivoa.net/documents/ADQL/20180112/PR-ADQL-2.1-20180112.html>`_. 
+It is basically a query language developed based on SQL92. 
+
+Synchronous vs. asynchronous query
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+With PyVO you can use two ways of query. Synchronous means that your 
+queries will be performed sequentially and once you have multiple 
+queries that are quite complex, it can take a lot of time waiting for 
+the results. Since the next query can only start once the previous one 
+is done. In this case it is advantageous to use the asynchronous 
+query instead. This allows you to assign multiple queries to the 
+TAP server and returns controls inmmediately with a promise to execute 
+all the queries and notify you the result later.
+
+The asynchronous query is indeed slower but it is convenient when you 
+have to run many queries since you don't have to wait for each query 
+to be finished in order to start the next task. Synchronous query is 
+faster and often used for one simpler query. It depends on the situation.
+
+Note that the ``search()`` method performs the synchronous query by default.
+To specify the query mode, you can use either ``run_sync()`` for 
+synchronous query or ``run_async()`` for asynchronous query.
+
+Query limit
+^^^^^^^^^^^
 
 As a sanity precaution, most services have some default limit of how many
 rows they will return before overflowing:

--- a/docs/dal/index.rst
+++ b/docs/dal/index.rst
@@ -162,7 +162,8 @@ mean G-band magnitude between 19 - 20:
     ...     WHERE phot_g_mean_mag BETWEEN 19 AND 20
     ...     ORDER BY phot_g_mean_mag
     ...     """
-    >>> tap_service.search(ex_query)
+    >>> result = tap_service.search(ex_query)
+    >>> print(result)
     <Table length=5>
         source_id              ra                dec         phot_g_mean_mag
                             deg                deg               mag      
@@ -174,28 +175,13 @@ mean G-band magnitude between 19 - 20:
     2171810342771336704 323.25913736080776  51.94305655940998            19.0
     2180349528028140800  310.5233961869657   50.3486391034819            19.0
 
-One can find the names of the tables using:
-
-.. doctest-remote-data::
-
-    >>> print([tab_name for tab_name in tap_service.tables.keys()])  # doctest: +ELLIPSIS 
-    ['amanda.nucand', 'annisred.main', 'antares.data', ... , 'wfpdb.main', 'wise.main', 'zcosmos.data']
-
-And also the names of the columns from a known table:
-
-.. doctest-remote-data::
-
-    >>> tap_service.search('select * from gaia.dr3lite', maxrec=1).table.columns    # doctest: +ELLIPSIS
-    <TableColumns names=('source_id','ra','dec', ... ,'random_index','ruwe')>
-
-Furthermore, to explore more query examples, you can try either the ``description`` 
+To explore more query examples, you can try either the ``description`` 
 attribute for some services. For other services like this one, try 
 the ``examples`` attribute.
 
 .. doctest-remote-data::
 
-    >>> for entry in tap_service.examples:
-    ...     print(entry['QUERY'])   # doctest: +ELLIPSIS
+    >>> print(tap_service.examples[0]['QUERY'])  
     SELECT TOP 50 l.id, l.pmra as lpmra, l.pmde as lpmde,
     g.source_id, g.pmra as gpmra, g.pmdec as gpmde
     FROM
@@ -210,7 +196,22 @@ the ``examples`` attribute.
         2016, 2000),
         POINT(l.raj2000, l.dej2000)
     )<0.0002                            -- fine selection with PMs
-    ...
+
+Furthermore, one can find the names of the tables using:
+
+.. doctest-remote-data::
+
+    >>> print([tab_name for tab_name in tap_service.tables.keys()])  # doctest: +ELLIPSIS, +IGNORE_WARNINGS
+    ['amanda.nucand', 'annisred.main', 'antares.data', ..., 'wfpdb.main', 'wise.main', 'zcosmos.data']
+    
+
+And also the names of the columns from a known table, for instance 
+the first three columns:
+
+.. doctest-remote-data::
+
+    >>> result.table.columns[:3]    # doctest: +IGNORE_WARNINGS
+    <TableColumns names=('source_id','ra','dec')>
 
 If you know a TAP service's access URL, you can directly pass it to
 :py:class:`~pyvo.dal.TAPService` to obtain a service object. 
@@ -288,7 +289,8 @@ When you are ready, you can start the job:
 
 .. doctest-remote-data::
 
-    >>> job.run()   # doctest: +IGNORE_OUTPUT
+    >>> job.run()   # doctest: +ELLIPSIS
+    <pyvo.dal.tap.AsyncTAPJob object at 0x...>
 
 This will put the job into the QUEUED state.  Depending on how busy
 the server is, it will immediately go to the EXECUTING status:
@@ -312,9 +314,9 @@ After the job ends up in COMPLETED, you can retrieve the result:
 
 .. doctest-remote-data::
 
-    >>> job.phase   # doctest: +IGNORE_OUTPUT
+    >>> job.phase  # doctest: +IGNORE_OUTPUT
     'COMPLETED'
-    >>> job.fetch_result()  # doctest: +IGNORE_OUTPUT
+    >>> job.fetch_result()  # doctest: +SKIP
     (result table as shown before)
 
 Eventually, it is friendly to clean up the job rather than relying

--- a/docs/dal/index.rst
+++ b/docs/dal/index.rst
@@ -174,30 +174,43 @@ mean G-band magnitude between 19 - 20:
     2171810342771336704 323.25913736080776  51.94305655940998            19.0
     2180349528028140800  310.5233961869657   50.3486391034819            19.0
 
-To explore more query examples, you can try either the ``description`` 
+One can find the names of the tables using:
+
+.. doctest-remote-data::
+
+    >>> print([tab_name for tab_name in tap_service.tables.keys()])  # doctest: +ELLIPSIS 
+    ['amanda.nucand', 'annisred.main', 'antares.data', ... , 'wfpdb.main', 'wise.main', 'zcosmos.data']
+
+And also the names of the columns from a known table:
+
+.. doctest-remote-data::
+
+    >>> tap_service.search('select * from gaia.dr3lite', maxrec=1).table.columns    # doctest: +ELLIPSIS
+    <TableColumns names=('source_id','ra','dec', ... ,'random_index','ruwe')>
+
+Furthermore, to explore more query examples, you can try either the ``description`` 
 attribute for some services. For other services like this one, try 
 the ``examples`` attribute.
 
 .. doctest-remote-data::
 
     >>> for entry in tap_service.examples:
-    ...     print(entry['QUERY'])   # doctest: +SKIP
-    <query examples>
-
-Furthermore, one can find the names of the tables using:
-
-.. doctest-remote-data::
-
-    >>> for tab_name in tap_service.tables.keys():
-    ...     print(tab_name)    # doctest: +SKIP
-    <table names>
-
-And also the names of their columns:
-
-.. doctest-remote-data::
-
-    >>> tap_service.search('select * from gaia.dr3lite', maxrec=1).table.columns    # doctest: +SKIP
-    <column names>
+    ...     print(entry['QUERY'])   # doctest: +ELLIPSIS
+    SELECT TOP 50 l.id, l.pmra as lpmra, l.pmde as lpmde,
+    g.source_id, g.pmra as gpmra, g.pmdec as gpmde
+    FROM
+    lspm.main as l
+    JOIN gaia.dr3lite AS g
+    ON (DISTANCE(g.ra, g.dec, l.raj2000, l.dej2000)<0.01) -- rough pre-selection
+    WHERE
+    DISTANCE(
+        ivo_epoch_prop_pos(
+        g.ra, g.dec, g.parallax,
+        g.pmra, g.pmdec, g.radial_velocity,
+        2016, 2000),
+        POINT(l.raj2000, l.dej2000)
+    )<0.0002                            -- fine selection with PMs
+    ...
 
 If you know a TAP service's access URL, you can directly pass it to
 :py:class:`~pyvo.dal.TAPService` to obtain a service object. 
@@ -247,8 +260,8 @@ starting it, it creates a new object :py:class:`~pyvo.dal.AsyncTAPJob`.
 
 .. doctest-remote-data::
 
-    >>> job.url     # doctest: +SKIP
-    <job-url>
+    >>> job.url     # doctest: +ELLIPSIS
+    'http://dc.zah.uni-heidelberg.de/__system__/tap/run/async/...'
 
 The job URL mentioned before is available in the ``url`` attribute. 
 Clicking on the URL leads you to the query itself, where you can check 
@@ -275,14 +288,14 @@ When you are ready, you can start the job:
 
 .. doctest-remote-data::
 
-    >>> job.run()   # doctest: +SKIP
+    >>> job.run()   # doctest: +IGNORE_OUTPUT
 
 This will put the job into the QUEUED state.  Depending on how busy
 the server is, it will immediately go to the EXECUTING status:
 
 .. doctest-remote-data::
 
-    >>> job.phase   # doctest: +SKIP
+    >>> job.phase   # doctest: +IGNORE_OUTPUT
     'EXECUTING'
 
 The job will eventually end up in one of the phases:
@@ -299,9 +312,9 @@ After the job ends up in COMPLETED, you can retrieve the result:
 
 .. doctest-remote-data::
 
-    >>> job.phase   # doctest: +SKIP
+    >>> job.phase   # doctest: +IGNORE_OUTPUT
     'COMPLETED'
-    >>> job.fetch_result()  # doctest: +SKIP
+    >>> job.fetch_result()  # doctest: +IGNORE_OUTPUT
     (result table as shown before)
 
 Eventually, it is friendly to clean up the job rather than relying

--- a/docs/dal/index.rst
+++ b/docs/dal/index.rst
@@ -155,13 +155,14 @@ mean G-band magnitude between 19 - 20:
 
     >>> import pyvo as vo
     >>> tap_service = vo.dal.TAPService("http://dc.g-vo.org/tap")
-    >>> tap_service.search(
-    ...        """ SELECT TOP 5 
-    ...        source_id, ra, dec, phot_g_mean_mag 
-    ...        FROM gaia.dr3lite
-    ...        WHERE phot_g_mean_mag BETWEEN 19 AND 20
-    ...        ORDER BY phot_g_mean_mag
-    ...        """)
+    >>> ex_query = """
+    ...     SELECT TOP 5 
+    ...     source_id, ra, dec, phot_g_mean_mag 
+    ...     FROM gaia.dr3lite
+    ...     WHERE phot_g_mean_mag BETWEEN 19 AND 20
+    ...     ORDER BY phot_g_mean_mag
+    ...     """
+    >>> tap_service.search(ex_query)
     <Table length=5>
         source_id              ra                dec         phot_g_mean_mag
                             deg                deg               mag      
@@ -213,13 +214,7 @@ synchronous query or ``run_async()`` for asynchronous query.
 
 .. doctest-remote-data::
 
-    >>> job = tap_service.submit_job(
-                """ SELECT TOP 5 
-                source_id, ra, dec, phot_g_mean_mag 
-                FROM gaia.dr3lite
-                WHERE phot_g_mean_mag BETWEEN 19 AND 20
-                ORDER BY phot_g_mean_mag
-                """)
+    >>> job = tap_service.submit_job(ex_query)
 
 To learn more details from the asynchronous query, let's look at the 
 ``submit_job()`` method. This submits an asynchronous query without 
@@ -227,8 +222,8 @@ starting it, it creates a new object :py:class:`~pyvo.dal.AsyncTAPJob`.
 
 .. doctest-remote-data::
 
-    >>> job.url
-    (...)
+    >>> job.url     # doctest: +SKIP
+    <job-url>
 
 The job URL mentioned before is available in the ``url`` attribute. 
 Clicking on the URL leads you to the query itself, where you can check 
@@ -255,14 +250,14 @@ When you are ready, you can start the job:
 
 .. doctest-remote-data::
 
-    >>> job.run()
+    >>> job.run()   # doctest: +SKIP
 
 This will put the job into the QUEUED state.  Depending on how busy
 the server is, it will immediately go to the EXECUTING status:
 
 .. doctest-remote-data::
 
-    >>> job.phase
+    >>> job.phase   # doctest: +SKIP
     'EXECUTING'
 
 The job will eventually end up in one of the phases:
@@ -279,10 +274,10 @@ After the job ends up in COMPLETED, you can retrieve the result:
 
 .. doctest-remote-data::
 
-    >>> job.phase
+    >>> job.phase   # doctest: +SKIP
     'COMPLETED'
-    >>> job.fetch_result()
-    (...table object)
+    >>> job.fetch_result()  # doctest: +SKIP
+    (result table as shown before)
 
 Eventually, it is friendly to clean up the job rather than relying
 on the server to clean it up once ``job.destruction`` (a datetime

--- a/docs/dal/index.rst
+++ b/docs/dal/index.rst
@@ -210,9 +210,35 @@ Note that the ``search()`` method performs the synchronous query by default.
 To specify the query mode, you can use either ``run_sync()`` for 
 synchronous query or ``run_async()`` for asynchronous query.
 
-#
-Here explain how run_async() works witn submit_jobs etc.. 
-#
+.. doctest-remote-data::
+
+    >>> tap_service.submit_job(
+            """ SELECT TOP 5 
+            source_id, ra, dec, phot_g_mean_mag 
+            FROM gaia.dr3lite
+            WHERE phot_g_mean_mag BETWEEN 19 AND 20
+            ORDER BY phot_g_mean_mag
+            """).url 
+    http://dc.zah.uni-heidelberg.de/__system__/tap/run/async/job_id
+
+To learn more details from the asynchronous query, let's look at the 
+``submit_job()`` method. This submits an asynchronous query without 
+starting it, it creates an new object :py:class:`~pyvo.dal.AsyncTAPJob`. 
+To get the URL of the query, we add an ``url`` attribute. Note that the 
+example query does not return a real URL since the last part of the 
+URL is a string composed by 8 numbers/alphabets which represents the 
+job's ID. It will be different every time you run the ``submit_job()`` method. 
+Clicking on the URL leads you to the query itself, where you can check 
+the status(phase) of the query and decide to run, modify or delete 
+the job. After the job is completed, you can download the result in 
+VOTable format. There are other attributes/methods besides ``url`` 
+available for you to configure the job via commands, without getting 
+to the website directly. Please read the description for the object 
+:py:class:`~pyvo.dal.AsyncTAPJob`. 
+
+With ``run_async()`` you basically submit an asynchronous query and 
+return its result. It is like running ``submit_job()`` first and then 
+run the query manually.
 
 Query limit
 ^^^^^^^^^^^

--- a/docs/dal/index.rst
+++ b/docs/dal/index.rst
@@ -179,7 +179,8 @@ If you know a TAP service's access URL, you can directly pass it to
 :py:class:`~pyvo.dal.TAPService` to obtain a service object (see
 :ref:`pyvo.registry <pyvo-registry>` for when you do not know this access URL). 
 Here we use the `GAVO DC TAP <http://dc.g-vo.org/tap>`_ service to demonstrate. 
-To perform a query using ADQL, the ``search()`` method is used. 
+To perform a query using ADQL, the ``search()`` method is used (note 
+that this method performs the synchronous query by default). 
 TAPService instances have several methods to inspect the metadata
 of the service - in particular, what tables with what columns are
 available - discussed below.  Note that for exploratory query
@@ -212,7 +213,6 @@ robust of long-running queries.  It also supports queuing queries,
 which allows service operators to be a lot more generous with
 resource limits.
 
-Note that the ``search()`` method performs the synchronous query by default.
 To specify the query mode, you can use either ``run_sync()`` for 
 synchronous query or ``run_async()`` for asynchronous query.
 

--- a/docs/dal/index.rst
+++ b/docs/dal/index.rst
@@ -180,16 +180,16 @@ the ``examples`` attribute.
 
 .. doctest-remote-data::
 
-    >>> for e in tap_service.examples:
-    ...     print(e['QUERY'])   # doctest: +SKIP
+    >>> for entry in tap_service.examples:
+    ...     print(entry['QUERY'])   # doctest: +SKIP
     <query examples>
 
 Furthermore, one can find the names of the tables using:
 
 .. doctest-remote-data::
 
-    >>> for t in tap_service.tables.keys():
-    ...     print(t)    # doctest: +SKIP
+    >>> for tab_name in tap_service.tables.keys():
+    ...     print(tab_name)    # doctest: +SKIP
     <table names>
 
 And also the names of their columns:

--- a/docs/dal/index.rst
+++ b/docs/dal/index.rst
@@ -174,6 +174,31 @@ mean G-band magnitude between 19 - 20:
     2171810342771336704 323.25913736080776  51.94305655940998            19.0
     2180349528028140800  310.5233961869657   50.3486391034819            19.0
 
+To explore more query examples, you can try either the ``description`` 
+attribute for some services. For other services like this one, try 
+the ``examples`` attribute.
+
+.. doctest-remote-data::
+
+    >>> for e in tap_service.examples:
+    ...     print(e['QUERY'])   # doctest: +SKIP
+    <query examples>
+
+Furthermore, one can find the names of the tables using:
+
+.. doctest-remote-data::
+
+    >>> for t in tap_service.tables.keys():
+    ...     print(t)    # doctest: +SKIP
+    <table names>
+
+And also the names of their columns:
+
+.. doctest-remote-data::
+
+    >>> tap_service.search('select * from gaia.dr3lite', maxrec=1).table.columns    # doctest: +SKIP
+    <column names>
+
 If you know a TAP service's access URL, you can directly pass it to
 :py:class:`~pyvo.dal.TAPService` to obtain a service object. 
 Sometimes, such URLs are published in papers or passed around through

--- a/docs/dal/index.rst
+++ b/docs/dal/index.rst
@@ -156,7 +156,7 @@ mean G-band magnitude between 19 - 20:
 .. doctest-remote-data::
 
     >>> import pyvo as vo
-    >>> tap_service = vo.dal.TAPservice("http://dc.g-vo.org/tap")
+    >>> tap_service = vo.dal.TAPService("http://dc.g-vo.org/tap")
     >>> tap_service.search(
             """ SELECT TOP 5 
             source_id, ra, dec, phot_g_mean_mag 

--- a/pyvo/dal/query.py
+++ b/pyvo/dal/query.py
@@ -112,7 +112,7 @@ class DALService:
 
     def describe(self):
         """
-        display the base URL for the DAL service
+        describe the general information about the DAL service
         """
         print('DAL Service at {}'.format(self.baseurl))
 

--- a/pyvo/dal/query.py
+++ b/pyvo/dal/query.py
@@ -111,6 +111,9 @@ class DALService:
         return q
 
     def describe(self):
+        """
+        display the base URL for the DAL service
+        """
         print('DAL Service at {}'.format(self.baseurl))
 
 

--- a/pyvo/dal/tap.py
+++ b/pyvo/dal/tap.py
@@ -859,7 +859,13 @@ class AsyncTAPJob:
     @property
     def uws_version(self):
         """
-        displays the UWS version
+        the version of the UWS serving this async job
+
+        Asynchronous TAP jobs are managed using a standard called Universal
+        Worker Service (UWS). For instance, starting version 1.1, you can
+        have long polls, which save on monitoring requests.  Normal users
+        generally will not have to look at this.
+
         """
         self._update()
         return self._job.version
@@ -1042,7 +1048,11 @@ class TAPQuery(DALQuery):
     @property
     def queryurl(self):
         """
-        The URL that encodes the current query
+        the URL to which to submit queries
+
+        In TAP, that varies depending on whether we run sync or async
+        queries.
+
         """
         return '{baseurl}/{mode}'.format(baseurl=self.baseurl, mode=self._mode)
 

--- a/pyvo/dal/tap.py
+++ b/pyvo/dal/tap.py
@@ -858,6 +858,9 @@ class AsyncTAPJob:
 
     @property
     def uws_version(self):
+        """
+        displays the UWS version
+        """
         self._update()
         return self._job.version
 
@@ -1038,6 +1041,9 @@ class TAPQuery(DALQuery):
 
     @property
     def queryurl(self):
+        """
+        The URL that encodes the current query
+        """
         return '{baseurl}/{mode}'.format(baseurl=self.baseurl, mode=self._mode)
 
     def execute_stream(self, post=False):


### PR DESCRIPTION
Greetings, 

I would like to add some extensions of the TAP doc from a beginner user perspective, to make it more detailed and easier to start with. 

Change suggestions:
1. overall extension of the documentation on how to use TAP service, e.g. sync and async query
2. add links to parameter/class description for each service protocol
3. add some doc strings for several functions
4. minor fixes on spelling