### PR TITLE
DEP: temporarily using dev version of indirect dependency pyerfa

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -25,12 +25,13 @@ description =
 setenv =
     PYTEST_ARGS = -rsxf --show-capture=no
     online: PYTEST_ARGS = --remote-data=any --reruns=1 --reruns-delay 10 -rsxf --show-capture=no
-    devdeps: PIP_EXTRA_INDEX_URL =  https://pypi.anaconda.org/scientific-python-nightly-wheels/simple https://pypi.anaconda.org/astropy/simple
+    devdeps: PIP_EXTRA_INDEX_URL =  https://pypi.anaconda.org/scientific-python-nightly-wheels/simple https://pypi.anaconda.org/liberfa/simple https://pypi.anaconda.org/astropy/simple
 
 deps =
     cov: coverage
 
     devdeps: numpy>=0.0.dev0
+    devdeps: pyerfa>=0.0.dev0
     devdeps: astropy>=0.0.dev0
 
     oldestdeps: astropy==4.1


### PR DESCRIPTION
Apparently we need to make this hack to make the dev testing work. (It's a hack as pyerfa is not our direct dependency but astropy's, I'm not even sure we use any features in pyvo that requires erfa)