### PR TITLE
Avoid assuming that `access_url` exists always

### DIFF
--- a/pyvo/dal/adhoc.py
+++ b/pyvo/dal/adhoc.py
@@ -223,12 +223,14 @@ class DatalinkResultsMixin(AdhocServiceResultsMixin):
                 yield current_batch.clone_byid(
                     id1,
                     original_row=row)
-            elif row.access_format == DATALINK_MIME_TYPE:
-                yield DatalinkResults.from_result_url(
-                    row.getdataurl(),
-                    original_row=row)
+            elif getattr(row, 'access_format', None) == DATALINK_MIME_TYPE:
+                yield DatalinkResults.from_result_url(row.getdataurl())
             else:
-                yield None
+                # Fall back to row-specific handling
+                try:
+                    yield row.getdatalink()
+                except AttributeError:
+                    yield None
 
 
 class DatalinkRecordMixin:


### PR DESCRIPTION
DatalinkResultsMixin was assuming that the records created by any subclass would have the `access_url` attribute. This is not true for SSA (whether it should do is a separate question). This replaces that assumption with a check for existence first, and then if that fails, fall back to getdatalink on the record.

See #569 for more context.

I'm not sure this is the right solution (especially around the fallback, as that's what the previous code did before the batching in #218), but it does work, both in that I no longer get an exception, and I can iterate over the datalink urls in the SSA results.

Fixes: #569 