### PR TITLE
DOC: ignore output in doctests

### DIFF
--- a/docs/registry/index.rst
+++ b/docs/registry/index.rst
@@ -369,7 +369,7 @@ and access URL:
 .. doctest-remote-data::
 
   >>> for service in archives:
-  ...     print(service.res_title, service.access_url)
+  ...     print(service.res_title, service.access_url)  # doctest: +IGNORE_OUTPUT
   Chandra X-ray Observatory Data Archive https://cda.harvard.edu/cxcsiap/queryImages?
   Chandra Source Catalog Release 1 http://cda.cfa.harvard.edu/csc1siap/queryImages?
   ...


### PR DESCRIPTION
This is to fix the CI. I skip comparing the doctest output because it has recently been flakey.