### PR TITLE
Adding support for VODataService 1.2 table/@nrows.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,6 +42,9 @@
 
 - TAP examples now support the continuation property [#483]
 
+- Adding support for the VODataService 1.2 nrows attribute on table
+  elements [#503]
+
 
 1.4.3 (unreleased)
 ==================

--- a/pyvo/io/vosi/tests/data/tables.xml
+++ b/pyvo/io/vosi/tests/data/tables.xml
@@ -9,6 +9,7 @@
       <title>Test table</title>
       <description>All test data in one table</description>
       <utype>utype</utype>
+      <nrows>30</nrows>
       <column>
         <name>id</name>
         <description>Primary key</description>

--- a/pyvo/io/vosi/tests/test_tables.py
+++ b/pyvo/io/vosi/tests/test_tables.py
@@ -26,7 +26,7 @@ class TestTables:
         assert table.title == "Test table"
         assert table.description == "All test data in one table"
         assert table.utype == "utype"
-        assert table.nrows==30
+        assert table.nrows == 30
 
         col = table.columns[0]
         fkc = table.foreignkeys[0]

--- a/pyvo/io/vosi/tests/test_tables.py
+++ b/pyvo/io/vosi/tests/test_tables.py
@@ -26,6 +26,7 @@ class TestTables:
         assert table.title == "Test table"
         assert table.description == "All test data in one table"
         assert table.utype == "utype"
+        assert table.nrows==30
 
         col = table.columns[0]
         fkc = table.foreignkeys[0]

--- a/pyvo/io/vosi/vodataservice.py
+++ b/pyvo/io/vosi/vodataservice.py
@@ -306,6 +306,7 @@ class VODataServiceTable(Element):
         self._utype = None
         self._type = kwargs.get("type")
         self._version = version
+        self._nrows = None
 
         self._columns = HomogeneousList(TableParam)
         self._foreignkeys = HomogeneousList(ForeignKey)
@@ -382,6 +383,20 @@ class VODataServiceTable(Element):
     @utype.setter
     def utype(self, utype):
         self._utype = utype
+
+    @xmlelement(plain=True, multiple_exc=W09)
+    def nrows(self):
+        """
+        the approximate number of rows in the table.
+
+        This is None if the data provider failed to provide this
+        information.
+        """
+        return self._nrows
+
+    @nrows.setter
+    def nrows(self, nrows):
+        self._nrows = int(nrows)
 
     @xmlattribute
     def type(self):


### PR DESCRIPTION
In version 1.2, VODataService added an nrows attribute to the tables element (cf.  https://ivoa.net/documents/VODataService/20211102/REC-VODataService-1.2.html#tth_sEcA.4).

This PR adds support for this attribute, which in particular fixes warnings that spoil our tests when accessing the GAVO RegTAP endpoint with PR #386.