### PR TITLE
CI: adding changelog checking GHA

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,20 @@
+name: Changelog check
+
+on:
+  pull_request:
+    types: [labeled, unlabeled, opened, synchronize, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  changelog:
+    name: Check changelog entry
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check change log entry
+      uses: scientific-python/action-check-changelogfile@865ff8154dd94f008f08de6bb8d8c1f661113658
+      env:
+        CHANGELOG_FILENAME: CHANGES.rst
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,3 @@
-[tool.astropy-bot]
-[tool.astropy-bot.changelog_checker]
-filename = "CHANGES.rst"
-
 [build-system]
 
 requires = ["setuptools",


### PR DESCRIPTION
I suppose this won't be triggered before landing on `main`, so we need to merge it away as is (note: there used to be changelog checking, but it was run by the astropy-bot, which is now defunct).