### PR TITLE
MAINT: fixing new dependency as reshuffle CI jobs

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -33,9 +33,6 @@ jobs:
           - name: py311 with online tests, Linux
             python-version: '3.11'
             tox_env: py311-test-alldeps-online
-          - name: linkcheck
-            python-version: '3.10'
-            tox_env: linkcheck
 
     steps:
     - name: Checkout code
@@ -87,3 +84,19 @@ jobs:
         run: python -m pip install --upgrade tox
       - name: Check codestyle
         run: tox -e codestyle
+
+  linkcheck:
+    if: github.event_name == 'schedule' && github.repository == 'astropy/pyvo'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.10
+      - name: Install tox
+        run: python -m pip install --upgrade tox
+      - name: Check docs links
+        run: tox -e linkcheck

--- a/README.rst
+++ b/README.rst
@@ -57,6 +57,7 @@ The following packages are optional dependencies and are required for the
 full functionality:
 
  * pillow
+ * defusedxml
 
 For running the tests, and building the documentation, the following
 infrastructure packages are required:

--- a/docs/dal/index.rst
+++ b/docs/dal/index.rst
@@ -799,7 +799,7 @@ as quantities):
 Datalink
 --------
 
-Datalink lets operators associate multiple artefacts with a dataset.
+Datalink lets operators associate multiple artifacts with a dataset.
 Examples include linking raw data, applicable or applied calibration
 data, derived datasets such as extracted sources, extra documentation,
 and much more.

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,11 +70,11 @@ python_requires = >=3.8
 [options.extras_require]
 all =
     pillow
+    defusedxml
 test =
     pytest-doctestplus>=0.13
     pytest-astropy
     requests-mock
-    defusedxml
 docs =
     sphinx-astropy
 


### PR DESCRIPTION
https://github.com/astropy/pyvo/pull/497 uses the new dependency and not just the tests, so it should be listed as an optional rather than a test dependency

This now also moves the linkcheck job to cron only. The docs build should be able to pick up any newly introduced API linking issues, and if a newly added URL is defunct, we will pick it up once it's merged, but won't fail PRs with unrelated failing URLs.

close #498 
