### PR TITLE
The regtap Ivoid constraint can now take multiple ivoids.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,8 @@ Enhancements and Fixes
 
 - Making optional parameters keyword only throughout the public API. [#507]
 
+- registry.Ivoid now accepts multiple ivoids and will then match any of
+  them. [#517]
 
 Deprecations and Removals
 -------------------------

--- a/pyvo/registry/rtcons.py
+++ b/pyvo/registry/rtcons.py
@@ -519,7 +519,7 @@ class Ivoid(Constraint):
     """
     _keyword = "ivoid"
 
-    def __init__(self, ivoid):
+    def __init__(self, ivoid, *more_ivoids):
         """
 
         Parameters
@@ -529,9 +529,17 @@ class Ivoid(Constraint):
             The IVOA identifier of the resource to match.  As RegTAP
             requires lowercasing ivoids on ingestion, the constraint
             lowercases the ivoid passed in, too.
+
+        more_ivoids : strings
+            You can pass in multiple ivoids to match.  As usual,
+            they are combined by an or.
         """
-        self._condition = "ivoid = {ivoid}"
-        self._fillers = {"ivoid": ivoid.lower()}
+        self.ivoids = [id.lower() for id in (ivoid,)+more_ivoids]
+
+    def get_search_condition(self, service):
+        return " OR ".join(
+            "ivoid={}".format(make_sql_literal(id))
+                for id in self.ivoids)
 
 
 class UCD(Constraint):

--- a/pyvo/registry/rtcons.py
+++ b/pyvo/registry/rtcons.py
@@ -534,12 +534,11 @@ class Ivoid(Constraint):
             You can pass in multiple ivoids to match.  As usual,
             they are combined by an or.
         """
-        self.ivoids = [id.lower() for id in (ivoid,)+more_ivoids]
+        self.ivoids = [id.lower() for id in (ivoid,) + more_ivoids]
 
     def get_search_condition(self, service):
         return " OR ".join(
-            "ivoid={}".format(make_sql_literal(id))
-                for id in self.ivoids)
+            f"ivoid={make_sql_literal(id)}" for id in self.ivoids)
 
 
 class UCD(Constraint):

--- a/pyvo/registry/tests/test_regtap.py
+++ b/pyvo/registry/tests/test_regtap.py
@@ -800,7 +800,7 @@ class TestExtraResourceMethods:
         rsc.describe(verbose=True, file=out)
         output = out.getvalue()
         # should cut the long author name at 70 characters
-        assert f"Authors: {'a'*70}..." in output
+        assert f"Authors: {'a' * 70}..." in output
 
     def test_no_access_url(self):
         rsc = _makeRegistryRecord(

--- a/pyvo/registry/tests/test_rtcons.py
+++ b/pyvo/registry/tests/test_rtcons.py
@@ -221,8 +221,8 @@ class TestIvoidConstraint:
             "ivo://org.gavo.dc/tap",
             "ivo://org.gavo.dc/__system__/siap2/sitewide")
         assert (cons.get_search_condition(FAKE_GAVO)
-                == "ivoid='ivo://org.gavo.dc/tap'"
-                    " OR ivoid='ivo://org.gavo.dc/__system__/siap2/sitewide'")
+                == ("ivoid='ivo://org.gavo.dc/tap'"
+                    " OR ivoid='ivo://org.gavo.dc/__system__/siap2/sitewide'"))
 
 
 class TestUCDConstraint:

--- a/pyvo/registry/tests/test_rtcons.py
+++ b/pyvo/registry/tests/test_rtcons.py
@@ -214,7 +214,15 @@ class TestIvoidConstraint:
     def test_basic(self):
         cons = rtcons.Ivoid("ivo://example/some_path")
         assert (cons.get_search_condition(FAKE_GAVO)
-                == "ivoid = 'ivo://example/some_path'")
+                == "ivoid='ivo://example/some_path'")
+
+    def test_multiple(self):
+        cons = rtcons.Ivoid(
+            "ivo://org.gavo.dc/tap",
+            "ivo://org.gavo.dc/__system__/siap2/sitewide")
+        assert (cons.get_search_condition(FAKE_GAVO)
+                == "ivoid='ivo://org.gavo.dc/tap'"
+                    " OR ivoid='ivo://org.gavo.dc/__system__/siap2/sitewide'")
 
 
 class TestUCDConstraint:


### PR DESCRIPTION
As usual in the pyvo Regtap API, these will then be matched in a disjunction.