### PR TITLE
DOC: fix doctest output

### DIFF
--- a/docs/dal/index.rst
+++ b/docs/dal/index.rst
@@ -720,16 +720,16 @@ Iterating over a resultset gives the rows in the result:
 
     >>> for row in resultset:
     ...     print(row['s_fov'])
-    0.05027778
-    0.05027778
-    0.05027778
-    0.05027778
-    0.05027778
-    0.05027778
     0.06527778
     0.06527778
     0.06527778
     0.06527778
+    0.06527778
+    0.06527778
+    0.05027778
+    0.05027778
+    0.05027778
+    0.05027778
 
 The total number of rows in the answer is available as its ``len()``:
 


### PR DESCRIPTION
Quick PR to fix the CI. If this same example break again, then we should switch using +IGNORE_OUTPUT, but for now fixing it seems reasonable.