### PR TITLE
MAINT: no automated black formatting here

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,11 @@ requires = ["setuptools",
             "wheel"]
 
 build-backend = 'setuptools.build_meta'
+
+
+[tool.black]
+force-exclude = '''
+(
+  .*
+)
+'''


### PR DESCRIPTION
This should make sure that editors and IDEs should not go rouge and reformat things just for the sake of reformatting.

(seems to work on the command line, and at least for certain editors/IDEs).