### PR TITLE
Async TAP delete no longer pulls the joblist.

### DIFF
--- a/pyvo/dal/tap.py
+++ b/pyvo/dal/tap.py
@@ -966,7 +966,9 @@ class AsyncTAPJob:
         deletes the job. this object will become invalid.
         """
         try:
-            response = self._session.post(self.url, data={"ACTION": "DELETE"})
+            response = self._session.delete(
+                self.url,
+                allow_redirects=False)
             response.raise_for_status()
         except requests.RequestException as ex:
             raise DALServiceError.from_except(ex, self.url)


### PR DESCRIPTION
I am also moving from the ACTION=DELETE hack to using a proper DELETE action (which really is purely aesthetic).

Background: bug #535.

I'd argue that this is a minor optimisation and can live without a changelog entry.