### PR TITLE
BUG:  SIA1's getdataurl() to favour ``VOX:Image_AccessReference``

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,8 @@
 
 - Fix SIA2 search to accept SkyCoord position inputs. [#459]
 
+- Favouring ``VOX:Image_AccessReference`` for data url for SIA1 queries. [#445]
+
 
 1.4.1 (2023-03-07)
 ==================

--- a/pyvo/dal/sia.py
+++ b/pyvo/dal/sia.py
@@ -878,11 +878,10 @@ class SIARecord(SodaRecordMixin, DatalinkRecordMixin, Record):
         to retrieve the dataset described by this record.  None is returned
         if no such column exists.
         """
-        dataurl = super().getdataurl()
-        if dataurl is None:
+        if self.acref is not None:
             return self.acref
         else:
-            return dataurl
+            return super().getdataurl()
 
     def suggest_dataset_basename(self):
         """

--- a/pyvo/dal/tests/data/sia/dataset.xml
+++ b/pyvo/dal/tests/data/sia/dataset.xml
@@ -5,7 +5,10 @@
  <RESOURCE type="results">
   <INFO ID="QUERY_STATUS" name="QUERY_STATUS" value="OK">OK</INFO>
   <TABLE>
-    <FIELD ID="accref" arraysize="*" datatype="char" name="accref" utype="Access.Reference">
+    <FIELD ID="not_data_url" arraysize="*" datatype="char" name="not_data_url" utype="obscore:access.reference" ucd="meta.ref.url">
+      <DESCRIPTION>Not the access key for the data</DESCRIPTION>
+    </FIELD>
+    <FIELD ID="accref" arraysize="*" datatype="char" name="accref" ucd="VOX:Image_AccessReference" utype="Access.Reference">
       <DESCRIPTION>Access key for the data</DESCRIPTION>
     </FIELD>
     <FIELD ID="mime" arraysize="*" datatype="char" name="mime" ucd="VOX:Image_Format" utype="Access.Format">
@@ -42,6 +45,7 @@
    <DATA>
     <TABLEDATA>
      <TR>
+      <TD>This should not be the dataurl</TD>
       <TD>http://example.com/querydata/image.fits</TD>
       <TD>image/fits</TD>
       <TD>153280</TD>


### PR DESCRIPTION
A snippet that fails with IRSA's `cloud_access` SIA column. We concluded that this is a bug in pyvo, and therefore this PR is a fix for it. 

@tomdonaldson - I went ahead and did this PR as we plan to roll back the deployment, and it was easier to do the bugfix while it was still failing. Following heasarc's example, we do roll back to populate the ucd for that field, so older pyvo versions will stay compatible.

Snippet (though not minimal example) to reproduce:

```
import numpy as np

# For downloading files
from astropy.utils.data import download_file

from astropy.coordinates import SkyCoord
from astropy.io import fits
from astropy.nddata import Cutout2D
import astropy.visualization as vis
from astropy.wcs import WCS
from astroquery.ipac.ned import Ned

import pyvo as vo
objects_in_paper = Ned.query_refcode('2016ApJ...817..109O')
allwise_image_services = vo.regsearch(servicetype='image', keywords=['allwise'])
allwise_image_service = allwise_image_services[0]
galaxies = objects_in_paper[np.array(objects_in_paper['Type']) == 'G']
ra = galaxies['RA'][0]
dec = galaxies['DEC'][0]
pos = SkyCoord(ra, dec, unit = 'deg')
allwise_image_table = allwise_image_service.search(pos=pos, size=0)
for allwise_image_record in allwise_image_table:
    if 'W1' in allwise_image_record.bandpass_id:
        break
allwise_image_record.getdataurl()
```