### PR TITLE
Fixing SODA_SYNC_IVOID so we work with all version 1 SODA services.

### DIFF
--- a/pyvo/dal/adhoc.py
+++ b/pyvo/dal/adhoc.py
@@ -30,7 +30,7 @@ from ..dam.obscore import POLARIZATION_STATES
 # reasons. This is the size of a batch
 DATALINK_BATCH_CALL_SIZE = 50
 
-SODA_SYNC_IVOID = 'ivo://ivoa.net/std/SODA#sync-1.0'
+SODA_SYNC_IVOID = 'ivo://ivoa.net/std/SODA#sync-1'
 DATALINK_IVOID = 'ivo://ivoa.net/std/datalink'
 
 # MIME types
@@ -109,7 +109,6 @@ class AdhocServiceResultsMixin:
 
     def __init__(self, votable, *, url=None, session=None):
         super().__init__(votable, url=url, session=session)
-
         self._adhocservices = list(
             resource for resource in votable.resources
             if resource.type == "meta" and resource.utype == "adhoc:service"


### PR DESCRIPTION
While protocol IVOIDs in the VO give the full version, matching must ignore the the minor version or we'll break when a new minor version is out.  Discussion on version 1.1 of SODA is just starting.  Let's better clean this up now.

Actually, it would even be better if we fixed get_adhocservice_by_ivoid to accept a regular expression, because we we really ought to be matching aginst is ivo://ivoa.net/std/SODA#sync-1\.\d+; but I'd say that can wait until there is thought of SODA 10.x.

Again, I'd argue this is a minor, preventive bug fix that can do without a changelog entry.  SODA 1.1 also is at least one year away, so there's probably no need for backports.