### PR TITLE
MAINT: fix doctest for online CI job

### DIFF
--- a/docs/dal/index.rst
+++ b/docs/dal/index.rst
@@ -198,7 +198,7 @@ Furthermore, one can find the names of the tables using:
 .. doctest-remote-data::
 
     >>> print([tab_name for tab_name in tap_service.tables.keys()])  # doctest: +IGNORE_WARNINGS
-    ['amanda.nucand', 'annisred.main', 'antares.data', ..., 'wise.main', 'xpparams.main', 'zcosmos.data']
+    ['ivoa.obs_radio', 'ivoa.obscore', 'tap_schema.columns', 'tap_schema.tables',..., 'taptest.main', 'veronqsos.data', 'vlastripe82.stripe82']
 
 
 And also the names of the columns from a known table, for instance


### PR DESCRIPTION
This should fix the online job
(note: on CI there are two failures, but I could only reproduce the doctest failure locally. I'll push a fix for the other one here, too if it is still around in CI)