### PR TITLE
BUG: SIA2 position search to be SkyCoord aware

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,8 @@
 
 - Fix handling of nan values for Time properties in SIA2 records. [#463]
 
+- Fix SIA2 search to accept SkyCoord position inputs. [#459]
+
 
 1.4.1 (2023-03-07)
 ==================

--- a/pyvo/dal/params.py
+++ b/pyvo/dal/params.py
@@ -7,6 +7,7 @@ from collections.abc import MutableSet
 import abc
 
 from astropy import units as u
+from astropy.coordinates import SkyCoord
 from astropy.units import Quantity, Unit
 from astropy.time import Time
 from astropy.io.votable.converters import (
@@ -301,7 +302,7 @@ class PosQueryParam(AbstractDalQueryParam):
         entries in values are either quantities or assumed to be degrees
         """
         self._validate_pos(val)
-        if len(val) == 3:
+        if len(val) == 2 or len(val) == 3:
             shape = 'CIRCLE'
         elif len(val) == 4:
             shape = 'RANGE'
@@ -313,6 +314,7 @@ class PosQueryParam(AbstractDalQueryParam):
                 'even 6 and above (POLYGON) accepted.'.format(val))
         return '{} {}'.format(shape, ' '.join(
             [str(val.to(u.deg).value) if isinstance(val, Quantity) else
+             val.transform_to('icrs').to_string() if isinstance(val, SkyCoord) else
              str((val * u.deg).value) for val in val]))
 
     def _validate_pos(self, pos):
@@ -321,7 +323,17 @@ class PosQueryParam(AbstractDalQueryParam):
 
         This has probably done already somewhere else
         """
-        if len(pos) == 3:
+
+        if len(pos) == 2:
+            if not isinstance(pos[0], SkyCoord):
+                raise ValueError
+            if not isinstance(pos[1], Quantity):
+                radius = pos[1] * u.deg
+            else:
+                radius = pos[1]
+            if radius <= 0 * u.deg or radius.to(u.deg) > 90 * u.deg:
+                raise ValueError('Invalid circle radius: {}'.format(radius))
+        elif len(pos) == 3:
             self._validate_ra(pos[0])
             self._validate_dec(pos[1])
             if not isinstance(pos[2], Quantity):

--- a/pyvo/dal/tests/test_sia.py
+++ b/pyvo/dal/tests/test_sia.py
@@ -11,6 +11,7 @@ import pytest
 from pyvo.dal.sia import search, SIAService
 
 from astropy.io.fits import HDUList
+from astropy.coordinates import SkyCoord
 from astropy.utils.data import get_pkg_data_contents
 
 get_pkg_data_contents = partial(
@@ -45,8 +46,9 @@ def _test_result(result):
 @pytest.mark.usefixtures('sia')
 @pytest.mark.usefixtures('register_mocks')
 @pytest.mark.filterwarnings("ignore::astropy.io.votable.exceptions.W06")
-def test_search():
-    results = search('http://example.com/sia', pos=(288, 15))
+@pytest.mark.parametrize("position", ((288, 15), SkyCoord(288, 15, unit="deg")))
+def test_search(position):
+    results = search('http://example.com/sia', pos=position)
     result = results[0]
 
     _test_result(result)

--- a/pyvo/dal/tests/test_sia2.py
+++ b/pyvo/dal/tests/test_sia2.py
@@ -12,6 +12,7 @@ import pytest
 from pyvo.dal.sia2 import search, SIA2Service, SIA2Query, SIAService, SIAQuery
 
 import astropy.units as u
+from astropy.coordinates import SkyCoord
 from astropy.utils.data import get_pkg_data_contents
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
@@ -101,7 +102,8 @@ class TestSIA2Service:
                  (12.0 * u.deg, 34.0 * u.deg,
                   14.0 * u.deg, 35.0 * u.deg,
                   14.0 * u.deg, 36.0 * u.deg,
-                  12.0 * u.deg, 35.0 * u.deg)]
+                  12.0 * u.deg, 35.0 * u.deg),
+                 (SkyCoord(2, 4, unit='deg'), 0.166 * u.deg)]
 
     @pytest.mark.usefixtures('sia')
     @pytest.mark.usefixtures('capabilities')


### PR DESCRIPTION
To fix #305


However, this is very much the bare minimum, as it still doesn't handle the case of vector skycoord input, neither non circular search, so eventually a more thorough overhaul will be required.