### PR TITLE
BUG: fix handling of nan input for Time properties

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,9 @@
 
 - Fixed TapResults to inherit session. [#447]
 
+- Fix handling of nan values for Time properties in SIA2 records. [#463]
+
+
 1.4.1 (2023-03-07)
 ==================
 

--- a/pyvo/dal/sia2.py
+++ b/pyvo/dal/sia2.py
@@ -881,28 +881,30 @@ class ObsCoreRecord(SodaRecordMixin, DatalinkRecordMixin, Record,
     @property
     def t_min(self):
         """
-        The start time of the observation specified in MJD. In case of data
-        products result of the combination of multiple frames, min time must
-        be the minimum of the start times
+        The start time of the observation specified in MJD as an
+        `~astropy.time.Time` instance. In case of data products result of the
+        combination of multiple frames, min time must be the minimum of the
+        start times. ``None`` is used for NaN response values.
         """
         t_min = self.get('t_min')
         if np.isfinite(t_min):
             return Time(t_min, format='mjd')
         else:
-            return t_min
+            return None
 
     @property
     def t_max(self):
         """
-        The stop time of the observation specified in MJD. In case of data
-        products result of the combination of multiple frames, t_max must
-        be the maximum of the stop times
+        The stop time of the observation specified in MJD as an
+        `~astropy.time.Time` instance. In case of data products result of the
+        combination of multiple frames, t_max must be the maximum of the
+        stop times. ``None`` is used for NaN response values.
         """
         t_max = self.get('t_max')
         if np.isfinite(t_max):
             return Time(t_max, format='mjd')
         else:
-            return t_max
+            return None
 
     @property
     def t_exptime(self):

--- a/pyvo/dal/sia2.py
+++ b/pyvo/dal/sia2.py
@@ -11,6 +11,7 @@ endpoint.
 """
 
 import warnings
+import numpy as np
 
 from astropy import units as u
 from astropy.time import Time
@@ -884,7 +885,11 @@ class ObsCoreRecord(SodaRecordMixin, DatalinkRecordMixin, Record,
         products result of the combination of multiple frames, min time must
         be the minimum of the start times
         """
-        return Time(self.get('t_min'), format='mjd')
+        t_min = self.get('t_min')
+        if np.isfinite(t_min):
+            return Time(t_min, format='mjd')
+        else:
+            return t_min
 
     @property
     def t_max(self):
@@ -893,7 +898,11 @@ class ObsCoreRecord(SodaRecordMixin, DatalinkRecordMixin, Record,
         products result of the combination of multiple frames, t_max must
         be the maximum of the stop times
         """
-        return Time(self.get('t_min'), format='mjd')
+        t_max = self.get('t_max')
+        if np.isfinite(t_max):
+            return Time(t_max, format='mjd')
+        else:
+            return t_max
 
     @property
     def t_exptime(self):


### PR DESCRIPTION
This should fix the current test failure with the IRAS record from CADC. 

Fix #460 