### PR TITLE
BUG: fix numpy dev version as their versioning system changed

### DIFF
--- a/pyvo/conftest.py
+++ b/pyvo/conftest.py
@@ -17,7 +17,7 @@ except ImportError:
     ASTROPY_HEADER = False
 
 # Keep this until we require numpy to be >=2.0
-if minversion(np, "2.0.0.dev0+151"):
+if minversion(np, "2.0.0.dev0+git20230726"):
     np.set_printoptions(legacy="1.25")
 
 


### PR DESCRIPTION
Numpy's versioning has changed in https://github.com/numpy/numpy/pull/24196 causing the repr issues we see #479. 

This PR fixes #479 