### PR TITLE
Fix rapid polling cause by unsupported WAIT parameter.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,9 @@
 
 - Deprecating ``ivoid2service`` because it is ill-defined. [#439]
 
+- Fix poor polling behavior when running an async query against a
+  TAP v1.1 service with unsupported WAIT parameter. [#440]
+
 
 1.4.1 (2023-03-07)
 ==================

--- a/pyvo/dal/tap.py
+++ b/pyvo/dal/tap.py
@@ -5,7 +5,6 @@ A module for accessing remote source and observation catalogs
 from functools import partial
 from datetime import datetime
 from time import sleep
-from packaging.version import Version
 
 import requests
 from urllib.parse import urlparse, urljoin

--- a/pyvo/dal/tap.py
+++ b/pyvo/dal/tap.py
@@ -922,10 +922,9 @@ class AsyncTAPJob:
             if cur_phase in phases:
                 break
 
-            # fallback for uws 1.0
-            if Version(self._job.version) < Version("1.1"):
-                sleep(interval)
-                interval = min(120, interval * increment)
+            # fallback for uws 1.0 or unsupported WAIT parameter
+            sleep(interval)
+            interval = min(120, interval * increment)
 
         return self
 


### PR DESCRIPTION
The current implementation of `wait()` in pyvo causes unexpected rapid polling in UWS v1.1 services that do not currently support the WAIT parameter in async job summary requests.

In the case the service advertises itself as UWS v1.1, pyvo will attempt to poll for the Job Summary using the WAIT parameter. If the service does not support it, it may immediately return a response where the phase is not in one of the breaking cases below ( it is in an active phase or not in a phase supplied by the user). Because the service has advertised itself as v1.1 however, it will not be caught by the fallback from v1.0 that will perform an increasing backoff polling.

The result is that pyvo will attempt to immediately repoll the service with no delay, and continue to do so until it reaches one of returnable phases. In local testing, this means pyvo can send > 75-100 requests in under 1.5 seconds.

This PR simply pulls the backoff sleep interval out of a dedicated v1.0 conditional, and into the main flow.  This handles both cases. For v1.0, the behavior remains the same. For v1.1 where the service does not support WAIT, the client will gradually slow polling requests.