### PR TITLE
Deprecating ivoid2service.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@
 
 - Deprecate VOSI ``AvailabilityMixin``, this mean the deprecation of the
   inherited ``availability``, ``available``, and ``up_since`` properties
-  of DAL service classes, too. [#413]
+
+- Deprecating ``ivoid2service`` because it is ill-defined. [#439]
 
 
 1.4.1 (2023-03-07)

--- a/pyvo/registry/regtap.py
+++ b/pyvo/registry/regtap.py
@@ -22,6 +22,7 @@ import os
 import warnings
 
 from astropy import table
+from astropy.utils.decorators import deprecated
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
 from . import rtcons
@@ -895,6 +896,9 @@ class RegistryResource(dalq.Record):
         return res
 
 
+@deprecated("1.5", "ivoid2service does not work in the presence of"
+    " multiple capabilities.  Use"
+    " registry.search(ivoid=...)[0].get_service('capname') instead.")
 def ivoid2service(ivoid, servicetype=None):
     """
     return service(s) for a given IVOID.


### PR DESCRIPTION
The problem with it is that when a resource has multiple capabilities (e.g., SCS and TAP, as is now true for the big majority of VO resources), its result is ill-defined.

One *could* add a parameter to select the kind of service desired, but that's complicated in detail.  Hence, we advise people to use normal registry search with an ivoid constraint.

This is supposed to address Bug #425.