### PR TITLE
DEP: Deprecate vodataservice Table

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,10 @@
   ``SIA2_PARAMETERS_DESC``. The old names now issue an
   ``AstropyDeprecationWarning``. [#419]
 
+- Class ``pyvo.vosi.vodataservice.Table`` has been renamed to
+  ``VODataServiceTable`` to avoid sharing the name with a more generic
+  ``astropy.table.Table`` while having different API. [#484]
+
 - Registry search now finds SIA v2 services. [#422, #428]
 
 - Deprecate VOSI ``AvailabilityMixin``, this mean the deprecation of the

--- a/docs/registry/index.rst
+++ b/docs/registry/index.rst
@@ -486,7 +486,7 @@ and then you can run:
 .. doctest-remote-data::
 
   >>> res.get_tables()  # doctest: +IGNORE_OUTPUT
-  {'flashheros.data': <Table name="flashheros.data">... 29 columns ...</Table>, 'ivoa.obscore': <Table name="ivoa.obscore">... 0 columns ...</Table>}
+  {'flashheros.data': <VODataServiceTable name="flashheros.data">... 29 columns ...</VODataServiceTable>, 'ivoa.obscore': <VODataServiceTable name="ivoa.obscore">... 0 columns ...</VODataServiceTable>}
 
 
 Reference/API

--- a/pyvo/io/vosi/endpoint.py
+++ b/pyvo/io/vosi/endpoint.py
@@ -245,10 +245,10 @@ class TablesFile(Element):
         tableset.parse(iterator, config)
         self._tableset = tableset
 
-    @xmlelement(cls=vs.Table)
+    @xmlelement(cls=vs.VODataServiceTable)
     def table(self):
         """
-        The `Table` root element if present.
+        The `VODataServiceTable` root element if present.
         """
         return self._table
 

--- a/pyvo/io/vosi/vodataservice.py
+++ b/pyvo/io/vosi/vodataservice.py
@@ -16,6 +16,7 @@ defining a `value` property.
 
 import re
 
+from astropy.utils import deprecated
 from astropy.utils.collections import HomogeneousList
 from astropy.utils.misc import indent
 from astropy.utils.xml import check as xml_check
@@ -31,7 +32,7 @@ from .exceptions import (
     E01, E02, E03, E04, E05, E06)
 
 __all__ = [
-    "TableSet", "TableSchema", "ParamHTTP", "Table", "BaseParam", "TableParam",
+    "TableSet", "TableSchema", "ParamHTTP", "VODataServiceTable", "BaseParam", "TableParam",
     "InputParam", "DataType", "SimpleDataType", "TableDataType", "VOTableType",
     "TAPDataType", "TAPType", "FKColumn", "ForeignKey"]
 
@@ -143,7 +144,7 @@ class TableSchema(Element, HomogeneousList):
     """
 
     def __init__(self, config=None, pos=None, _name='schema', **kwargs):
-        HomogeneousList.__init__(self, Table)
+        HomogeneousList.__init__(self, VODataServiceTable)
         Element.__init__(self, config, pos, _name, **kwargs)
 
         self._name = None
@@ -230,7 +231,7 @@ class TableSchema(Element, HomogeneousList):
 
     @tables.adder
     def tables(self, iterator, tag, data, config, pos):
-        table = Table(config, pos, 'table', **data)
+        table = VODataServiceTable(config, pos, 'table', **data)
         table.parse(iterator, config)
         self.append(table)
 
@@ -288,7 +289,7 @@ class ParamHTTP(vr.Interface):
             warn_or_raise(W18, W18, config=config, pos=self._pos)
 
 
-class Table(Element):
+class VODataServiceTable(Element):
     """
     Table element as described in
     http://www.ivoa.net/xml/VODataService/v1.1
@@ -310,7 +311,7 @@ class Table(Element):
         self._foreignkeys = HomogeneousList(ForeignKey)
 
     def __repr__(self):
-        return '<Table name="{}">... {} columns ...</Table>'.format(
+        return '<VODataServiceTable name="{}">... {} columns ...</VODataServiceTable>'.format(
             self.name, len(self.columns))
 
     def describe(self):
@@ -447,6 +448,11 @@ class Table(Element):
 
         if not self.name:
             vo_raise(E06, self._Element__name, config=config, pos=self._pos)
+
+
+@deprecated("1.5", alternative="VODataServiceTable")
+class Table(VODataServiceTable):
+    pass
 
 
 class BaseParam(Element):

--- a/pyvo/registry/regtap.py
+++ b/pyvo/registry/regtap.py
@@ -873,10 +873,10 @@ class RegistryResource(dalq.Record):
 
     def _build_vosi_table(self, table_row, columns):
         """
-        return a io.vosi.vodataservice.Table element for a
+        return a io.vosi.vodataservice.VODataServiceTable element for a
         query result from get_tables.
         """
-        res = vodataservice.Table()
+        res = vodataservice.VODataServiceTable()
         res.name = table_row["table_name"]
         res.title = table_row["table_title"]
         res.description = table_row["table_description"]
@@ -892,7 +892,7 @@ class RegistryResource(dalq.Record):
         """
         return the structure of the tables underlying the service.
 
-        This returns a dict with table names as keys and vosi.Table
+        This returns a dict with table names as keys and vodataservice.VODataServiceTable
         objects as values (pretty much what tables returns for a TAP
         service).  The table instances will have an ``origin`` attribute
         pointing back to the registry record.


### PR DESCRIPTION
to close #477 

I haven't touched the other classes in the module, for consistency it may make some sense to rename all with the prefix ``VODataService``, but unlike for `Table`, it would be purely cosmetical for them.