### PR TITLE
MAINT: add workaround for doctesting with new numpy repr

### DIFF
--- a/pyvo/conftest.py
+++ b/pyvo/conftest.py
@@ -7,6 +7,7 @@ get picked up when running the tests inside an interpreter using
 
 """
 
+import numpy as np
 from astropy.version import version as astropy_version
 
 try:
@@ -15,6 +16,8 @@ try:
 except ImportError:
     ASTROPY_HEADER = False
 
+# Keep this until we require numpy to be >=2.0
+np.set_printoptions(legacy="1.25")
 
 def pytest_configure(config):
     """Configure Pytest with Astropy.

--- a/pyvo/conftest.py
+++ b/pyvo/conftest.py
@@ -8,7 +8,7 @@ get picked up when running the tests inside an interpreter using
 """
 
 import numpy as np
-from astropy.version import version as astropy_version
+from astropy.utils import minversion
 
 try:
     from pytest_astropy_header.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
@@ -17,7 +17,9 @@ except ImportError:
     ASTROPY_HEADER = False
 
 # Keep this until we require numpy to be >=2.0
-np.set_printoptions(legacy="1.25")
+if minversion(np, "2.0.0.dev0+151"):
+    np.set_printoptions(legacy="1.25")
+
 
 def pytest_configure(config):
     """Configure Pytest with Astropy.


### PR DESCRIPTION
This should close https://github.com/astropy/pyvo/issues/464 and fix the CI failure we see in the devtest job.