### PR TITLE
CI: remove job cross dependency from CI matrix

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -14,9 +14,8 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
-    needs: stylecheck
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         include:
           - name: py38 oldest dependencies, Linux
@@ -49,9 +48,8 @@ jobs:
   mac_windows:
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} py310
-    needs: tests
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: [macos-latest, windows-latest]
     steps:
@@ -85,7 +83,6 @@ jobs:
 
   devdeps:
     runs-on: ubuntu-latest
-    needs: tests
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python 3.11


### PR DESCRIPTION
The full CI matrix is rather fast to run, and we tend to have rather experienced contributors, so having cross dependency between CI jobs is more limiting than helpful, so I'm turning off all cross-job dependencies 