### PR TITLE
MAINT: updating mailmap after v1.5 

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,8 +1,12 @@
 Adam Ginsburg     <keflavich@gmail.com>
 Adrian Damian     <adrian.damian@nrc.ca> <Adrian.Damian@nrc.ca>
+Adrian Damian     <adrian.damian@nrc.ca> <andamian@gmail.com>
 Brigitta Sipőcz   <bsipocz@gmail.com>
 Brigitta Sipőcz   <bsipocz@gmail.com> <b.sipocz@gmail.com>
 Christine Banek   <cbanek@lsst.org> <cbanek@gmail.com>
+Chuanming Mao     <myosotis.mao@gmail.com>
+Chuanming Mao     <myosotis.mao@gmail.com> <113032306+ChuanmingMao@users.noreply.github.com>
+Dustin Jenkins    <djenkins.cadc@gmail.com> <at88mph@users.noreply.github.com>
 Hugo van Kemenade <hugovk@users.noreply.github.com>
 Markus Demleitner <m@tfiu.de>
 Pey Lian Lim      <2090236+pllim@users.noreply.github.com>


### PR DESCRIPTION
Should have done this prior tagging the release, but instead opening this PR now so I don't forget before the next release. 
It can stay open until release time in case some more addition will be needed.

(reminder: we only list cleanup entries in the mailmap to remove duplicates, etc, the full list of contributors is longer than those listed)