### PR TITLE
Removing a remote-data mark in a RegTAP test.

### DIFF
--- a/pyvo/registry/tests/test_regtap.py
+++ b/pyvo/registry/tests/test_regtap.py
@@ -762,7 +762,6 @@ class TestExtraResourceMethods:
 # TODO: While I suppose the contact test should keep requiring network,
 # I think we should can the network responses involved in the following;
 # the stuff might change upstream any time and then break our unit tests.
-@pytest.mark.remote_data
 @pytest.fixture(name='flash_tables')
 def _flash_tables():
     rsc = _makeRegistryRecord(


### PR DESCRIPTION
That was spurious in this position anyway; the fixture in question does not require network access (but the tests it is there for do, so they have the mark).

This fixes bug #480.