### PR TITLE
Relaxed baseurl requirements in SIA2Service

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 1.5 (unreleased)
 ================
 
+- Made SIA2Service accept access urls without finding them in the service capabilities [#500]
+
 - Add intersect modes for the spatial constraint in the registry module ``pyvo.registry.Spatial`` [#495]
 
 - Added ``alt_identifier``, ``created``, ``updated`` and ``rights`` to the

--- a/pyvo/dal/tests/test_sia2_remote.py
+++ b/pyvo/dal/tests/test_sia2_remote.py
@@ -262,5 +262,5 @@ class TestSIACadc():
         irsa_seip = \
             [s for s in image_services if
              'irsa' in s.ivoid and 'seip' in s.ivoid][0]
-        result = irsa_seip.search(pos=(2.8425, 74.4846, 10), maxrec=1)
+        result = irsa_seip.search(pos=(31.8425, 77.4846, 0.1), maxrec=1)
         assert len(result) == 1

--- a/pyvo/dal/tests/test_sia2_remote.py
+++ b/pyvo/dal/tests/test_sia2_remote.py
@@ -11,6 +11,7 @@ from astropy.utils.exceptions import AstropyDeprecationWarning
 
 from pyvo.dal.sia2 import search, SIA2Service
 from pyvo.dal.adhoc import DatalinkResults
+from pyvo import regsearch
 
 
 CADC_SIA_URL = 'https://ws.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/sia'
@@ -254,3 +255,12 @@ class TestSIACadc():
         for rr in results:
             assert rr.access_format == \
                 'application/x-votable+xml;content=datalink'
+
+    @pytest.mark.filterwarnings("ignore::pyvo.dal.exceptions.DALOverflowWarning")
+    def test_reg_sia2(self):
+        image_services = regsearch(servicetype='sia2')
+        irsa_seip = \
+            [s for s in image_services if
+             'irsa' in s.ivoid and 'seip' in s.ivoid][0]
+        result = irsa_seip.search(pos=(2.8425, 74.4846, 10), maxrec=1)
+        assert len(result) == 1

--- a/pyvo/dal/vosi.py
+++ b/pyvo/dal/vosi.py
@@ -4,6 +4,7 @@ VOSI classes and mixins
 """
 from itertools import chain
 import requests
+from urllib.parse import urlparse
 
 from astropy.utils.decorators import lazyproperty, deprecated
 
@@ -20,12 +21,18 @@ class EndpointMixin():
     def _get_endpoint(self, endpoint):
         # finds the endpoint relative to the base url or its parent
         # and returns its content in raw format
+
+        # do not trust baseurl as it might contain query or fragments
+        urlcomp = urlparse(self.baseurl)
+        curated_baseurl = '{}://{}{}'.format(urlcomp.scheme,
+                                             urlcomp.hostname,
+                                             urlcomp.path)
         if not endpoint:
             raise AttributeError('endpoint required')
         ep_urls = [
-            '{baseurl}/{endpoint}'.format(baseurl=self.baseurl,
+            '{baseurl}/{endpoint}'.format(baseurl=curated_baseurl,
                                           endpoint=endpoint),
-            url_sibling(self.baseurl, endpoint)
+            url_sibling(curated_baseurl, endpoint)
         ]
 
         for ep_url in ep_urls:

--- a/pyvo/registry/regtap.py
+++ b/pyvo/registry/regtap.py
@@ -371,7 +371,10 @@ class Interface:
             raise ValueError("PyVO has no support for interfaces with"
                              f" standard id {self.standard_id}.")
 
-        return service_class(self.access_url)
+        if service_class == sia2.SIA2Service:
+            return service_class(self.access_url, check_baseurl=False)
+        else:
+            return service_class(self.access_url)
 
     def supports(self, standard_id):
         """returns true if we believe the interface should be able to talk

--- a/pyvo/registry/tests/test_regtap.py
+++ b/pyvo/registry/tests/test_regtap.py
@@ -19,7 +19,7 @@ from pyvo.registry.regtap import REGISTRY_BASEURL
 from pyvo.registry import search as regsearch
 from pyvo.dal import DALOverflowWarning
 from pyvo.dal import query as dalq
-from pyvo.dal import tap
+from pyvo.dal import tap, sia2
 
 from astropy.utils.data import get_pkg_data_contents
 
@@ -237,6 +237,12 @@ class TestInterfaceClass:
         intf = regtap.Interface("http://example.org",
                                 "ivo://ivoa.net/std/tap#aux", "vs:paramhttp", "std")
         assert isinstance(intf.to_service(), tap.TAPService)
+        assert not intf.is_vosi
+
+    def test_sia2_standard(self):
+        intf = regtap.Interface("http://example.org",
+                                "ivo://ivoa.net/std/sia2", "vs:paramhttp", "std")
+        assert isinstance(intf.to_service(), sia2.SIA2Service)
         assert not intf.is_vosi
 
     def test_secondary_interface(self):


### PR DESCRIPTION
Solution for #450. 

Still not sure that it's correct to relax the adherence to the spec in order to accommodate services that don't, but here you have it.

SIA2 was not wrong in what it was doing, just that it didn't expect the access URL to contain a query. It can deal with that now. Note that the service is still required to have a `capabilities` end point.