### PR TITLE
Update of the dictionaries that are used to build the MIVOT_INSTANCE

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,12 +34,14 @@ Enhancements and Fixes
   any model serialized in VO-DML. This package dynamically generates python objects
   whose structure corresponds to the classes of the mapped models. [#497]
 
+- MIVOT module: the model references in the dictionaries that are used to build ``MivotInstance``
+  objects are made more consistent [#551]
+
 - RegTAP constraints involving tables other than rr.resource are now
   done via subqueries for less duplication of interfaces. [#562]
 
 - Where datalink records are made from table rows, the table row is
   now accessible as datalinks.original_row. []
-
 
 Deprecations and Removals
 -------------------------

--- a/docs/mivot/index.rst
+++ b/docs/mivot/index.rst
@@ -103,7 +103,7 @@ Model leaves (class attributes) are complex types that provide additional inform
 - ``ref``: identifier of the table column mapped on the attribute
 
 The model view on a data row can also be passed as a Python dictionary
-using the ``dict`` property of ``MivotInstance``.
+using the ``to_dict()`` method of ``MivotInstance``. 
 
 .. code-block:: python
     :caption: Working with a model view as a dictionary
@@ -114,7 +114,7 @@ using the ``dict`` property of ``MivotInstance``.
     
     m_viewer = MivotViewer(path_to_votable)
     mivot_instance = m_viewer.dm_instance
-    mivot_object_dict = mivot_object.dict
+    mivot_object_dict = mivot_object.to_dict()
 
     DictUtils.print_pretty_json(mivot_object_dict)
 	{
@@ -133,9 +133,11 @@ using the ``dict`` property of ``MivotInstance``.
     }
 
 - It is recommended to use a copy of the
-  dictionary as it will be rebuilt each time the ``dict`` property is invoked.
+  dictionary as it will be rebuilt each time the ``to_dict()`` method is invoked.
 - The default representation of ``MivotInstance`` instances is made with a pretty
-  string serialization of this dictionary.
+  string serialization of this dictionary (method ``__repr__()``).
+- An extended version of the object dictionary e.g. with information about where 
+  the values were picked from from, is available  using the method ``to_hk_dict()``.
 
 Per-Row Readout
 ---------------
@@ -207,7 +209,7 @@ identifiers, which have the following structure: ``model:a.b``.
 - Original ``@dmtype`` are kept as attributes of generated Python objects.
 - The structure of the ``MivotInstance`` objects can be inferred from the mapped model in 2 different ways:
 
-  - 1.  From the MIVOT instance property ``MivotInstance.dict`` a shown above.
+  - 1.  From the MIVOT instance property ``MivotInstance.to_dict()`` a shown above.
         This is a pure Python dictionary but its access can be slow because it is generated
         on the fly each time the property is invoked.
   - 2.  From the internal  class dictionary ``MivotInstance.__dict__``

--- a/docs/mivot/index.rst
+++ b/docs/mivot/index.rst
@@ -109,8 +109,10 @@ using the ``dict`` property of ``MivotInstance``.
     :caption: Working with a model view as a dictionary
               (the JSON layout has been squashed for display purpose)
 
+	from pyvo.mivot import MivotViewer
     from pyvo.mivot.utils.dict_utils import DictUtils
-
+    
+    m_viewer = MivotViewer(path_to_votable)
     mivot_instance = m_viewer.dm_instance
     mivot_object_dict = mivot_object.dict
 
@@ -210,20 +212,6 @@ identifiers, which have the following structure: ``model:a.b``.
         on the fly each time the property is invoked.
   - 2.  From the internal  class dictionary ``MivotInstance.__dict__``
         (see the Python `data model <https://docs.python.org/3/reference/datamodel.html>`_).
-
- .. code-block:: python
-    :caption: Exploring the MivotInstance structure with the internal dictionaries
-
-    mivot_instance = mivot_viewer.dm_instance
-
-    print(mivot_instance.__dict__.keys())
-    dict_keys(['dmtype', 'longitude', 'latitude', 'pmLongitude', 'pmLatitude', 'epoch', 'coordSys'])
-
-    print(mivot_instance.coordSys.__dict__.keys())
-    dict_keys(['dmtype', 'dmid', 'dmrole', 'spaceRefFrame'])
-
-    print(mivot_instance.coordSys.spaceRefFrame.__dict__.keys())
-    dict_keys(['dmtype', 'value', 'unit', 'ref'])
 
 Reference/API
 =============

--- a/docs/mivot/index.rst
+++ b/docs/mivot/index.rst
@@ -84,8 +84,8 @@ to the ``EpochPosition`` class, can be consumed.
     ... )
     >>> mivot_instance = m_viewer.dm_instance
     >>> print(mivot_instance.dmtype)
-    EpochPosition
-    >>> print(mivot_instance.Coordinate_coordSys.spaceRefFrame.value)
+    mango:EpochPosition
+    >>> print(mivot_instance.coordSys.spaceRefFrame.value)
     ICRS
     >>> while m_viewer.next():
     ...     print(f"position: {mivot_instance.latitude.value} {mivot_instance.longitude.value}")
@@ -116,16 +116,16 @@ using the ``dict`` property of ``MivotInstance``.
 
     DictUtils.print_pretty_json(mivot_object_dict)
 	{
-        "dmtype": "EpochPosition",
+        "dmtype": "mango:EpochPosition",
         "longitude": {"value": 359.94372764, "unit": "deg"},
         "latitude": {"value": -0.28005255, "unit": "deg"},
         "pmLongitude": {"value": -5.14, "unit": "mas/yr"},
         "pmLatitude": {"value": -25.43, "unit": "mas/yr"},
         "epoch": {"value": 1991.25, "unit": "year"},
-        "Coordinate_coordSys": {
-            "dmtype": "SpaceSys",
-            "dmid": "SpaceFrame_ICRS",
-            "dmrole": "coordSys",
+        "coordSys": {
+            "dmtype": "coords:SpaceSys",
+            "dmid": "ICRS",
+            "dmrole": "coords:Coordinate.coordSys",
             "spaceRefFrame": {"value": "ICRS"},
         },
     }
@@ -217,12 +217,12 @@ identifiers, which have the following structure: ``model:a.b``.
     mivot_instance = mivot_viewer.dm_instance
 
     print(mivot_instance.__dict__.keys())
-    dict_keys(['dmtype', 'longitude', 'latitude', 'pmLongitude', 'pmLatitude', 'epoch', 'Coordinate_coordSys'])
+    dict_keys(['dmtype', 'longitude', 'latitude', 'pmLongitude', 'pmLatitude', 'epoch', 'coordSys'])
 
-    print(mivot_instance.Coordinate_coordSys.__dict__.keys())
+    print(mivot_instance.coordSys.__dict__.keys())
     dict_keys(['dmtype', 'dmid', 'dmrole', 'spaceRefFrame'])
 
-    print(mivot_instance.Coordinate_coordSys.spaceRefFrame.__dict__.keys())
+    print(mivot_instance.coordSys.spaceRefFrame.__dict__.keys())
     dict_keys(['dmtype', 'value', 'unit', 'ref'])
 
 Reference/API

--- a/pyvo/mivot/tests/test_annotation_seeker.py
+++ b/pyvo/mivot/tests/test_annotation_seeker.py
@@ -2,12 +2,12 @@
 """
 Test for mivot.seekers.annotation_seeker.py
 """
-import os
 import pytest
 try:
     from defusedxml import ElementTree as etree
 except ImportError:
     from xml.etree import ElementTree as etree
+from astropy.utils.data import get_pkg_data_filename
 from pyvo.mivot.seekers.annotation_seeker import AnnotationSeeker
 from pyvo.mivot.utils.dict_utils import DictUtils
 from pyvo.mivot.version_checker import check_astropy_version
@@ -16,38 +16,35 @@ from . import XMLOutputChecker
 
 
 @pytest.fixture
-def a_seeker(data_path,):
-    m_viewer = MivotViewer(os.path.join(data_path, "data", "test.mivot_viewer.xml"),
-                       tableref="Results")
+def a_seeker():
+    m_viewer = MivotViewer(
+        get_pkg_data_filename("data/test.mivot_viewer.xml"),
+        tableref="Results"
+    )
     return AnnotationSeeker(m_viewer._mapping_block)
 
 
-@pytest.fixture
-def data_path():
-    return os.path.dirname(os.path.realpath(__file__))
-
-
 @pytest.mark.skipif(not check_astropy_version(), reason="need astropy 6+")
-def test_multiple_templates(data_path):
+def test_multiple_templates():
     """
     Try to create an AnnotationSeeker with a mapping_block containing multiple TEMPLATES.
     """
     mapping_block = XMLOutputChecker.xmltree_from_file(
-        os.path.join(data_path, "data/reference/multiple_templates.xml"))
+        get_pkg_data_filename("data/reference/multiple_templates.xml"))
     with pytest.raises(Exception, match="TEMPLATES without tableref must be unique"):
         AnnotationSeeker(mapping_block.getroot())
 
 
 @pytest.mark.skipif(not check_astropy_version(), reason="need astropy 6+")
-def test_all_reverts(a_seeker, data_path):
+def test_all_reverts(a_seeker):
     # Checks the GLOBALS block given by the AnnotationSeeker
     # by comparing it to the content of the file test.0.1.xml
     XMLOutputChecker.assertXmltreeEqualsFile(a_seeker.globals_block,
-                                     os.path.join(data_path, "data/reference/annotation_seeker.0.1.xml"))
+                                     get_pkg_data_filename("data/reference/annotation_seeker.0.1.xml"))
     # Checks the TEMPLATES block given by the AnnotationSeeker
     # by comparing it to the content of the file test.0.2.xml
     XMLOutputChecker.assertXmltreeEqualsFile(a_seeker.get_templates_block("Results"),
-                                     os.path.join(data_path, "data/reference/annotation_seeker.0.2.xml"))
+                                     get_pkg_data_filename("data/reference/annotation_seeker.0.2.xml"))
     # Checks the list of all the tableref found by the AnnotationSeeker
     assert list(a_seeker.get_templates_tableref()) == ['_PKTable', 'Results']
     # a_seeker should have only 2 COLLECTIONS in GLOBALS: _CoordinateSystems and _Datasets
@@ -73,7 +70,7 @@ def test_all_reverts(a_seeker, data_path):
         a_seeker.get_collection_item_by_primarykey("_Datasets", "wrong_key_value")
     pksel = a_seeker.get_collection_item_by_primarykey("_Datasets", "5813181197970338560")
     XMLOutputChecker.assertXmltreeEqualsFile(pksel,
-                                     os.path.join(data_path, "data/reference/annotation_seeker.0.4.xml"))
+                                     get_pkg_data_filename("data/reference/annotation_seeker.0.4.xml"))
     with (pytest.raises(Exception, match="More than one INSTANCE with "
                                          "PRIMARY_KEY = G found in COLLECTION dmid G")):
         double_key = etree.fromstring("""<PRIMARY_KEY dmtype="ivoa:string" value="G"/>""")
@@ -84,7 +81,7 @@ def test_all_reverts(a_seeker, data_path):
                                         "in COLLECTION dmid wrong_key not found"):
         a_seeker.get_collection_item_by_primarykey("_CoordinateSystems", "wrong_key")
     assert a_seeker.get_instance_dmtypes() == DictUtils.read_dict_from_file(
-        os.path.join(data_path, "data/reference/instance_dmtypes.json"))
+        get_pkg_data_filename("data/reference/instance_dmtypes.json"))
     assert a_seeker.get_templates_instance_by_dmid("Results", "wrong_dmid") is None
     assert a_seeker.get_templates_instance_by_dmid("Results", "_ts_data").get("dmtype") == "cube:NDPoint"
     assert a_seeker.get_globals_instance_from_collection(

--- a/pyvo/mivot/tests/test_mivot_instance.py
+++ b/pyvo/mivot/tests/test_mivot_instance.py
@@ -4,10 +4,13 @@ Created on 19 févr. 2024
 
 @author: michel
 '''
+import os
 import pytest
 from astropy.table import Table
+from pyvo.mivot.version_checker import check_astropy_version
 from pyvo.mivot.viewer.mivot_instance import MivotInstance
-
+from pyvo.mivot.utils.mivot_utils import MivotUtils
+from pyvo.mivot import MivotViewer
 
 fake_hk_dict = {
     "dmtype": "EpochPosition",
@@ -38,6 +41,84 @@ fake_dict = {
                 "unit": "deg",
             }
 }
+
+test_dict = {
+    "tableref": "Results",
+    "root_object": {
+        "dmid": "_ts_data",
+        "dmrole": "",
+        "dmtype": "cube:NDPoint",
+        "observable": [
+            {
+                "dmtype": "cube:Observable",
+                "dependent": {"value": True},
+                "measure": {
+                    "dmrole": "cube:MeasurementAxis.measure",
+                    "dmtype": "meas:Time",
+                    "coord": {
+                        "dmrole": "meas:Time.coord",
+                        "dmtype": "coords:MJD",
+                        "date": {"value": 1705.9437360200984},
+                    },
+                },
+            },
+            {
+                "dmtype": "cube:Observable",
+                "dependent": {"value": True},
+                "measure": {
+                    "dmrole": "cube:MeasurementAxis.measure",
+                    "dmtype": "meas:GenericMeasure",
+                    "coord": {
+                        "dmrole": "meas:GenericMeasure.coord",
+                        "dmtype": "coords:PhysicalCoordinate",
+                        "cval": {"value": 15.216575},
+                    },
+                },
+            },
+            {
+                "dmtype": "cube:Observable",
+                "dependent": {"value": True},
+                "measure": {
+                    "dmrole": "cube:MeasurementAxis.measure",
+                    "dmtype": "meas:GenericMeasure",
+                    "coord": {
+                        "dmrole": "meas:GenericMeasure.coord",
+                        "dmtype": "coords:PhysicalCoordinate",
+                        "cval": {"value": 15442.456},
+                    },
+                    "error": {
+                        "dmrole": "meas:Measure.error",
+                        "dmtype": "meas:Error",
+                        "statError": {
+                            "dmrole": "meas:Error.statError",
+                            "dmtype": "meas:Symmetrical",
+                            "radius": {"value": 44.15126},
+                        },
+                    },
+                },
+            },
+        ],
+    },
+}
+
+
+@pytest.fixture
+def m_viewer(data_path):
+    return MivotViewer(os.path.join(data_path, "data", "test.mivot_viewer.xml"),
+                       tableref="Results")
+
+
+@pytest.fixture
+def data_path():
+    return os.path.dirname(os.path.realpath(__file__))
+
+
+@pytest.mark.skipif(not check_astropy_version(), reason="need astropy 6+")
+def test_xml_viewer(m_viewer):
+
+    xml_instance = m_viewer.xml_viewer.view
+    dm_instance = MivotInstance(**MivotUtils.xml_to_dict(xml_instance))
+    assert dm_instance.dict == test_dict
 
 
 def test_mivot_instance_constructor():

--- a/pyvo/mivot/tests/test_mivot_instance.py
+++ b/pyvo/mivot/tests/test_mivot_instance.py
@@ -7,6 +7,7 @@ Created on 19 févr. 2024
 import os
 import pytest
 from astropy.table import Table
+from astropy.utils.data import get_pkg_data_filename
 from pyvo.mivot.version_checker import check_astropy_version
 from pyvo.mivot.viewer.mivot_instance import MivotInstance
 from pyvo.mivot.utils.mivot_utils import MivotUtils
@@ -103,14 +104,11 @@ test_dict = {
 
 
 @pytest.fixture
-def m_viewer(data_path):
-    return MivotViewer(os.path.join(data_path, "data", "test.mivot_viewer.xml"),
-                       tableref="Results")
-
-
-@pytest.fixture
-def data_path():
-    return os.path.dirname(os.path.realpath(__file__))
+def m_viewer():
+    data_path = get_pkg_data_filename(os.path.join("data",
+                                       "test.mivot_viewer.xml")
+    )
+    return MivotViewer(data_path, tableref="Results")
 
 
 @pytest.mark.skipif(not check_astropy_version(), reason="need astropy 6+")

--- a/pyvo/mivot/tests/test_mivot_instance.py
+++ b/pyvo/mivot/tests/test_mivot_instance.py
@@ -116,7 +116,7 @@ def test_xml_viewer(m_viewer):
 
     xml_instance = m_viewer.xml_viewer.view
     dm_instance = MivotInstance(**MivotUtils.xml_to_dict(xml_instance))
-    assert dm_instance.dict == test_dict
+    assert dm_instance.to_dict() == test_dict
 
 
 def test_mivot_instance_constructor():
@@ -156,5 +156,5 @@ def test_mivot_instance_update_wrong_columns():
 def test_mivot_instance_display_dict():
     """Test the class generation from a dict and rebuild the dict from the instance."""
     mivot_object = MivotInstance(**fake_hk_dict)
-    assert mivot_object.hk_dict == fake_hk_dict
-    assert mivot_object.dict == fake_dict
+    assert mivot_object.to_hk_dict() == fake_hk_dict
+    assert mivot_object.to_dict() == fake_dict

--- a/pyvo/mivot/tests/test_mivot_instance_generation.py
+++ b/pyvo/mivot/tests/test_mivot_instance_generation.py
@@ -50,7 +50,7 @@ def recusive_xml_check(xml_simple_votable, MivotInstance):
                             elif child.tag == 'INSTANCE':
                                 recusive_xml_check(child, getattr(MivotInstance,
                                                                   MivotInstance._remove_model_name
-                                                                  (child.get('dmrole'), True)))
+                                                                  (child.get('dmrole'))))
                         else:
                             if child.tag == 'ATTRIBUTE':
                                 recusive_xml_check(child, getattr(MivotInstance,
@@ -59,7 +59,7 @@ def recusive_xml_check(xml_simple_votable, MivotInstance):
                             elif child.tag == 'INSTANCE':
                                 recusive_xml_check(child, getattr(MivotInstance,
                                                                   MivotInstance._remove_model_name(
-                                                                      child.get('dmrole'), True)))
+                                                                      child.get('dmrole'))))
                             elif child.tag == 'COLLECTION':
                                 recusive_xml_check(child, getattr(MivotInstance,
                                                                   MivotInstance._remove_model_name(

--- a/pyvo/mivot/tests/test_mivot_viewer.py
+++ b/pyvo/mivot/tests/test_mivot_viewer.py
@@ -53,7 +53,7 @@ def test_table_ref(m_viewer):
 @pytest.mark.skipif(not check_astropy_version(), reason="need astropy 6+")
 def test_global_getters(m_viewer, data_path):
     """
-    Test each getter of the model_viewer_level1 specific for the GLOBALS.
+    Test each getter for TEMPLATES of the model_viewer.
     """
     assert m_viewer.get_table_ids() == ['_PKTable', 'Results']
     assert m_viewer.get_globals_models() == DictUtils.read_dict_from_file(
@@ -76,7 +76,7 @@ def test_global_getters(m_viewer, data_path):
 @pytest.mark.skipif(not check_astropy_version(), reason="need astropy 6+")
 def test_no_mivot(path_no_mivot):
     """
-    Test each getter of the model_viewer_level1 specific for the GLOBALS.
+    Test each getter for GLOBALS of the model_viewer specific .
     """
     m_viewer = MivotViewer(path_no_mivot)
     assert m_viewer.get_table_ids() is None

--- a/pyvo/mivot/tests/test_mivot_viewer.py
+++ b/pyvo/mivot/tests/test_mivot_viewer.py
@@ -5,6 +5,7 @@ Test for mivot.viewer.mivot_viewer.py
 import os
 import pytest
 import re
+from astropy.utils.data import get_pkg_data_filename
 from pyvo.mivot.utils.vocabulary import Constant
 from pyvo.mivot.utils.dict_utils import DictUtils
 from pyvo.mivot.utils.exceptions import MappingException
@@ -51,15 +52,15 @@ def test_table_ref(m_viewer):
 
 
 @pytest.mark.skipif(not check_astropy_version(), reason="need astropy 6+")
-def test_global_getters(m_viewer, data_path):
+def test_global_getters(m_viewer):
     """
     Test each getter for TEMPLATES of the model_viewer.
     """
     assert m_viewer.get_table_ids() == ['_PKTable', 'Results']
     assert m_viewer.get_globals_models() == DictUtils.read_dict_from_file(
-        os.path.join(data_path, "data/reference/globals_models.json"))
+        get_pkg_data_filename("data/reference/globals_models.json"))
     assert m_viewer.get_templates_models() == DictUtils.read_dict_from_file(
-        os.path.join(data_path, "data/reference/templates_models.json"))
+        get_pkg_data_filename("data/reference/templates_models.json"))
     m_viewer._connect_table('_PKTable')
     row = m_viewer.next_table_row()
     assert row[0] == '5813181197970338560'
@@ -106,37 +107,31 @@ def test_check_version(path_to_viewer):
 
 
 @pytest.fixture
-def m_viewer(data_path):
+def m_viewer():
     if not check_astropy_version():
         pytest.skip("MIVOT test skipped because of the astropy version.")
 
     votable_name = "test.mivot_viewer.xml"
-    votable_path = os.path.join(data_path, "data", votable_name)
+    votable_path = get_pkg_data_filename(os.path.join("data", votable_name))
     return MivotViewer(votable_path=votable_path)
 
 
 @pytest.fixture
-def path_to_viewer(data_path):
+def path_to_viewer():
     if not check_astropy_version():
         pytest.skip("MIVOT test skipped because of the astropy version.")
 
     votable_name = "test.mivot_viewer.xml"
-    return os.path.join(data_path, "data", votable_name)
+    return get_pkg_data_filename(os.path.join("data", votable_name))
 
 
 @pytest.fixture
-def path_to_first_instance(data_path):
-
+def path_to_first_instance():
     votable_name = "test.mivot_viewer.first_instance.xml"
-    return os.path.join(data_path, "data", votable_name)
+    return get_pkg_data_filename(os.path.join("data", votable_name))
 
 
 @pytest.fixture
-def path_no_mivot(data_path):
+def path_no_mivot():
     votable_name = "test.mivot_viewer.no_mivot.xml"
-    return os.path.join(data_path, "data", votable_name)
-
-
-@pytest.fixture
-def data_path():
-    return os.path.dirname(os.path.realpath(__file__))
+    return get_pkg_data_filename(os.path.join("data", votable_name))

--- a/pyvo/mivot/tests/test_resource_seeker.py
+++ b/pyvo/mivot/tests/test_resource_seeker.py
@@ -2,9 +2,9 @@
 """
 Test for mivot.seekers.resource_seeker.py
 """
-import os
 import pytest
 from astropy.io.votable import parse
+from astropy.utils.data import get_pkg_data_filename
 from pyvo.mivot.seekers.resource_seeker import ResourceSeeker
 from pyvo.mivot.version_checker import check_astropy_version
 
@@ -59,15 +59,10 @@ def test_id_table(rseeker):
 
 
 @pytest.fixture
-def rseeker(data_path):
+def rseeker():
 
-    votable_path = os.path.join(data_path, "data", "test.mivot_viewer.xml")
+    votable_path = get_pkg_data_filename("data/test.mivot_viewer.xml")
 
     votable = parse(votable_path)
     for resource in votable.resources:
         return ResourceSeeker(resource)
-
-
-@pytest.fixture
-def data_path():
-    return os.path.dirname(os.path.realpath(__file__))

--- a/pyvo/mivot/tests/test_static_reference.py
+++ b/pyvo/mivot/tests/test_static_reference.py
@@ -2,8 +2,8 @@
 """
 Test for mivot.features.static_reference_resolver.py
 """
-import os
 import pytest
+from astropy.utils.data import get_pkg_data_filename
 from pyvo.mivot.seekers.annotation_seeker import AnnotationSeeker
 from pyvo.mivot.features.static_reference_resolver import StaticReferenceResolver
 from pyvo.mivot.version_checker import check_astropy_version
@@ -12,27 +12,23 @@ from . import XMLOutputChecker
 
 
 @pytest.mark.skipif(not check_astropy_version(), reason="need astropy 6+")
-def test_static_reference_resolve(a_seeker, instance, data_path):
+def test_static_reference_resolve(a_seeker, instance):
     StaticReferenceResolver.resolve(a_seeker, None, instance)
-    XMLOutputChecker.assertXmltreeEqualsFile(instance.getroot(),
-                                     os.path.join(data_path,
-                                                 "data/reference/static_reference_resolved.xml"))
+    XMLOutputChecker.assertXmltreeEqualsFile(
+        instance.getroot(),
+        get_pkg_data_filename("data/reference/static_reference_resolved.xml")
+    )
 
 
 @pytest.fixture
-def instance(data_path):
-    return XMLOutputChecker.xmltree_from_file(os.path.join(
-        data_path,
-        "data/static_reference.xml"))
+def instance():
+    return XMLOutputChecker.xmltree_from_file(
+        get_pkg_data_filename("data/static_reference.xml"))
 
 
 @pytest.fixture
-def data_path():
-    return os.path.dirname(os.path.realpath(__file__))
-
-
-@pytest.fixture
-def a_seeker(data_path):
-    m_viewer = MivotViewer(os.path.join(data_path, "data", "test.mivot_viewer.xml"),
-                       tableref="Results")
+def a_seeker():
+    m_viewer = MivotViewer(
+        get_pkg_data_filename("data/test.mivot_viewer.xml"),
+        tableref="Results")
     return AnnotationSeeker(m_viewer._mapping_block)

--- a/pyvo/mivot/tests/test_user_api.py
+++ b/pyvo/mivot/tests/test_user_api.py
@@ -210,10 +210,10 @@ def test_with_dict(path_to_votable):
         # let's focus on the last data row
         while mivot_viewer.next():
             pass
-    DictUtils.print_pretty_json(mivot_object.hk_dict)
+    DictUtils.print_pretty_json(mivot_object.to_hk_dict())
 
     # check the slim (user friendly) dictionary
-    assert mivot_object.dict == {
+    assert mivot_object.to_dict() == {
         "dmtype": "mango:EpochPosition",
         "longitude": {"value": 359.94372764, "unit": "deg"},
         "latitude": {"value": -0.28005255, "unit": "deg"},
@@ -228,7 +228,7 @@ def test_with_dict(path_to_votable):
         },
     }
     # check the whole dictionary
-    assert mivot_object.hk_dict == {
+    assert mivot_object.to_hk_dict() == {
         "dmtype": "mango:EpochPosition",
         "longitude": {
             "dmtype": "ivoa:RealQuantity",
@@ -290,7 +290,7 @@ def test_with_full_dict(path_to_full_mapped_votable):
         # let's focus on the second data row
         while mivot_viewer.next():
             # check the slim (user friendly) dictionary
-            assert mivot_object.dict == {
+            assert mivot_object.to_dict() == {
                 "dmtype": "mango:EpochPosition",
                 "longitude": {"value": 307.79115807079, "unit": "deg"},
                 "latitude": {"value": 20.43108005561, "unit": "deg"},

--- a/pyvo/mivot/tests/test_user_api.py
+++ b/pyvo/mivot/tests/test_user_api.py
@@ -101,8 +101,8 @@ def test_mivot_viewer_next(path_to_votable):
     """
     mivot_viewer = MivotViewer(path_to_votable)
     mivot_instance = mivot_viewer.dm_instance
-    assert mivot_instance.dmtype == "EpochPosition"
-    assert mivot_instance.Coordinate_coordSys.spaceRefFrame.value == "ICRS"
+    assert mivot_instance.dmtype == "mango:EpochPosition"
+    assert mivot_instance.coordSys.spaceRefFrame.value == "ICRS"
     ra = []
     dec = []
     pmra = []
@@ -133,8 +133,8 @@ def test_mivot_tablerow_next(path_to_votable):
     mivot_viewer = MivotViewer(votable)
 
     mivot_instance = mivot_viewer.dm_instance
-    assert mivot_instance.dmtype == "EpochPosition"
-    assert mivot_instance.Coordinate_coordSys.spaceRefFrame.value == "ICRS"
+    assert mivot_instance.dmtype == "mango:EpochPosition"
+    assert mivot_instance.coordSys.spaceRefFrame.value == "ICRS"
     ra = []
     dec = []
     pmra = []
@@ -210,39 +210,70 @@ def test_with_dict(path_to_votable):
         # let's focus on the last data row
         while mivot_viewer.next():
             pass
+    DictUtils.print_pretty_json(mivot_object.hk_dict)
 
     # check the slim (user friendly) dictionary
     assert mivot_object.dict == {
-        "dmtype": "EpochPosition",
+        "dmtype": "mango:EpochPosition",
         "longitude": {"value": 359.94372764, "unit": "deg"},
         "latitude": {"value": -0.28005255, "unit": "deg"},
         "pmLongitude": {"value": -5.14, "unit": "mas/yr"},
         "pmLatitude": {"value": -25.43, "unit": "mas/yr"},
         "epoch": {"value": 1991.25, "unit": "year"},
-        "Coordinate_coordSys": {
-            "dmtype": "SpaceSys",
+        "coordSys": {
+            "dmtype": "coords:SpaceSys",
             "dmid": "SpaceFrame_ICRS",
-            "dmrole": "coordSys",
+            "dmrole": "coords:Coordinate.coordSys",
             "spaceRefFrame": {"value": "ICRS"},
         },
     }
     # check the whole dictionary
     assert mivot_object.hk_dict == {
-        "dmtype": "EpochPosition",
-        "longitude": {"dmtype": "RealQuantity", "value": 359.94372764,
-                      "unit": "deg", "astropy_unit": {}, "ref": "RAICRS"},
-        "latitude": {"dmtype": "RealQuantity", "value": -0.28005255,
-                     "unit": "deg", "astropy_unit": {}, "ref": "DEICRS"},
-        "pmLongitude": {"value": -5.14, "unit": "mas/yr", "dmtype": "RealQuantity",
-                        "ref": "pmRA", "astropy_unit": {}},
-        "pmLatitude": {"value": -25.43, "unit": "mas/yr", "dmtype": "RealQuantity",
-                       "ref": "pmDE", "astropy_unit": {}},
-        "epoch": {"dmtype": "RealQuantity", "ref": None, "unit": "year", "value": 1991.25},
-        "Coordinate_coordSys": {
-            "dmtype": "SpaceSys",
+        "dmtype": "mango:EpochPosition",
+        "longitude": {
+            "dmtype": "ivoa:RealQuantity",
+            "value": 359.94372764,
+            "unit": "deg",
+            "astropy_unit": {},
+            "ref": "RAICRS",
+        },
+        "latitude": {
+            "dmtype": "ivoa:RealQuantity",
+            "value": -0.28005255,
+            "unit": "deg",
+            "astropy_unit": {},
+            "ref": "DEICRS",
+        },
+        "pmLongitude": {
+            "dmtype": "ivoa:RealQuantity",
+            "value": -5.14,
+            "unit": "mas/yr",
+            "astropy_unit": {},
+            "ref": "pmRA",
+        },
+        "pmLatitude": {
+            "dmtype": "ivoa:RealQuantity",
+            "value": -25.43,
+            "unit": "mas/yr",
+            "astropy_unit": {},
+            "ref": "pmDE",
+        },
+        "epoch": {
+            "dmtype": "ivoa:RealQuantity",
+            "value": 1991.25,
+            "unit": "year",
+            "ref": None,
+        },
+        "coordSys": {
+            "dmtype": "coords:SpaceSys",
             "dmid": "SpaceFrame_ICRS",
-            "dmrole": "coordSys",
-            "spaceRefFrame": {"dmtype": "SpaceFrame", "ref": None, "unit": None, "value": "ICRS"},
+            "dmrole": "coords:Coordinate.coordSys",
+            "spaceRefFrame": {
+                "dmtype": "coords:SpaceFrame",
+                "value": "ICRS",
+                "unit": None,
+                "ref": None,
+            },
         },
     }
 
@@ -258,10 +289,9 @@ def test_with_full_dict(path_to_full_mapped_votable):
         mivot_object = mivot_viewer.dm_instance
         # let's focus on the second data row
         while mivot_viewer.next():
-            DictUtils.print_pretty_json(mivot_object.dict)
             # check the slim (user friendly) dictionary
             assert mivot_object.dict == {
-                "dmtype": "EpochPosition",
+                "dmtype": "mango:EpochPosition",
                 "longitude": {"value": 307.79115807079, "unit": "deg"},
                 "latitude": {"value": 20.43108005561, "unit": "deg"},
                 "parallax": {"value": 0.4319, "unit": "mas"},
@@ -270,80 +300,80 @@ def test_with_full_dict(path_to_full_mapped_votable):
                 "pmLatitude": {"value": -5.482, "unit": "mas/yr"},
                 "epoch": {"value": "2016.5"},
                 "pmCosDeltApplied": {"value": True},
-                "EpochPosition_errors": {
-                    "dmrole": "errors",
-                    "dmtype": "EpochPositionErrors",
-                    "EpochPositionErrors_parallax": {
-                        "dmrole": "parallax",
-                        "dmtype": "PropertyError1D",
+                "errors": {
+                    "dmrole": "mango:EpochPosition.errors",
+                    "dmtype": "mango:EpochPositionErrors",
+                    "parallax": {
+                        "dmrole": "mango:EpochPositionErrors.parallax",
+                        "dmtype": "mango:ErrorTypes.PropertyError1D",
                         "sigma": {"value": 0.06909999996423721, "unit": "mas"},
                     },
-                    "EpochPositionErrors_radialVelocity": {
-                        "dmrole": "radialVelocity",
-                        "dmtype": "PropertyError1D",
+                    "radialVelocity": {
+                        "dmrole": "mango:EpochPositionErrors.radialVelocity",
+                        "dmtype": "mango:ErrorTypes.PropertyError1D",
                         "sigma": {"value": None, "unit": "km/s"},
                     },
-                    "EpochPositionErrors_position": {
-                        "dmrole": "position",
-                        "dmtype": "ErrorMatrix",
+                    "position": {
+                        "dmrole": "mango:EpochPositionErrors.position",
+                        "dmtype": "mango:ErrorTypes.ErrorMatrix",
                         "sigma1": {"value": 0.0511, "unit": "mas"},
                         "sigma2": {"value": 0.0477, "unit": "mas"},
                     },
-                    "EpochPositionErrors_properMotion": {
-                        "dmrole": "properMotion",
-                        "dmtype": "ErrorMatrix",
+                    "properMotion": {
+                        "dmrole": "mango:EpochPositionErrors.properMotion",
+                        "dmtype": "mango:ErrorTypes.ErrorMatrix",
                         "sigma1": {"value": 0.06400000303983688, "unit": "mas/yr"},
                         "sigma2": {"value": 0.06700000166893005, "unit": "mas/yr"},
                     },
                 },
-                "EpochPosition_correlations": {
-                    "dmrole": "correlations",
-                    "dmtype": "EpochPositionCorrelations",
-                    "EpochPositionCorrelations_positionPm": {
-                        "dmrole": "positionPm",
-                        "dmtype": "Correlation22",
+                "correlations": {
+                    "dmrole": "mango:EpochPosition.correlations",
+                    "dmtype": "mango:EpochPositionCorrelations",
+                    "positionPm": {
+                        "dmrole": "mango:EpochPositionCorrelations.positionPm",
+                        "dmtype": "mango:Correlation22",
                         "isCovariance": {"value": True},
                         "a2b1": {"value": -0.0085},
                         "a2b2": {"value": -0.2983},
                         "a1b1": {"value": -0.4109},
                         "a1b2": {"value": -0.0072},
                     },
-                    "EpochPositionCorrelations_parallaxPm": {
-                        "dmrole": "parallaxPm",
-                        "dmtype": "Correlation12",
+                    "parallaxPm": {
+                        "dmrole": "mango:EpochPositionCorrelations.parallaxPm",
+                        "dmtype": "mango:Correlation12",
                         "isCovariance": {"value": True},
                         "a1b1": {"value": -0.2603},
                         "a1b2": {"value": -0.0251},
                     },
-                    "EpochPositionCorrelations_positionParallax": {
-                        "dmrole": "positionParallax",
-                        "dmtype": "Correlation21",
+                    "positionParallax": {
+                        "dmrole": "mango:EpochPositionCorrelations.positionParallax",
+                        "dmtype": "mango:Correlation21",
                         "isCovariance": {"value": True},
                         "a2b1": {"value": 0.0069},
                         "a1b1": {"value": 0.1337},
                     },
-                    "EpochPositionCorrelations_positionPosition": {
-                        "dmrole": "positionPosition",
-                        "dmtype": "Correlation22",
+                    "positionPosition": {
+                        "dmrole": "mango:EpochPositionCorrelations.positionPosition",
+                        "dmtype": "mango:Correlation22",
                         "isCovariance": {"value": True},
                         "a2b1": {"value": 0.1212},
                         "a1b2": {"value": 0.1212},
                     },
-                    "EpochPositionCorrelations_properMotionPm": {
-                        "dmrole": "properMotionPm",
-                        "dmtype": "Correlation22",
+                    "properMotionPm": {
+                        "dmrole": "mango:EpochPositionCorrelations.properMotionPm",
+                        "dmtype": "mango:Correlation22",
                         "isCovariance": {"value": True},
                         "a2b1": {"value": 0.2688},
                         "a1b2": {"value": 0.2688},
                     },
                 },
-                "EpochPosition_coordSys": {
+                "coordSys": {
                     "dmid": "_spacesys_icrs",
-                    "dmrole": "coordSys",
-                    "dmtype": "SpaceSys",
-                    "PhysicalCoordSys_frame": {
-                        "dmrole": "frame",
-                        "dmtype": "SpaceFrame",
+                    "dmrole": "mango:EpochPosition.coordSys",
+                    "dmtype": "coords:SpaceSys",
+                    "frame": {
+                        "dmrole": "coords:PhysicalCoordSys.frame",
+                        "dmtype": "coords:SpaceFrame",
                         "spaceRefFrame": {"value": "ICRS"},
                     },
                 },
@@ -365,8 +395,8 @@ def test_cone_search(vizier_url):
         )
     )
     mivot_instance = m_viewer.dm_instance
-    assert mivot_instance.dmtype == "EpochPosition"
-    assert mivot_instance.Coordinate_coordSys.spaceRefFrame.value == "ICRS"
+    assert mivot_instance.dmtype == "mango:EpochPosition"
+    assert mivot_instance.coordSys.spaceRefFrame.value == "ICRS"
     ra = []
     dec = []
     pmra = []

--- a/pyvo/mivot/tests/test_vizier_cs.py
+++ b/pyvo/mivot/tests/test_vizier_cs.py
@@ -91,7 +91,7 @@ def test_with_name(path_to_withname, delt_coo):
     assert abs(mivot_object.pmLongitude.value - 1.5) < delt_coo
     assert abs(mivot_object.pmLatitude.value - -12.30000019) < delt_coo
     assert str(mivot_object.epoch.value) == '2013.418'
-    assert str(mivot_object.Coordinate_coordSys.spaceRefFrame.value) == 'ICRS'
+    assert str(mivot_object.coordSys.spaceRefFrame.value) == 'ICRS'
 
     m_viewer.next()
 
@@ -100,7 +100,7 @@ def test_with_name(path_to_withname, delt_coo):
     assert abs(mivot_object.pmLongitude.value - 1.5) < delt_coo
     assert abs(mivot_object.pmLatitude.value - -12.30000019) < delt_coo
     assert str(mivot_object.epoch.value) == '2013.418'
-    assert str(mivot_object.Coordinate_coordSys.spaceRefFrame.value) == 'ICRS'
+    assert str(mivot_object.coordSys.spaceRefFrame.value) == 'ICRS'
 
 
 @pytest.mark.remote_data

--- a/pyvo/mivot/tests/test_xml_viewer.py
+++ b/pyvo/mivot/tests/test_xml_viewer.py
@@ -2,12 +2,12 @@
 """
 Test for mivot.viewer.model_viewer_level2.py
 """
-import os
 import pytest
 try:
     from defusedxml.ElementTree import Element as element
 except ImportError:
     from xml.etree.ElementTree import Element as element
+from astropy.utils.data import get_pkg_data_filename
 from pyvo.mivot.version_checker import check_astropy_version
 from pyvo.mivot import MivotViewer
 from pyvo.mivot.utils.exceptions import MivotException
@@ -62,11 +62,6 @@ def test_xml_viewer(m_viewer):
 
 
 @pytest.fixture
-def m_viewer(data_path):
-    return MivotViewer(os.path.join(data_path, "data", "test.mivot_viewer.xml"),
+def m_viewer():
+    return MivotViewer(get_pkg_data_filename("data/test.mivot_viewer.xml"),
                        tableref="Results")
-
-
-@pytest.fixture
-def data_path():
-    return os.path.dirname(os.path.realpath(__file__))

--- a/pyvo/mivot/utils/vocabulary.py
+++ b/pyvo/mivot/utils/vocabulary.py
@@ -14,6 +14,7 @@ class Constant:
     FIELD_UNIT = "field_unit"
     COL_INDEX = "col_index"
     ROOT_COLLECTION = "root_collection"
+    ROOT_OBJECT = "root_object"
     NOT_SET = "NotSet"
     ANONYMOUS_TABLE = "AnonymousTable"
 

--- a/pyvo/mivot/viewer/mivot_instance.py
+++ b/pyvo/mivot/viewer/mivot_instance.py
@@ -45,10 +45,9 @@ class MivotInstance:
         """
         return  a human readable (json) representation of object
         """
-        return DictUtils._get_pretty_json(self.dict)
+        return DictUtils._get_pretty_json(self.to_dict())
 
-    @property
-    def hk_dict(self):
+    def to_hk_dict(self):
         """
         return a human readable (dict) representation of object with a few
         housekeeping data such as column references. This might be used
@@ -56,8 +55,7 @@ class MivotInstance:
         """
         return self._get_class_dict(self)
 
-    @property
-    def dict(self):
+    def to_dict(self):
         """
         return a human readable (dict) representation of object
         """


### PR DESCRIPTION
The model references in the dictionaries that are used to build `MivotInstance` objects are more consistent:

- Both `dmtype`and `dmrole` keys are set with complete VODML-ID  (`model:a.b.c`).
- Dictionary keys derived from `dmrole` are truncated (`model:a.b.c`-> `c`). The names of Python attributes are equals to these keys.

```
	{
        "dmtype": "mango:EpochPosition",
        "longitude": {"value": 359.94372764, "unit": "deg"},
        "latitude": {"value": -0.28005255, "unit": "deg"},
        "pmLongitude": {"value": -5.14, "unit": "mas/yr"},
        "pmLatitude": {"value": -25.43, "unit": "mas/yr"},
        "epoch": {"value": 1991.25, "unit": "year"},
        "coordSys": {
            "dmtype": "coords:SpaceSys",
            "dmid": "ICRS",
            "dmrole": "coords:Coordinate.coordSys",
            "spaceRefFrame": {"value": "ICRS"},
        },
    }
```
This makes the understanding of  these dictionaries and the use of the `MivotInstance` objects quite easier and more intuitive.