### PR TITLE
ENH: adding sys.version to User-Agent

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,9 @@
 - Fix poor polling behavior when running an async query against a
   TAP v1.1 service with unsupported WAIT parameter. [#440]
 
+- Adding python version to User-Agent. [#452]
+
+
 1.4.2 (unreleased)
 ==================
 

--- a/pyvo/dal/tests/test_query.py
+++ b/pyvo/dal/tests/test_query.py
@@ -110,8 +110,8 @@ def register_mocks(mocker):
 
         def useragent_callback(request, context):
             assert 'User-Agent' in request.headers
-            assert request.headers['User-Agent'] == 'python-pyvo/{} ({} {})'.format(
-                version, platform.system(), platform.python_version())
+            assert request.headers['User-Agent'] == 'pyVO/{} Python/{} ({})'.format(
+                version, platform.python_version(), platform.system())
             return get_pkg_data_contents('data/query/basic.xml')
 
         matchers.append(stack.enter_context(mocker.register_uri(

--- a/pyvo/dal/tests/test_query.py
+++ b/pyvo/dal/tests/test_query.py
@@ -110,8 +110,8 @@ def register_mocks(mocker):
 
         def useragent_callback(request, context):
             assert 'User-Agent' in request.headers
-            assert request.headers['User-Agent'] == 'python-pyvo/{} ({})'.format(
-                version, platform.system())
+            assert request.headers['User-Agent'] == 'python-pyvo/{} ({} {})'.format(
+                version, platform.system(), platform.python_version())
             return get_pkg_data_contents('data/query/basic.xml')
 
         matchers.append(stack.enter_context(mocker.register_uri(

--- a/pyvo/utils/http.py
+++ b/pyvo/utils/http.py
@@ -6,7 +6,7 @@ import platform
 import requests
 from ..version import version
 
-DEFAULT_USER_AGENT = 'python-pyvo/{} ({})'.format(version, platform.system())
+DEFAULT_USER_AGENT = 'python-pyvo/{} ({} {})'.format(version, platform.system(), platform.python_version())
 
 
 def use_session(session):

--- a/pyvo/utils/http.py
+++ b/pyvo/utils/http.py
@@ -6,7 +6,7 @@ import platform
 import requests
 from ..version import version
 
-DEFAULT_USER_AGENT = 'python-pyvo/{} ({} {})'.format(version, platform.system(), platform.python_version())
+DEFAULT_USER_AGENT = f'pyVO/{version} Python/{platform.python_version()} ({platform.system()})'
 
 
 def use_session(session):

--- a/pyvo/utils/tests/test_http.py
+++ b/pyvo/utils/tests/test_http.py
@@ -4,10 +4,12 @@ Tests for pyvo.utils.http
 """
 
 import platform
+
 from pyvo.utils.http import create_session
 from pyvo.version import version
 
 
 def test_create_session():
     test_session = create_session()
-    assert test_session.headers['User-Agent'] == 'python-pyvo/{} ({})'.format(version, platform.system())
+    assert (test_session.headers['User-Agent']
+            == f'python-pyvo/{version} ({platform.system()} {platform.python_version()})')

--- a/pyvo/utils/tests/test_http.py
+++ b/pyvo/utils/tests/test_http.py
@@ -12,4 +12,4 @@ from pyvo.version import version
 def test_create_session():
     test_session = create_session()
     assert (test_session.headers['User-Agent']
-            == f'python-pyvo/{version} ({platform.system()} {platform.python_version()})')
+            == f'pyVO/{version} Python/{platform.python_version()} ({platform.system()})')


### PR DESCRIPTION
Kind of a follow-up to #344 

This potentially would help us to see when to drop python version support, etc.

The connecting astroquery PR is here: https://github.com/astropy/astroquery/pull/2762