### PR TITLE
MAINT: do less style checks

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,8 @@ max-line-length = 110
 max-doc-length = 110
 exclude = __init__.py, conf.py, setup.py, version.py, conftest.py
 # W503 line break before operator
-ignore = W503,E128,E131
+# E226 missing whitespace around arithmetic operator
+ignore = W503,E226,E128,E131
 
 
 [pycodestyle]


### PR DESCRIPTION
This turns off check for `foo/2`vs `foo / 2`, but still keeps checking for spaces around operators for better legibility, e.g. `foo < bar` and not `foo<bar`.

Similarly, we keep `foo = 2` while `bar(foo=2)`.

https://github.com/astropy/pyvo/pull/470#issuecomment-1963998088

@msdemlei - if you have other specific error code you would like to turn off, please comment them here. The whitespace in arithmetic is a typically problematic one, so I fully agree that we can turn that off, but I find the rest of the examples above useful choices.