### PR TITLE
BUG: fixing maxrec=0 case for SIA2 queries

### DIFF
--- a/pyvo/dal/sia2.py
+++ b/pyvo/dal/sia2.py
@@ -447,10 +447,10 @@ class SIA2Query(DALQuery, AxisParamMixin):
 
     @maxrec.setter
     def maxrec(self, val):
-        if not val:
-            return
-        if not isinstance(val, int) and val > 0:
-            raise ValueError('maxrec {} must be positive int'.format(val))
+        if not isinstance(val, int):
+            if not val:
+                return
+            raise ValueError(f'maxrec {val} must be non-negative int')
         self._maxrec = val
         self['MAXREC'] = str(val)
 


### PR DESCRIPTION
(It should be valid special case where the service respond with metadata-only)


However, something this doesn't work as expected, as e.g.  https://irsa.ipac.caltech.edu/SIA/?MAXREC=0 returns the possible options for the parameters, I don't see this same happening when running it through pyvo with `SIA2Service(baseurl='https://irsa.ipac.caltech.edu/SIA').search(maxrec=0)`, or eventually what's under the hood with `SIA2Query(baseurl, maxrec=0)` 

Direct call:
```
<?xml version="1.0" encoding="utf-8"?>
<VOTABLE version="1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:stc="http://www.ivoa.net/xml/STC/v1.30" xsi:schemaLocation="http://www.ivoa.net/xml/VOTable/v1.3 http://www.ivoa.net/xml/VOTable/v1.3 http://www.ivoa.net/xml/STC/v1.30 http://www.ivoa.net/xml/STC/v1.30">
  <RESOURCE type="meta" utype="adhoc:this">
    <DESCRIPTION>Self description and list of supported parameters</DESCRIPTION>
    <GROUP name="inputParams">
      <PARAM name="BAND" datatype="double" arraysize="*" unit="m" xtype="interval">
        <DESCRIPTION>Specify energy bounds</DESCRIPTION>
      </PARAM>
      <PARAM name="CALIB" datatype="int" arraysize="*">
        <DESCRIPTION>Specify calibration level</DESCRIPTION>
        <VALUES type="actual">
          <OPTION value="1"/>
          <OPTION value="2"/>
          <OPTION value="3"/>
          <OPTION value="4"/>
        </VALUES>
      </PARAM>
      <PARAM name="COLLECTION" datatype="char" arraysize="*">
        <DESCRIPTION>Specify collection name</DESCRIPTION>
        <VALUES type="actual">
          <OPTION value="akari_allskymaps"/>
          <OPTION value="blast"/>
          <OPTION value="bolocam_gps"/>
          <OPTION value="bolocam_lh"/>
          <OPTION value="bolocam_planck_sz"/>
          <OPTION value="goals"/>
          <OPTION value="heron"/>
          <OPTION value="herschel_acmc"/>
          <OPTION value="herschel_coldcores"/>
          <OPTION value="herschel_cooltnos"/>
```

pyvo:

```
<?xml version="1.0" encoding="utf-8"?>
<!-- Produced with astropy.io.votable version 6.0.0
     http://www.astropy.org/ -->
<VOTABLE version="1.3" xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.ivoa.net/xml/VOTable/v1.3 http://www.ivoa.net/xml/VOTable/VOTable-1.3.xsd">
 <RESOURCE type="meta" utype="adhoc:this">
  <DESCRIPTION>
   Self description and list of supported parameters
  </DESCRIPTION>
  
  <PARAM ID="standardID" arraysize="*" datatype="char" name="standardID" value="ivo://ivoa.net/std/SIA#query-2.0"/>
  <PARAM ID="accessURL" arraysize="*" datatype="char" name="accessURL" value="https://irsa.ipac.caltech.edu/SIA"/>
  <PARAM ID="resourceIdentifier" arraysize="*" datatype="char" name="resourceIdentifier" value="ivo://irsa.ipac/SIA"/>
 </RESOURCE>
 <RESOURCE type="results">
  <INFO ID="QUERY_STATUS" name="QUERY_STATUS" value="OVERFLOW"/>
  <TABLE nrows="0">
   <FIELD ID="s_ra" datatype="double" name="s_ra" ucd="pos.eq.ra" unit="deg" utype="obscore:char.spatialaxis.coverage.location.coord.position2d.value2.c1">
    <DESCRIPTION>
     Central Spatial Position in ICRS Right ascension
    </DESCRIPTION>
   </FIELD>
   <FIELD ID="s_dec" datatype="double" name="s_dec" ucd="pos.eq.dec" unit="deg" utype="obscore:char.spatialaxis.coverage.location.coord.position2d.value2.c2">
    <DESCRIPTION>
     Central Spatial Position in ICRS Declination
    </DESCRIPTION>
   </FIELD>
   ```