### PR TITLE
Updated SIA up-casing behavior

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,8 +23,9 @@ Enhancements and Fixes
   them. [#517]
 
 - Introducing the new MIVOT module, enabling processed VOTable data mapped to
-  any model serialized in VO-DML. This package dynamically generates python objects 
+  any model serialized in VO-DML. This package dynamically generates python objects
   whose structure corresponds to the classes of the mapped models. [#497]
+
 
 Deprecations and Removals
 -------------------------
@@ -38,6 +39,8 @@ Bug Fixes
 
 - Avoid Astropy Time error for SIAResult.dateobs when
   VOX:Image_MJDateObs or ssa:DataID.Date is nan. [#550]
+
+- More robust handling of SIA1 FORMAT [#545]
 
 
 1.5.1 (2024-02-21)

--- a/pyvo/dal/sia.py
+++ b/pyvo/dal/sia.py
@@ -509,16 +509,13 @@ class SIAQuery(DALQuery):
         if not isinstance(format_, list):
             format_ = format_.split(',')
         normalized_formats = []
-        for _ in format_:
-            if _.upper() in ['ALL', 'METADATA', 'GRAPHIC', 'GRAPHIC-ALL']:
-                normalized_formats += [_.upper()]
-            elif _.split('-')[0].upper() == 'GRAPHIC':
-                normalized_formats += [_.split('-')[0].upper()+"-"+_.split('-')[1]]
-            elif _.lower() in ['image', 'image/png', 'image/jpeg', 'image/gif',
-                               'image/fits', 'png', 'jpeg', 'fits', 'gif']:
-                normalized_formats += [_.lower()]
+        for user_input in format_:
+            if user_input.upper() in ['ALL', 'METADATA', 'GRAPHIC', 'GRAPHIC-ALL']:
+                normalized_formats += [user_input.upper()]
+            elif user_input.split('-')[0].upper() == 'GRAPHIC':
+                normalized_formats += [user_input.split('-')[0].upper()+"-"+user_input.split('-')[1]]
             else:
-                normalized_formats += [_]
+                normalized_formats += [user_input]
 
         self["FORMAT"] = ",".join(normalized_formats)
 

--- a/pyvo/dal/sia.py
+++ b/pyvo/dal/sia.py
@@ -504,24 +504,23 @@ class SIAQuery(DALQuery):
 
     @format.setter
     def format(self, format_):
-        print("Set format")
         setattr(self, "_format", format_)
 
-        if isinstance(format_, (str, bytes)):
-            format_ = [format_]
-        format__ = []
+        if not isinstance(format_, list):
+            format_ = format_.split(',')
+        normalized_formats = []
         for _ in format_:
             if _.upper() in ['ALL', 'METADATA', 'GRAPHIC', 'GRAPHIC-ALL']:
-                format__ += [_.upper()]
+                normalized_formats += [_.upper()]
             elif _.split('-')[0].upper() == 'GRAPHIC':
-                # GRAPHIC-xxx not supported, will throw an error and suggest supported arguments
-                # If it gets support, uncomment the following line:
-                # format__ += _.split('-'[0].upper()+"-"+_.split('-')[1].lower())
-                pass
+                normalized_formats += [_.split('-')[0].upper()+"-"+_.split('-')[1]]
+            elif _.lower() in ['image', 'image/png', 'image/jpeg', 'image/gif',
+                               'image/fits', 'png', 'jpeg', 'fits', 'gif']:
+                normalized_formats += [_.lower()]
             else:
-                format__ += [_.lower()]
+                normalized_formats += [_]
 
-        self["FORMAT"] = ",".join(format__)
+        self["FORMAT"] = ",".join(normalized_formats)
 
     @format.deleter
     def format(self):

--- a/pyvo/dal/sia.py
+++ b/pyvo/dal/sia.py
@@ -511,11 +511,11 @@ class SIAQuery(DALQuery):
         normalized_formats = []
         for user_input in format_:
             if user_input.upper() in ['ALL', 'METADATA', 'GRAPHIC', 'GRAPHIC-ALL']:
-                normalized_formats += [user_input.upper()]
+                normalized_formats.append(user_input.upper())
             elif user_input.split('-')[0].upper() == 'GRAPHIC':
-                normalized_formats += [user_input.split('-')[0].upper()+"-"+user_input.split('-')[1]]
+                normalized_formats.append(user_input.split('-')[0].upper()+"-"+user_input.split('-')[1])
             else:
-                normalized_formats += [user_input]
+                normalized_formats.append(user_input)
 
         self["FORMAT"] = ",".join(normalized_formats)
 

--- a/pyvo/dal/sia.py
+++ b/pyvo/dal/sia.py
@@ -508,8 +508,19 @@ class SIAQuery(DALQuery):
 
         if isinstance(format_, (str, bytes)):
             format_ = [format_]
+        format__ = []
+        for _ in format_:
+            if _.upper() in ['ALL', 'METADATA', 'GRAPHIC']:
+                format__ += [_.upper()]
+            elif _.split('-')[0].upper() == 'GRAPHIC':
+                if _.split('-')[1].upper() == 'ALL':
+                    format__ += [_.upper()]
+                else:
+                    format__ += _.split('-'[0].upper()+"-"+_.split('-')[1].lower())
+            else:
+                format__ += [_.lower()]
 
-        self["FORMAT"] = ",".join(_.upper() for _ in format_)
+        self["FORMAT"] = ",".join(format__)
 
     @format.deleter
     def format(self):

--- a/pyvo/dal/sia.py
+++ b/pyvo/dal/sia.py
@@ -504,19 +504,20 @@ class SIAQuery(DALQuery):
 
     @format.setter
     def format(self, format_):
+        print("Set format")
         setattr(self, "_format", format_)
 
         if isinstance(format_, (str, bytes)):
             format_ = [format_]
         format__ = []
         for _ in format_:
-            if _.upper() in ['ALL', 'METADATA', 'GRAPHIC']:
+            if _.upper() in ['ALL', 'METADATA', 'GRAPHIC', 'GRAPHIC-ALL']:
                 format__ += [_.upper()]
             elif _.split('-')[0].upper() == 'GRAPHIC':
-                if _.split('-')[1].upper() == 'ALL':
-                    format__ += [_.upper()]
-                else:
-                    format__ += _.split('-'[0].upper()+"-"+_.split('-')[1].lower())
+                # GRAPHIC-xxx not supported, will throw an error and suggest supported arguments
+                # If it gets support, uncomment the following line:
+                # format__ += _.split('-'[0].upper()+"-"+_.split('-')[1].lower())
+                pass
             else:
                 format__ += [_.lower()]
 

--- a/pyvo/dal/tests/test_sia.py
+++ b/pyvo/dal/tests/test_sia.py
@@ -54,6 +54,7 @@ def test_search(position, format):
 
     _test_result(result)
 
+
 class TestSIAService:
     @pytest.mark.usefixtures('sia')
     @pytest.mark.usefixtures('register_mocks')
@@ -81,7 +82,7 @@ class TestSIAService:
     @pytest.mark.filterwarnings("ignore::astropy.io.votable.exceptions.W49")
     def test_formatter(self):
         service = SIAQuery('http://example.com/sia')
-        service.format = "Image"
+        service.format = "image"
         assert service["FORMAT"] == "image"
         service.format = "all"
         assert service["FORMAT"] == "ALL"

--- a/pyvo/dal/tests/test_sia.py
+++ b/pyvo/dal/tests/test_sia.py
@@ -81,7 +81,11 @@ class TestSIAService:
     @pytest.mark.filterwarnings("ignore::astropy.io.votable.exceptions.W49")
     def test_formatter(self):
         service = SIAQuery('http://example.com/sia')
-        service.format = "IMAGE"
+        service.format = "Image"
         assert service["FORMAT"] == "image"
         service.format = "all"
         assert service["FORMAT"] == "ALL"
+        service.format = "Graphic-png"
+        assert service["FORMAT"] == "GRAPHIC-png"
+        service.format = "Unsupported"
+        assert service["FORMAT"] == "Unsupported"

--- a/pyvo/dal/tests/test_sia.py
+++ b/pyvo/dal/tests/test_sia.py
@@ -8,7 +8,7 @@ import re
 
 import pytest
 
-from pyvo.dal.sia import search, SIAService
+from pyvo.dal.sia import search, SIAService, SIAQuery
 
 from astropy.io.fits import HDUList
 from astropy.coordinates import SkyCoord
@@ -47,12 +47,12 @@ def _test_result(result):
 @pytest.mark.usefixtures('register_mocks')
 @pytest.mark.filterwarnings("ignore::astropy.io.votable.exceptions.W06")
 @pytest.mark.parametrize("position", ((288, 15), SkyCoord(288, 15, unit="deg")))
-def test_search(position):
-    results = search('http://example.com/sia', pos=position)
+@pytest.mark.parametrize("format", ("IMAGE/JPEG", "all"))
+def test_search(position, format):
+    results = search('http://example.com/sia', pos=position, format=format)
     result = results[0]
 
     _test_result(result)
-
 
 class TestSIAService:
     @pytest.mark.usefixtures('sia')
@@ -73,3 +73,15 @@ class TestSIAService:
         _test_result(result)
 
         assert results[1].dateobs is None
+
+    @pytest.mark.usefixtures('sia')
+    @pytest.mark.usefixtures('register_mocks')
+    @pytest.mark.filterwarnings("ignore::astropy.io.votable.exceptions.W06")
+    @pytest.mark.filterwarnings("ignore::astropy.io.votable.exceptions.W42")
+    @pytest.mark.filterwarnings("ignore::astropy.io.votable.exceptions.W49")
+    def test_formatter(self):
+        service = SIAQuery('http://example.com/sia')
+        service.format = "IMAGE"
+        assert service["FORMAT"] == "image"
+        service.format = "all"
+        assert service["FORMAT"] == "ALL"


### PR DESCRIPTION
Modified the behavior of the SIA service where it would upcase all format keywords. Modified to upcase keywords "ALL", "METADATA", and "GRAPHIC", otherwise the parameter is passed unchanged. The format "GRAPHIC-xyz" will capitalize "GRAPHIC" and leave the rest unchanged. 

Tests have been added to check that the formats are cased as expected. Variable names have been updated to be more descriptive.

Edit: changed description of PR to reflect updates.