### PR TITLE
Fixing two function signatures that recently went bad.

### DIFF
--- a/pyvo/dal/scs.py
+++ b/pyvo/dal/scs.py
@@ -33,7 +33,7 @@ from .adhoc import DatalinkResultsMixin, DatalinkRecordMixin
 __all__ = ["search", "SCSService", "SCSQuery", "SCSResults", "SCSRecord"]
 
 
-def search(url, pos, *, radius=1.0, verbosity=2, **keywords):
+def search(url, pos, radius=1.0, *, verbosity=2, **keywords):
     """
     submit a simple Cone Search query that requests objects or observations
     whose positions fall within some distance from a search position.
@@ -138,7 +138,7 @@ class SCSService(DALService):
         except AttributeError:
             return []
 
-    def search(self, pos, *, radius=1.0, verbosity=2, **keywords):
+    def search(self, pos, radius=1.0, *, verbosity=2, **keywords):
         """
         submit a simple Cone Search query that requests objects or observations
         whose positions fall within some distance from a search position.
@@ -274,7 +274,7 @@ class SCSQuery(DALQuery):
     """
 
     def __init__(
-            self, baseurl, pos=None, *, radius=None, verbosity=None, session=None, **keywords):
+            self, baseurl, pos=None, radius=None, *, verbosity=None, session=None, **keywords):
         """
         initialize the query object with a baseurl and the given parameters
 

--- a/pyvo/registry/regtap.py
+++ b/pyvo/registry/regtap.py
@@ -805,8 +805,7 @@ class RegistryResource(dalq.Record):
 
         return candidates[0]
 
-    def get_service(self, *,
-                    service_type: str = None,
+    def get_service(self, service_type: str = None, *,
                     lax: bool = False,
                     keyword: str = None):
         """


### PR DESCRIPTION
This addresses #512, which made the SCS radius keyword-only.  As said
in the bug report, we might consider deprecating the default 1 for the
radius, as it really makes no sense, but I am too lazy to figure out
a good way to emit a DeprecationWarning when someone relies on the
default, and frankly, I don't think that's a bug magnet.

It also addresses #513.  I'm afraid removing the None default here isn't much
of an option given historical usage patterns.  But forcing people
to type service_type here is just wrong.

I don't think this warrants a changelog entry, since I think the breaking 
changes never made them there (explicitly) either.