### PR TITLE
Defuse sia title characters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Bug Fixes
 
 - cachedataset() and friends again produce reasonable file extensions.
   [#553]
+- path separators are no longer taken over from image titles to file
+  system paths. [#557]
 
 Enhancements and Fixes
 ----------------------

--- a/pyvo/dal/query.py
+++ b/pyvo/dal/query.py
@@ -894,6 +894,9 @@ class Record(Mapping):
         if not ext:
             ext = self.suggest_extension(default="dat")
 
+        base = base.replace("/", "_"
+            ).replace("\\", "_")
+
         # be efficient when writing a bunch of files into the same directory
         # in succession
         n = self._dsname_no

--- a/pyvo/dal/tests/test_sia.py
+++ b/pyvo/dal/tests/test_sia.py
@@ -4,6 +4,7 @@
 Tests for pyvo.dal.sia
 """
 from functools import partial
+import os
 import re
 
 import pytest
@@ -97,14 +98,14 @@ class TestNameMaking:
     def test_slash_replace(self):
         res = SIAService('http://example.com/sia').search(pos=(288, 15))
         res["imageTitle"][0] = "ogsa/dai output"
-        assert res[0].make_dataset_filename() == "./ogsa_dai_output.fits"
+        assert res[0].make_dataset_filename() == os.path.join(".", "ogsa_dai_output.fits")
 
     def test_default_for_broken_media_type(self):
         res = SIAService('http://example.com/sia').search(pos=(288, 15))
         res["mime"][0] = "application/x-youcannotknowthis"
-        assert res[0].make_dataset_filename() == "./Test_Observation.dat"
+        assert res[0].make_dataset_filename() == os.path.join(".", "Test_Observation.dat")
 
     def test_default_media_type_adaption(self):
         res = SIAService('http://example.com/sia').search(pos=(288, 15))
         res["mime"][0] = "image/png"
-        assert res[0].make_dataset_filename() == "./Test_Observation.png"
+        assert res[0].make_dataset_filename() == os.path.join(".", "Test_Observation.png")

--- a/pyvo/dal/tests/test_sia.py
+++ b/pyvo/dal/tests/test_sia.py
@@ -90,3 +90,21 @@ class TestSIAService:
         assert service["FORMAT"] == "GRAPHIC-png"
         service.format = "Unsupported"
         assert service["FORMAT"] == "Unsupported"
+
+
+@pytest.mark.usefixtures('sia')
+class TestNameMaking:
+    def test_slash_replace(self):
+        res = SIAService('http://example.com/sia').search(pos=(288, 15))
+        res["imageTitle"][0] = "ogsa/dai output"
+        assert res[0].make_dataset_filename() == "./ogsa_dai_output.fits"
+
+    def test_default_for_broken_media_type(self):
+        res = SIAService('http://example.com/sia').search(pos=(288, 15))
+        res["mime"][0] = "application/x-youcannotknowthis"
+        assert res[0].make_dataset_filename() == "./Test_Observation.dat"
+
+    def test_default_media_type_adaption(self):
+        res = SIAService('http://example.com/sia').search(pos=(288, 15))
+        res["mime"][0] = "image/png"
+        assert res[0].make_dataset_filename() == "./Test_Observation.png"


### PR DESCRIPTION
This is intended as a fix for bug #556.  To keep things simple, I'm basing this on the branch of PR #553, because this plays in the vicinity of its code.

As mentioned in the commit message, one *might* argue we should lock down the file names more strongly than that.  I'd be open to that, but only if people actually feel there is a sufficient need for that.

fixes #556