### PR TITLE
Now using DISTINCT in ivoid-selecting registry subqueries.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,7 +27,7 @@ Enhancements and Fixes
   whose structure corresponds to the classes of the mapped models. [#497]
 
 - RegTAP constraints involving tables other than rr.resource are now
-  done via subqueries for less duplication of interfaces. [#562]
+  done via subqueries for less duplication of interfaces. [#562, #572]
 
 
 Deprecations and Removals

--- a/pyvo/registry/rtcons.py
+++ b/pyvo/registry/rtcons.py
@@ -233,7 +233,7 @@ class SubqueriedConstraint(Constraint):
             raise NotImplementedError("{} is an abstract Constraint"
                                       .format(self.__class__.__name__))
 
-        return ("ivoid IN (SELECT ivoid FROM {subquery_table}"
+        return ("ivoid IN (SELECT DISTINCT ivoid FROM {subquery_table}"
             " WHERE {condition})".format(
                 subquery_table=self._subquery_table,
                 condition=self._condition.format(**self._get_sql_literals())))
@@ -274,11 +274,11 @@ class Freetext(Constraint):
 
     def _get_union_condition(self, service):
         base_queries = [
-            "SELECT ivoid FROM rr.resource WHERE"
+            "SELECT DISTINCT ivoid FROM rr.resource WHERE"
             " 1=ivo_hasword(res_description, {{{parname}}})",
-            "SELECT ivoid FROM rr.resource WHERE"
+            "SELECT DISTINCT ivoid FROM rr.resource WHERE"
             " 1=ivo_hasword(res_title, {{{parname}}})",
-            "SELECT ivoid FROM rr.res_subject WHERE"
+            "SELECT DISTINCT ivoid FROM rr.res_subject WHERE"
             " rr.res_subject.res_subject ILIKE {{{parpatname}}}"]
         self._fillers, subqueries = {}, []
 
@@ -288,7 +288,7 @@ class Freetext(Constraint):
             self._fillers[parname] = word
             self._fillers[parpatname] = '%' + word + '%'
             args = locals()
-            subqueries.append(" UNION ".join(
+            subqueries.append(" UNION ALL ".join(
                 q.format(**args) for q in base_queries))
 
         self._condition = " AND ".join(

--- a/pyvo/registry/tests/test_regtap.py
+++ b/pyvo/registry/tests/test_regtap.py
@@ -349,14 +349,14 @@ def get_regtap_results(**kwargs):
 def test_spatial():
     assert (rtcons.keywords_to_constraints({
             "spatial": (23, -40)})[0].get_search_condition(FAKE_GAVO)
-            == "ivoid IN (SELECT ivoid FROM rr.stc_spatial"
+            == "ivoid IN (SELECT DISTINCT ivoid FROM rr.stc_spatial"
             " WHERE 1 = CONTAINS(MOC(6, POINT(23, -40)), coverage))")
 
 
 def test_spectral():
     assert (rtcons.keywords_to_constraints({
             "spectral": (1e-17, 2e-17)})[0].get_search_condition(FAKE_GAVO)
-            == "ivoid IN (SELECT ivoid FROM rr.stc_spectral WHERE"
+            == "ivoid IN (SELECT DISTINCT ivoid FROM rr.stc_spectral WHERE"
             " 1 = ivo_interval_overlaps(spectral_start, spectral_end, 1e-17, 2e-17))")
 
 


### PR DESCRIPTION
This is not only more logical (let's filter out duplicates as early as possible)but experimentally also is enough to keep the planner going off to follies of the type encountered in bug #571.