### PR TITLE
feat: add intersect modes for registry.Spatial constraint

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 1.5 (unreleased)
 ================
 
+- Add intersect modes for the spatial constraint in the registry module ``pyvo.registry.Spatial`` [#495]
+
 - Added ``alt_identifier``, ``created``, ``updated`` and ``rights`` to the
   attributes of ``pyvo.registry.regtap.RegistryResource`` [#492]
 

--- a/docs/registry/index.rst
+++ b/docs/registry/index.rst
@@ -65,8 +65,8 @@ keyword arguments.  The following constraints are available:
 * :py:class:`pyvo.registry.Ivoid` (``ivoid``): exactly match a single
   IVOA identifier (that is, in effect, the primary key in the VO).
 * :py:class:`pyvo.registry.Spatial` (``spatial``): match resources
-  covering a certain geometry (point, circle, polygon, or MOC).
-  *RegTAP 1.2 Extension*
+  covering, enclosed or overlapping a certain geometry
+  (point, circle, polygon, or MOC). *RegTAP 1.2 Extension*
 * :py:class:`pyvo.registry.Spectral` (``spectral``): match resources
   covering a certain part of the spectrum (usually, but not limited to,
   the electromagnetic spectrum).  *RegTAP 1.2 Extension*
@@ -146,6 +146,25 @@ interactive data discovery, however, it is usually preferable to use the
        Sloan Digital Sky Survey-II Supernova Survey (Sako+, 2018) ... conesearch, tap#aux, web
   ...
 
+And to look for tap resources *in* a specific cone, you would do
+
+.. doctest-remote-data::
+
+  >>> from astropy.coordinates import SkyCoord
+  >>> registry.search(registry.Servicetype("tap"),
+  ...                 registry.Spatial((SkyCoord("23d +3d"), 3), intersect="enclosed"),
+  ...                 includeaux=True) # doctest: +IGNORE_OUTPUT
+  <DALResultsTable length=1>
+              ivoid                   res_type       short_name                   res_title                  ...  intf_types  intf_roles          alt_identifier         
+                                                                                                             ...                                                         
+              object                   object          object                       object                   ...    object      object                object             
+  ------------------------------ ----------------- ------------- ------------------------------------------- ... ------------ ---------- --------------------------------
+  ivo://cds.vizier/j/apj/835/123 vs:catalogservice J/ApJ/835/123 Globular clusters in NGC 474 from CFHT obs. ... vs:paramhttp        std doi:10.26093/cds/vizier.18350123
+
+Where ``intersect`` can take the following values:
+  * 'covers' is the default and returns resources that cover the geometry provided,
+  * 'enclosed' is for services in the given region,
+  * 'overlaps' returns services intersecting with the region.
 
 The idea is that in notebook-like interfaces you can pick resources by
 title, description, and perhaps the access mode (“interface”) offered.

--- a/pyvo/registry/tests/test_rtcons.py
+++ b/pyvo/registry/tests/test_rtcons.py
@@ -226,6 +226,19 @@ class TestSpatialConstraint:
         assert cons.get_search_condition() == "1 = CONTAINS(MOC(6, CIRCLE(3.0, -30.0, 3)), coverage)"
         assert cons._extra_tables == ["rr.stc_spatial"]
 
+    def test_enclosed(self):
+        cons = registry.Spatial("0/1-3", intersect="enclosed")
+        assert cons.get_search_condition() == "1 = CONTAINS(coverage, MOC('0/1-3'))"
+
+    def test_overlaps(self):
+        cons = registry.Spatial("0/1-3", intersect="overlaps")
+        assert cons.get_search_condition() == "1 = INTERSECTS(coverage, MOC('0/1-3'))"
+
+    def test_not_an_intersect_mode(self):
+        with pytest.raises(ValueError, match="'intersect' should be one of 'covers', 'enclosed',"
+                           " or 'overlaps' but its current value is 'wrong'."):
+            registry.Spatial("0/1-3", intersect="wrong")
+
 
 class TestSpectralConstraint:
     # These tests might need some float literal fuzziness.  I'm just


### PR DESCRIPTION
Hello pyvo, 

## What the PR does

It adds intersect modes for the constraint `registry.Spatial`.

- 'covers' that keeps the previous behavior, 
- 'enclosed' is for services covering the given region,
- 'overlaps' returns services intersecting with the region

In practice, if I give the allsky MOC, it looks like this:

(former behavior, now default. Returns any service that contains allsky)

```python
>>> from astroquery.pyvo import registry
>>> result = registry.search(registry.Spatial("0/0-11"))
>>> len(result)
1147
```

(new behavior, returns any service overlapping with allsky)

```python
>>> from astroquery.pyvo import registry
>>> result = registry.search(registry.Spatial("0/0-11", intersect="overlaps"))
>>> len(result)
18938
```

## Why this API

I copied the SIA one https://github.com/astropy/pyvo/blob/ad84a0e309344a990342a830dbd42d77533f0425/pyvo/dal/sia.py#L74 but there might be better options ?