### PR TITLE
TST: update kwarg usage in tests and code to use keywords

### DIFF
--- a/pyvo/auth/tests/test_auth.py
+++ b/pyvo/auth/tests/test_auth.py
@@ -104,7 +104,7 @@ def basic_auth_service(mocker):
 def test_cookies_auth():
     session = AuthSession()
     session.credentials.set_cookie('TEST_COOKIE', 'BADCOOKIE')
-    service = pyvo.dal.TAPService('http://example.com/tap', session)
+    service = pyvo.dal.TAPService('http://example.com/tap', session=session)
     service.run_async("SELECT * FROM ivoa.obscore")
 
 
@@ -118,7 +118,7 @@ def test_cookie_jar_auth():
     jar = RequestsCookieJar()
     jar.set('TEST_COOKIE', 'BADCOOKIE')
     session.credentials.set_cookie_jar(jar)
-    service = pyvo.dal.TAPService('http://example.com/tap', session)
+    service = pyvo.dal.TAPService('http://example.com/tap', session=session)
     service.run_async("SELECT * FROM ivoa.obscore")
 
 
@@ -130,7 +130,7 @@ def test_cookie_jar_auth():
 def test_certificate_auth():
     session = AuthSession()
     session.credentials.set_client_certificate('client-certificate.pem')
-    service = pyvo.dal.TAPService('http://example.com/tap', session)
+    service = pyvo.dal.TAPService('http://example.com/tap', session=session)
     service.run_async("SELECT * FROM ivoa.obscore")
 
 
@@ -142,7 +142,7 @@ def test_certificate_auth():
 def test_basic_auth():
     session = AuthSession()
     session.credentials.set_password('testuser', 'hunter2')
-    service = pyvo.dal.TAPService('http://example.com/tap', session)
+    service = pyvo.dal.TAPService('http://example.com/tap', session=session)
     service.run_async("SELECT * FROM ivoa.obscore")
 
 
@@ -156,7 +156,7 @@ def test_negotiation():
     session.credentials.set_password('testuser', 'hunter2')
     session.credentials.set_client_certificate('client-certificate.pem')
     session.credentials.set_cookie('TEST_COOKIE', 'BADCOOKIE')
-    service = pyvo.dal.TAPService('http://example.com/tap', session)
+    service = pyvo.dal.TAPService('http://example.com/tap', session=session)
     service.run_async("SELECT * FROM ivoa.obscore")
 
 
@@ -170,5 +170,5 @@ def test_no_common_auth_negotiation():
     session.credentials.set_password('testuser', 'hunter2')
     session.credentials.set_client_certificate('client-certificate.pem')
     session.credentials.set_cookie('TEST_COOKIE', 'BADCOOKIE')
-    service = pyvo.dal.TAPService('http://example.com/tap', session)
+    service = pyvo.dal.TAPService('http://example.com/tap', session=session)
     service.run_async("SELECT * FROM ivoa.obscore")

--- a/pyvo/dal/adhoc.py
+++ b/pyvo/dal/adhoc.py
@@ -442,7 +442,7 @@ class DatalinkQuery(DALQuery):
         DALFormatError
            for errors parsing the VOTable response
         """
-        return DatalinkResults(self.execute_votable(post),
+        return DatalinkResults(self.execute_votable(post=post),
                                url=self.queryurl, session=self._session)
 
 

--- a/pyvo/dal/query.py
+++ b/pyvo/dal/query.py
@@ -165,7 +165,7 @@ class DALQuery(dict):
         DALFormatError
            for errors parsing the VOTable response
         """
-        return DALResults(self.execute_votable(), self.queryurl, session=self._session)
+        return DALResults(self.execute_votable(), url=self.queryurl, session=self._session)
 
     def execute_raw(self):
         """
@@ -833,7 +833,7 @@ class Record(Mapping):
             bufsize = 524288
 
         if not filename:
-            filename = self.make_dataset_filename(dir)
+            filename = self.make_dataset_filename(dir=dir)
 
         inp = self.getdataset(timeout)
         try:
@@ -878,7 +878,7 @@ class Record(Mapping):
         if not base:
             base = self.suggest_dataset_basename()
         if not ext:
-            ext = self.suggest_extension("dat")
+            ext = self.suggest_extension(default="dat")
 
         # be efficient when writing a bunch of files into the same directory
         # in succession

--- a/pyvo/dal/scs.py
+++ b/pyvo/dal/scs.py
@@ -79,7 +79,7 @@ def search(url, pos, radius=1.0, verbosity=2, **keywords):
     pyvo.dal.query.DALServiceError
     pyvo.dal.query.DALQueryError
     """
-    return SCSService(url).search(pos, radius, verbosity, **keywords)
+    return SCSService(url).search(pos=pos, radius=radius, verbosity=verbosity, **keywords)
 
 
 class SCSService(DALService):
@@ -184,7 +184,7 @@ class SCSService(DALService):
         pyvo.dal.query.DALServiceError
         pyvo.dal.query.DALQueryError
         """
-        return self.create_query(pos, radius, verbosity, **keywords).execute()
+        return self.create_query(pos=pos, radius=radius, verbosity=verbosity, **keywords).execute()
 
     def create_query(self, pos=None, radius=None, verbosity=None, **keywords):
         """
@@ -222,7 +222,8 @@ class SCSService(DALService):
         --------
         SCSQuery
         """
-        return SCSQuery(self.baseurl, pos, radius, verbosity, session=self._session, **keywords)
+        return SCSQuery(self.baseurl, pos=pos, radius=radius, verbosity=verbosity,
+                        session=self._session, **keywords)
 
     def describe(self):
         print(self.description)

--- a/pyvo/dal/sia.py
+++ b/pyvo/dal/sia.py
@@ -113,7 +113,8 @@ def search(
     pyvo.dal.query.DALQueryError
     """
     service = SIAService(url)
-    return service.search(pos, size, format, intersect, verbosity, **keywords)
+    return service.search(pos=pos, size=size, format=format, intersect=intersect,
+                          verbosity=verbosity, **keywords)
 
 
 class SIAService(DALService):
@@ -255,7 +256,7 @@ class SIAService(DALService):
         pyvo.dal.query.DALQueryError
         """
         return self.create_query(
-            pos, size, format, intersect, verbosity, **keywords).execute()
+            pos=pos, size=size, format=format, intersect=intersect, verbosity=verbosity, **keywords).execute()
 
     def create_query(
             self, pos=None, size=None, format=None, intersect=None,
@@ -317,7 +318,8 @@ class SIAService(DALService):
         SIAQuery
         """
         return SIAQuery(
-            self.baseurl, pos, size, format, intersect, verbosity, self._session, **keywords)
+            self.baseurl, pos=pos, size=size, format=format, intersect=intersect,
+            verbosity=verbosity, session=self._session, **keywords)
 
     def describe(self):
         print(self.description)

--- a/pyvo/dal/sla.py
+++ b/pyvo/dal/sla.py
@@ -189,7 +189,8 @@ class SLAService(DALService):
         --------
         SLAQuery
         """
-        return SLAQuery(self.baseurl, wavelength, request, session=self._session, **keywords)
+        return SLAQuery(baseurl=self.baseurl, wavelength=wavelength, request=request,
+                        session=self._session, **keywords)
 
     def describe(self):
         print(self.description)
@@ -342,7 +343,7 @@ class SLAQuery(DALQuery):
         DALFormatError
            for errors parsing the VOTable response
         """
-        return SLAResults(self.execute_votable(), self.queryurl, session=self._session)
+        return SLAResults(self.execute_votable(), url=self.queryurl, session=self._session)
 
 
 class SLAResults(DALResults):

--- a/pyvo/dal/ssa.py
+++ b/pyvo/dal/ssa.py
@@ -102,7 +102,7 @@ def search(
     pyvo.dal.query.DALQueryError
     """
     return SSAService(baseurl).search(
-        pos, diameter, band, time, format, **keywords)
+        pos=pos, diameter=diameter, band=band, time=time, format=format, **keywords)
 
 
 class SSAService(DALService):
@@ -211,7 +211,7 @@ class SSAService(DALService):
         pyvo.dal.query.DALQueryError
         """
         return self.create_query(
-            pos, diameter, band, time, format, **keywords).execute()
+            pos=pos, diameter=diameter, band=band, time=time, format=format, **keywords).execute()
 
     def create_query(
             self, pos=None, diameter=None, band=None, time=None, format=None,
@@ -257,7 +257,7 @@ class SSAService(DALService):
         SSAQuery
         """
         return SSAQuery(
-            self.baseurl, pos, diameter, band, time, format, request,
+            self.baseurl, pos=pos, diameter=diameter, band=band, time=time, format=format, request=request,
             session=self._session, **keywords)
 
     def describe(self):

--- a/pyvo/dal/tap.py
+++ b/pyvo/dal/tap.py
@@ -96,7 +96,7 @@ def search(url, query, language="ADQL", maxrec=None, uploads=None, **keywords):
         an error, including a query syntax error.
     """
     service = TAPService(url)
-    return service.search(query, language, maxrec, uploads, **keywords)
+    return service.search(query, language=language, maxrec=maxrec, uploads=uploads, **keywords)
 
 
 class TAPService(DALService, AvailabilityMixin, CapabilityMixin):
@@ -318,7 +318,8 @@ class TAPService(DALService, AvailabilityMixin, CapabilityMixin):
         AsyncTAPJob
         """
         job = AsyncTAPJob.create(
-            self.baseurl, query, language, maxrec, uploads, self._session, **keywords)
+            self.baseurl, query, language=language, maxrec=maxrec, uploads=uploads,
+            session=self._session, **keywords)
         job = job.run().wait()
         job.raise_if_error()
         result = job.fetch_result()
@@ -355,7 +356,8 @@ class TAPService(DALService, AvailabilityMixin, CapabilityMixin):
         AsyncTAPJob
         """
         return AsyncTAPJob.create(
-            self.baseurl, query, language, maxrec, uploads, self._session, **keywords)
+            self.baseurl, query, language=language, maxrec=maxrec, uploads=uploads,
+            session=self._session, **keywords)
 
     def create_query(
             self, query=None, mode="sync", language="ADQL", maxrec=None,
@@ -383,7 +385,8 @@ class TAPService(DALService, AvailabilityMixin, CapabilityMixin):
             a mapping from table names to objects containing a votable.
         """
         return TAPQuery(
-            self.baseurl, query, mode, language, maxrec, uploads, self._session, **keywords)
+            self.baseurl, query, mode=mode, language=language, maxrec=maxrec,
+            uploads=uploads, session=self._session, **keywords)
 
     def get_job(self, job_id):
         """

--- a/pyvo/dal/tests/test_scs.py
+++ b/pyvo/dal/tests/test_scs.py
@@ -32,7 +32,7 @@ def scs(mocker):
 @pytest.mark.usefixtures('scs')
 @pytest.mark.filterwarnings("ignore::astropy.io.votable.exceptions.W06")
 def test_search():
-    results = search('http://example.com/scs', (78, 2), 0.5)
+    results = search('http://example.com/scs', pos=(78, 2), radius=0.5)
 
     assert len(results) == 1273
 
@@ -48,6 +48,6 @@ class TestSCSService:
     def test_search(self):
         service = SCSService('http://example.com/scs')
 
-        results = service.search((78, 2), 0.5)
+        results = service.search(pos=(78, 2), radius=0.5)
 
         assert len(results) == 1273

--- a/pyvo/registry/regtap.py
+++ b/pyvo/registry/regtap.py
@@ -267,7 +267,7 @@ class RegistryQuery(tap.TAPQuery):
         DALFormatError
            for errors parsing the VOTable response
         """
-        return RegistryResults(self.execute_votable(), self.queryurl)
+        return RegistryResults(self.execute_votable(), url=self.queryurl)
 
 
 class RegistryResults(dalq.DALResults):
@@ -397,8 +397,8 @@ class Interface:
             self.is_vosi = False
 
     def __repr__(self):
-        return (f"Interface({self.access_url!r}, {self.standard_id!r},"
-                f" {self.type!r}, {self.role!r})")
+        return (f"Interface({self.access_url!r}, standard_id={self.standard_id!r},"
+                f" intf_type={self.type!r}, intf_role={self.role!r})")
 
     def to_service(self):
         if self.type == "vr:webbrowser":
@@ -491,7 +491,7 @@ class RegistryResource(dalq.Record):
         "alt_identifier"]
 
     def __init__(self, results, index, session=None):
-        dalq.Record.__init__(self, results, index, session)
+        dalq.Record.__init__(self, results, index, session=session)
 
         self._mapping["access_urls"
                       ] = self._parse_pseudo_array(self._mapping["access_urls"])
@@ -503,7 +503,7 @@ class RegistryResource(dalq.Record):
         self._mapping["intf_roles"
                       ] = self._parse_pseudo_array(self._mapping["intf_roles"])
 
-        self.interfaces = [Interface(*props)
+        self.interfaces = [Interface(props[0], standard_id=props[1], intf_type=props[2], intf_role=props[3])
                            for props in itertools.zip_longest(
             self["access_urls"],
             self["standard_ids"],

--- a/pyvo/registry/tests/test_regtap.py
+++ b/pyvo/registry/tests/test_regtap.py
@@ -213,18 +213,18 @@ class TestInterfaceClass:
         assert not intf.is_vosi
 
     def test_repr(self):
-        intf = regtap.Interface("http://example.org", "ivo://gavo/std/a",
-                                "vs:paramhttp", "std")
+        intf = regtap.Interface("http://example.org", standard_id="ivo://gavo/std/a",
+                                intf_type="vs:paramhttp", intf_role="std")
         assert (repr(intf) == "Interface('http://example.org',"
-                " 'ivo://gavo/std/a', 'vs:paramhttp', 'std')")
-        intf = regtap.Interface("http://example.org", "ivo://gavo/std/a",
-                                None, None)
+                " standard_id='ivo://gavo/std/a', intf_type='vs:paramhttp', intf_role='std')")
+        intf = regtap.Interface("http://example.org", standard_id="ivo://gavo/std/a",
+                                intf_type=None, intf_role=None)
         assert repr(intf) == ("Interface('http://example.org',"
-                              " 'ivo://gavo/std/a', None, None)")
+                              " standard_id='ivo://gavo/std/a', intf_type=None, intf_role=None)")
 
     def test_unknown_standard(self):
-        intf = regtap.Interface("http://example.org", "ivo://gavo/std/a",
-                                "vs:paramhttp", "std")
+        intf = regtap.Interface("http://example.org", standard_id="ivo://gavo/std/a",
+                                intf_type="vs:paramhttp", intf_role="std")
         assert intf.is_standard
         with pytest.raises(ValueError) as excinfo:
             intf.to_service()
@@ -234,21 +234,20 @@ class TestInterfaceClass:
             " id ivo://gavo/std/a.")
 
     def test_known_standard(self):
-        intf = regtap.Interface("http://example.org",
-                                "ivo://ivoa.net/std/tap#aux", "vs:paramhttp", "std")
+        intf = regtap.Interface("http://example.org", standard_id="ivo://ivoa.net/std/tap#aux",
+                                intf_type="vs:paramhttp", intf_role="std")
         assert isinstance(intf.to_service(), tap.TAPService)
         assert not intf.is_vosi
 
     def test_sia2_standard(self):
-        intf = regtap.Interface("http://example.org",
-                                "ivo://ivoa.net/std/sia2", "vs:paramhttp", "std")
+        intf = regtap.Interface("http://example.org", standard_id="ivo://ivoa.net/std/sia2",
+                                intf_type="vs:paramhttp", intf_role="std")
         assert isinstance(intf.to_service(), sia2.SIA2Service)
         assert not intf.is_vosi
 
     def test_secondary_interface(self):
-        intf = regtap.Interface("http://example.org",
-                                "ivo://ivoa.net/std/tap#aux",
-                                "vs:webbrowser", "web")
+        intf = regtap.Interface("http://example.org", standard_id="ivo://ivoa.net/std/tap#aux",
+                                intf_type="vs:webbrowser", intf_role="web")
 
         with pytest.raises(ValueError) as excinfo:
             intf.to_service()
@@ -257,9 +256,8 @@ class TestInterfaceClass:
             "This is not a standard interface.  PyVO cannot speak to it.")
 
     def test_VOSI(self):
-        intf = regtap.Interface("http://example.org",
-                                "ivo://ivoa.net/std/vosi#capabilities",
-                                "vs:ParamHTTP", "std")
+        intf = regtap.Interface("http://example.org", standard_id="ivo://ivoa.net/std/vosi#capabilities",
+                                intf_type="vs:ParamHTTP", intf_role="std")
         assert intf.is_vosi
 
 
@@ -564,11 +562,11 @@ class TestInterfaceSelection:
         assert rec.get_interface("sia").access_url == 'http://sia.example.com'
 
     def test_non_standard_interface(self):
-        intf = regtap.Interface("http://url", "", "", "")
+        intf = regtap.Interface("http://url", standard_id="", intf_type="", intf_role="")
         assert intf.supports("ivo://ivoa.net/std/sia") is False
 
     def test_supports_none(self):
-        intf = regtap.Interface("http://url", "", "", "")
+        intf = regtap.Interface("http://url", standard_id="", intf_type="", intf_role="")
         assert intf.supports(None) is False
 
     def test_non_searchable_service(self):


### PR DESCRIPTION
This is the non-API changing part of #507, adding it to the v1.5 release, in case anyone using these as an actual usage example.

This should be non-controversial, so if all CI is green, I go ahead and merge this and would now really go ahead with the release.