### PR TITLE
TST: restructure tests to use parametrize rather than internal loop

### DIFF
--- a/pyvo/dal/tests/test_sia2.py
+++ b/pyvo/dal/tests/test_sia2.py
@@ -96,37 +96,41 @@ class TestSIA2Service:
             service = SIA2Service('https://example.com/sia-priv')
             assert service.query_ep == 'https://example.com/sia/v2query'
 
+    POSITIONS = [(2, 4, 0.0166 * u.deg),
+                 (12, 12.5, 34, 36),
+                 (12.0 * u.deg, 34.0 * u.deg,
+                  14.0 * u.deg, 35.0 * u.deg,
+                  14.0 * u.deg, 36.0 * u.deg,
+                  12.0 * u.deg, 35.0 * u.deg)]
+
     @pytest.mark.usefixtures('sia')
     @pytest.mark.usefixtures('capabilities')
     @pytest.mark.filterwarnings("ignore::astropy.io.votable.exceptions.W06")
     @pytest.mark.filterwarnings("ignore::astropy.io.votable.exceptions.W42")
     @pytest.mark.filterwarnings("ignore::astropy.io.votable.exceptions.W49")
-    def test_search(self):
+    @pytest.mark.parametrize("position", POSITIONS)
+    def test_search_scalar(self, position):
         service = SIA2Service('https://example.com/sia')
 
-        positions = [
-            (2, 4, 0.0166 * u.deg),
-            (12, 12.5, 34, 36),
-            (12.0 * u.deg, 34.0 * u.deg,
-             14.0 * u.deg, 35.0 * u.deg,
-             14.0 * u.deg, 36.0 * u.deg,
-             12.0 * u.deg, 35.0 * u.deg)]
-
-        # each position
-        for pos in positions:
-            results = service.search(pos=pos)
-            result = results[0]
-            _test_result(result)
-
-        # all positions
-        results = service.search(pos=positions)
+        results = service.search(pos=position)
         result = results[0]
         _test_result(result)
 
+    @pytest.mark.usefixtures('sia')
+    @pytest.mark.usefixtures('capabilities')
+    def test_search_vector(self, pos=POSITIONS):
+        service = SIA2Service('https://example.com/sia')
+        results = service.search(pos=pos)
+        result = results[0]
+        _test_result(result)
+
+    @pytest.mark.usefixtures('sia')
+    @pytest.mark.usefixtures('capabilities')
+    def test_search_deprecation(self, pos=POSITIONS):
         # test the deprecation
         with pytest.warns(AstropyDeprecationWarning):
             deprecated_service = SIAService('https://example.com/sia')
-            deprecated_results = deprecated_service.search(pos=positions)
+            deprecated_results = deprecated_service.search(pos=pos)
             result = deprecated_results[0]
             _test_result(result)
 


### PR DESCRIPTION
Bumped into this test while doing #459, so systematically looked for cases where parametrize should be used instead of internal loops. Opening it as a separate PR as this supposed to be a trivial refactoring.