### PR TITLE
MAINT: fix formatting raised by new flake8 version

### DIFF
--- a/pyvo/dal/mimetype.py
+++ b/pyvo/dal/mimetype.py
@@ -46,7 +46,7 @@ def mime2extension(mimetype, default=None):
     if not mimetype:
         return default
 
-    if type(mimetype) == str:
+    if isinstance(mimetype, str):
         mimetype = mimetype.encode('utf-8')
 
     ext = mimetypes.guess_extension(mimetype, strict=False)

--- a/pyvo/dal/query.py
+++ b/pyvo/dal/query.py
@@ -135,7 +135,7 @@ class DALQuery(dict):
         """
         initialize the query object with a baseurl
         """
-        if type(baseurl) == bytes:
+        if isinstance(baseurl, bytes):
             baseurl = baseurl.decode("utf-8")
 
         self._baseurl = baseurl.rstrip("?")

--- a/pyvo/dal/sia.py
+++ b/pyvo/dal/sia.py
@@ -503,7 +503,7 @@ class SIAQuery(DALQuery):
     def format(self, format_):
         setattr(self, "_format", format_)
 
-        if type(format_) in (str, bytes):
+        if isinstance(format_, (str, bytes)):
             format_ = [format_]
 
         self["FORMAT"] = ",".join(_.upper() for _ in format_)
@@ -893,7 +893,7 @@ class SIARecord(SodaRecordMixin, DatalinkRecordMixin, Record):
         ``make_dataset_filename()``.
         """
         out = self.title
-        if type(out) == bytes:
+        if isinstance(out, bytes):
             out = out.decode('utf-8')
 
         if not out:

--- a/pyvo/dal/sia2.py
+++ b/pyvo/dal/sia2.py
@@ -19,8 +19,7 @@ from astropy.utils.decorators import deprecated
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
 from .query import DALResults, DALQuery, DALService, Record
-from .adhoc import DatalinkResultsMixin, AxisParamMixin, SodaRecordMixin,\
-    DatalinkRecordMixin
+from .adhoc import DatalinkResultsMixin, AxisParamMixin, SodaRecordMixin, DatalinkRecordMixin
 from .params import IntervalQueryParam, StrQueryParam, EnumQueryParam
 from .vosi import AvailabilityMixin, CapabilityMixin
 from ..dam import ObsCoreMetadata, CALIBRATION_LEVELS

--- a/pyvo/dal/ssa.py
+++ b/pyvo/dal/ssa.py
@@ -533,7 +533,7 @@ class SSAQuery(DALQuery):
     def format(self, val):
         setattr(self, "_format", val)
 
-        if type(val) in (str, bytes):
+        if isinstance(val, (str, bytes)):
             val = [val]
 
         self["FORMAT"] = ",".join(val)
@@ -746,7 +746,7 @@ class SSARecord(SodaRecordMixin, DatalinkRecordMixin, Record):
         ``make_dataset_filename()``.
         """
         out = self.title
-        if type(out) == bytes:
+        if isinstance(out, bytes):
             out = out.decode('utf-8')
 
         if not out:

--- a/pyvo/dal/tests/test_params.py
+++ b/pyvo/dal/tests/test_params.py
@@ -7,8 +7,7 @@ from functools import partial
 from urllib.parse import parse_qsl
 
 from pyvo.dal.adhoc import DatalinkResults
-from pyvo.dal.params import find_param_by_keyword, get_converter,\
-    AbstractDalQueryParam, IntervalQueryParam
+from pyvo.dal.params import find_param_by_keyword, get_converter, AbstractDalQueryParam, IntervalQueryParam
 from pyvo.dal.exceptions import DALServiceError
 
 import pytest

--- a/pyvo/dal/tests/test_query.py
+++ b/pyvo/dal/tests/test_query.py
@@ -16,8 +16,7 @@ import numpy as np
 import platform
 
 from pyvo.dal.query import DALService, DALQuery, DALResults, Record
-from pyvo.dal.exceptions import DALServiceError, DALQueryError,\
-    DALFormatError, DALOverflowWarning
+from pyvo.dal.exceptions import DALServiceError, DALQueryError, DALFormatError, DALOverflowWarning
 from pyvo.version import version
 
 from astropy.table import Table, QTable

--- a/pyvo/dal/tests/test_tap.py
+++ b/pyvo/dal/tests/test_tap.py
@@ -59,8 +59,7 @@ def create_fixture(mocker):
     def match_request(request):
         data = request.text.read()
         if b'VOSITable' in data:
-            assert request.headers['Content-Type'] == 'text/xml',\
-                'Wrong file format'
+            assert request.headers['Content-Type'] == 'text/xml', 'Wrong file format'
         elif b'VOTable' in data:
             assert request.headers['Content-Type'] == \
                 'application/x-votable+xml', 'Wrong file format'
@@ -88,8 +87,7 @@ def load_fixture(mocker):
     def match_request(request):
         data = request.text.read()
         if b',' in data:
-            assert request.headers['Content-Type'] == 'text/csv',\
-                'Wrong file format'
+            assert request.headers['Content-Type'] == 'text/csv', 'Wrong file format'
         elif b'\t' in data:
             assert request.headers['Content-Type'] == \
                 'text/tab-separated-values', 'Wrong file format'

--- a/pyvo/io/vosi/tests/test_capabilities.py
+++ b/pyvo/io/vosi/tests/test_capabilities.py
@@ -28,7 +28,7 @@ class TestCapabilities:
         assert equals(
             parsed_caps[0].standardid,
             "ivo://ivoa.net/std/VOSI#availability")
-        assert type(parsed_caps[0].interfaces[0]) == vs.ParamHTTP
+        assert isinstance(parsed_caps[0].interfaces[0], vs.ParamHTTP)
         assert parsed_caps[0].interfaces[0].accessurls[0].use == "full"
         assert equals(
             parsed_caps[0].interfaces[0].accessurls[0].content,
@@ -38,7 +38,7 @@ class TestCapabilities:
         assert equals(
             parsed_caps[1].standardid,
             "ivo://ivoa.net/std/VOSI#capabilities")
-        assert type(parsed_caps[1].interfaces[0]) == vs.ParamHTTP
+        assert isinstance(parsed_caps[1].interfaces[0], vs.ParamHTTP)
         assert parsed_caps[1].interfaces[0].accessurls[0].use == "full"
         assert equals(
             parsed_caps[1].interfaces[0].accessurls[0].content,
@@ -46,14 +46,14 @@ class TestCapabilities:
 
     def test_tablesendpoint(self, parsed_caps):
         assert parsed_caps[2].standardid == "ivo://ivoa.net/std/VOSI#tables"
-        assert type(parsed_caps[2].interfaces[0]) == vs.ParamHTTP
+        assert isinstance(parsed_caps[2].interfaces[0], vs.ParamHTTP)
         assert parsed_caps[2].interfaces[0].accessurls[0].use == "full"
         assert equals(
             parsed_caps[2].interfaces[0].accessurls[0].content,
             "http://example.org/tap/tables")
 
     def test_type_parsed(self, parsed_caps):
-        assert type(parsed_caps[3]) == tr.TableAccess
+        assert isinstance(parsed_caps[3], tr.TableAccess)
 
     def test_stdid_parsed(self, parsed_caps):
         assert parsed_caps[3].standardid == "ivo://ivoa.net/std/TAP"

--- a/pyvo/io/vosi/tests/test_tables.py
+++ b/pyvo/io/vosi/tests/test_tables.py
@@ -36,7 +36,7 @@ class TestTables:
         assert col.ucd == "meta.id;meta.main"
         assert col.utype == "utype"
 
-        assert type(col.datatype) == vs.TAPType
+        assert isinstance(col.datatype, vs.TAPType)
         assert str(col.datatype) == "<DataType arraysize=*>VARCHAR</DataType>"
         assert col.datatype.arraysize == "*"
         assert col.datatype.delim == ";"


### PR DESCRIPTION
This should fix the new errors we see due to the new flake8 release.
All of them seem to be reasonable, so we should just go ahead with the update.