### PR TITLE
Replace list_services by list_interfaces

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,10 @@ Enhancements and Fixes
 - Add method ``list_interfaces`` to ``pyvo.registry.regtap.RegistryResource``
   that returns the list of available interfaces linked to services.
   Add ``keyword`` parameter in ``get_service`` which should match
-  ``capability_description``. [#505, #524]
+  ``capability_description``. [#505, #525]
+
+- Add list of access points to services in ``pyvo.registry.regtap.RegistryResource.describe``
+  when there is more than one service available [#525]
 
 - Add optional ``capability_description`` parameter and a ``__repr__`` to ``pyvo.dal.query.DALService``
   abstract base class [#505]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,9 +4,10 @@
 Enhancements and Fixes
 ----------------------
 
-- Add method ``list_services`` to ``pyvo.registry.regtap.RegistryResource`` that returns the
-  list of available services. Add ``keyword`` parameter in ``get_service`` which should match
-  ``capability_description``. [#505]
+- Add method ``list_interfaces`` to ``pyvo.registry.regtap.RegistryResource``
+  that returns the list of available interfaces linked to services.
+  Add ``keyword`` parameter in ``get_service`` which should match
+  ``capability_description``. [#505, #524]
 
 - Add optional ``capability_description`` parameter and a ``__repr__`` to ``pyvo.dal.query.DALService``
   abstract base class [#505]

--- a/docs/registry/index.rst
+++ b/docs/registry/index.rst
@@ -206,25 +206,32 @@ the first conesearch it finds.
 
 However some providers provide multiple services of the same type
 -- for example in VizieR you'll find one conesearch per table.
-In this case, you can inspect the available services with
-`~pyvo.registry.regtap.RegistryResource.list_services`. Then, you can refine your
+In this case, you can inspect the available `~pyvo.registry.regtap.Interface` to services with
+`~pyvo.registry.regtap.RegistryResource.list_interfaces`. Then, you can refine your
 instructions to `~pyvo.registry.regtap.RegistryResource.get_service` with a keyword
 constraint on the description ``get_service(service_type='conesearch', keyword='sncat')``.
 
 .. doctest-remote-data::
 
-  >>> for service in voresource.list_services():
-  ...     print(service)
-  TAPService(baseurl : 'http://tapvizier.cds.unistra.fr/TAPVizieR/tap', description : '')
-  BrowserService(baseurl : 'http://vizier.cds.unistra.fr/viz-bin/VizieR-2?-source=II/283', description : 'None')
-  SCSService(baseurl : 'http://vizier.cds.unistra.fr/viz-bin/conesearch/II/283/sncat?', description : 'Cone search capability for table II/283/sncat (List of SNe arranged in chronological order)')
+  >>> for interface in voresource.list_interfaces():
+  ...     print(interface)
+  Interface(type='tap#aux', description='', url='http://tapvizier.cds.unistra.fr/TAPVizieR/tap')
+  Interface(type='conesearch', description='Cone search capability for table II/283/sncat (List of SNe arranged in chronological order)', url='http://vizier.cds.unistra.fr/viz-bin/conesearch/II/283/sncat?')
 
-Or to get the list of services corresponding to a specific service type:
+Or construct the service object directly from the list of interfaces with:
+
+.. doctest-remote-data::
+  
+  >>> voresource.list_interfaces()[0].to_service()
+  TAPService(baseurl : 'http://tapvizier.cds.unistra.fr/TAPVizieR/tap', description : '')
+ 
+The list of interfaces can also be filtered to interfaces corresponding to services of a
+specific service type:
 
 .. doctest-remote-data::
 
-  >>> voresource.list_services("tap")
-  [TAPService(baseurl : 'http://tapvizier.cds.unistra.fr/TAPVizieR/tap', description : '')]
+  >>> voresource.list_interfaces("tap")
+  [Interface(type='tap#aux', description='', url='http://tapvizier.cds.unistra.fr/TAPVizieR/tap')]
 
 To operate TAP services, you need to know what tables make up a
 resource; you could construct a TAP service and access its ``tables``

--- a/docs/registry/index.rst
+++ b/docs/registry/index.rst
@@ -216,6 +216,7 @@ constraint on the description ``get_service(service_type='conesearch', keyword='
   >>> for interface in voresource.list_interfaces():
   ...     print(interface)
   Interface(type='tap#aux', description='', url='http://tapvizier.cds.unistra.fr/TAPVizieR/tap')
+  Interface(type='vr:webbrowser', description='', url='http://vizier.cds.unistra.fr/viz-bin/VizieR-2?-source=II/283')
   Interface(type='conesearch', description='Cone search capability for table II/283/sncat (List of SNe arranged in chronological order)', url='http://vizier.cds.unistra.fr/viz-bin/conesearch/II/283/sncat?')
 
 Or construct the service object directly from the list of interfaces with:
@@ -446,7 +447,7 @@ the ``describe`` function.
   Short Name: NVSS
   IVOA Identifier: ivo://nasa.heasarc/skyview/nvss
   Access modes: sia
-  Base URL: https://skyview.gsfc.nasa.gov/cgi-bin/vo/sia.pl?survey=nvss&
+  - sia: https://skyview.gsfc.nasa.gov/cgi-bin/vo/sia.pl?survey=nvss&
   ...
 
 The verbose option in ``describe`` will output more information about

--- a/pyvo/registry/regtap.py
+++ b/pyvo/registry/regtap.py
@@ -402,7 +402,7 @@ class Interface:
 
         # a service is user visible if it has a corresponding service class
         if self.standard_id is not None and self.standard_id != "":
-            service_type = self.standard_id.split("#")[0]  # remove possible suffixes
+            service_type = self.standard_id.split("#")[0]  # remove possible suffixes/standard keys
             self.is_user_visible = service_type in self.service_for_standardid
         # or if it is a webpage
         else:
@@ -909,15 +909,15 @@ class RegistryResource(dalq.Record):
         get_service : when you already know that there is only one service of a specific service type.
 
         """
-        list_interfaces = [interface for interface in self.interfaces
-                           if interface.is_user_visible]
+        interfaces = [interface for interface in self.interfaces
+                      if interface.is_user_visible]
 
         if service_type is not None:
             service_type = expand_stdid(rtcons.SERVICE_TYPE_MAP.get(service_type, service_type))
-            list_interfaces = [interface for interface in list_interfaces
-                               if interface.is_standard and interface.supports(service_type)]
+            interfaces = [interface for interface in interfaces
+                          if interface.is_standard and interface.supports(service_type)]
 
-        return sorted(list_interfaces, key=lambda interface: interface.access_url)
+        return sorted(interfaces, key=lambda interface: interface.access_url)
 
     def search(self, *args, **keys):
         """

--- a/pyvo/registry/tests/test_regtap.py
+++ b/pyvo/registry/tests/test_regtap.py
@@ -218,14 +218,11 @@ class TestInterfaceClass:
         intf = regtap.Interface("http://example.org", standard_id="ivo://gavo/std/a",
                                 intf_type="vs:paramhttp", intf_role="std",
                                 capability_description=description)
-        assert (repr(intf) == "Interface('http://example.org',"
-                " standard_id='ivo://gavo/std/a', intf_type='vs:paramhttp', intf_role='std',"
-                " capability_description='An example description.')")
-        intf = regtap.Interface("http://example.org", standard_id="ivo://gavo/std/a",
-                                intf_type=None, intf_role=None, capability_description=None)
-        assert repr(intf) == ("Interface('http://example.org',"
-                              " standard_id='ivo://gavo/std/a', intf_type=None, intf_role=None, "
-                              "capability_description=None)")
+        assert (repr(intf) == "Interface(type='a', description='An example description.',"
+                " url='http://example.org')")
+        intf = regtap.Interface("http://example.org", capability_description=description)
+        assert repr(intf) == ("Interface(description='An example description.',"
+                " url='http://example.org')")
 
     def test_unknown_standard(self):
         intf = regtap.Interface("http://example.org", standard_id="ivo://gavo/std/a",
@@ -593,7 +590,7 @@ class TestInterfaceSelection:
         assert str(excinfo.value) == (
             "Resource ivo://pyvo/test_regtap.py is not a searchable service")
 
-    def test_list_services(self):
+    def test_list_interfaces(self):
         rec = _makeRegistryRecord(
             access_urls=["http://sia.example.com", "http://sia.example.com",
                          "http://tap.example.com", "http://website.com"],
@@ -605,9 +602,9 @@ class TestInterfaceSelection:
             intf_types=["vs:paramhttp"] * 4,
             cap_descriptions=["A mock service."] * 4)
         # all available standard services
-        assert len(rec.list_services()) == 3
+        assert len(rec.list_interfaces()) == 3
         # only sia ones
-        assert len(rec.list_services("sia")) == 2
+        assert len(rec.list_interfaces("sia")) == 2
 
 
 class _FakeResult:

--- a/pyvo/registry/tests/test_regtap.py
+++ b/pyvo/registry/tests/test_regtap.py
@@ -593,16 +593,18 @@ class TestInterfaceSelection:
     def test_list_interfaces(self):
         rec = _makeRegistryRecord(
             access_urls=["http://sia.example.com", "http://sia.example.com",
-                         "http://tap.example.com", "http://website.com"],
+                         "http://tap.example.com", "http://vosi.example.com",
+                         "http://website.com"
+                         ],
             standard_ids=["ivo://ivoa.net/std/sia#aux",
                           "ivo://ivoa.net/std/sia#aux",
                           "ivo://ivoa.net/std/tap",
-                          ""],
-            intf_roles=["std"] * 3 + ["non standard"],
-            intf_types=["vs:paramhttp"] * 4,
-            cap_descriptions=["A mock service."] * 4)
-        # all available standard services
-        assert len(rec.list_interfaces()) == 3
+                          "ivo://ivoa.net/std/vosi", ""],
+            intf_roles=["std"] * 4 + ["non standard"],
+            intf_types=["vs:paramhttp"] * 4 + ["vr:webbrowser"],
+            cap_descriptions=["A mock service."] * 5)
+        # webpages should be there, but not vosi
+        assert len(rec.list_interfaces()) == 4
         # only sia ones
         assert len(rec.list_interfaces("sia")) == 2
 

--- a/pyvo/registry/tests/test_regtap.py
+++ b/pyvo/registry/tests/test_regtap.py
@@ -221,7 +221,7 @@ class TestInterfaceClass:
         assert (repr(intf) == "Interface(type='a', description='An example description.',"
                 " url='http://example.org')")
         intf = regtap.Interface("http://example.org", capability_description=description)
-        assert repr(intf) == ("Interface(description='An example description.',"
+        assert repr(intf) == ("Interface(type=None, description='An example description.',"
                 " url='http://example.org')")
 
     def test_unknown_standard(self):
@@ -769,7 +769,10 @@ class TestExtraResourceMethods:
         assert "Flash/Heros SSAP" in output
         assert ("Access modes: datalink#links-1.1, soda#sync-1.0,"
                 " ssa, tap#aux, web" in output)
-        assert "Multi-capability service" in output
+        assert "- webpage: http://dc.zah.uni-heidelberg.de/flashheros/q/web/form" in output
+        assert "- tap#aux: http://dc.zah.uni-heidelberg.de/tap" in output
+        # datalink, soda and vosi are not printed here
+        assert "- datalink" not in output
         assert "Source: 1996A&A...312..539S" in output
         assert "Authors: Wolf" in output
         assert "Alternative identifier(s): doi:10.21938/" in output

--- a/pyvo/registry/tests/test_regtap.py
+++ b/pyvo/registry/tests/test_regtap.py
@@ -762,7 +762,6 @@ class TestExtraResourceMethods:
             intf_roles=["std"])
         assert rsc.standard_id == "ivo://ivoa.net/std/tap"
 
-    @pytest.mark.remote_data
     def test_describe_multi(self, flash_service):
         out = io.StringIO()
         flash_service.describe(verbose=True, file=out)
@@ -780,7 +779,6 @@ class TestExtraResourceMethods:
         assert "Alternative identifier(s): doi:10.21938/" in output
         assert "More info: http://dc.zah" in output
 
-    @pytest.mark.remote_data
     def test_describe_long_authors_list(self):
         """Check that long list of authors use et al.."""
         rsc = _makeRegistryRecord(
@@ -798,7 +796,6 @@ class TestExtraResourceMethods:
         # output should cut at 5 authors
         assert "Authors: a, a, a, a, a et al." in output
 
-    @pytest.mark.remote_data
     def test_describe_long_author_name(self):
         """Check that long author names are truncated."""
         rsc = _makeRegistryRecord(


### PR DESCRIPTION
This PR addresses #521 

The `list_services` method is removed and replaced by `list_interfaces` to prevent the instantiation of Service objects that wouldn't be used.

The repr of the class Interfaces (added in #505 so not impacting the released version) is now lighter/shorter. 