### PR TITLE
CI: update RTD config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,8 +10,11 @@ sphinx:
 
 # Install regular dependencies.
 # Then, install special pinning for RTD.
+build:
+  tools:
+    python: "3.10"
+
 python:
-  version: 3.8
   system_packages: false
   install:
     - requirements: docs/requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,6 +14,8 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.10"
+  apt_packages:
+    - graphviz
 
 python:
   system_packages: false

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,6 +11,7 @@ sphinx:
 # Install regular dependencies.
 # Then, install special pinning for RTD.
 build:
+  os: ubuntu-22.04
   tools:
     python: "3.10"
 


### PR DESCRIPTION
python.version got deprecated, thus the new section (following the official config docs: https://docs.readthedocs.io/en/stable/config-file/v2.html)

This can be merged when getting a green CI, the main branch currently has a red status on RTD.