### PR TITLE
MAINT: adding warning filter for numpy._core rename

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,9 @@ filterwarnings =
     ignore:unclosed <ssl.SSLSocket:ResourceWarning
 # This can be removed once the minimum astropy is 5.0.1?
     ignore:distutils Version classes are deprecated:DeprecationWarning
+# Numpy 2.0 deprecations triggered by upstream libraries.
+# Exact warning messages differ, thus using a super generic filter.
+    ignore:numpy.core:DeprecationWarning
 
 
 [flake8]


### PR DESCRIPTION
This should deal with the failures we see in the devtesting job. Unfortunately, this all take some time upstream to get sorted out, so we apply the quick and generic workaround for now.