### PR TITLE
Documentation of Freetext constraint

### DIFF
--- a/pyvo/registry/rtcons.py
+++ b/pyvo/registry/rtcons.py
@@ -241,7 +241,7 @@ class SubqueriedConstraint(Constraint):
 
 class Freetext(Constraint):
     """
-    A contraint using plain text to match against title, description,
+    A constraint using plain text to match against title, description,
     subjects, and person names.
     """
     _keyword = "keywords"
@@ -252,6 +252,7 @@ class Freetext(Constraint):
         Parameters
         ----------
         *words : str
+            One or more string arguments.
             It is recommended to pass multiple words in multiple strings
             arguments.  You can pass in phrases (i.e., multiple words
             separated by space), but behaviour might then vary quite
@@ -392,7 +393,7 @@ class Servicetype(Constraint):
 
         Parameters
         ----------
-        *stds : tuple of str
+        *stds : str
             one or more standards identifiers.  The constraint will
             match records that have any of them.
         """
@@ -467,7 +468,7 @@ class Waveband(Constraint):
 
         Parameters
         ----------
-        *bands : tuple of strings
+        *bands : strings
             One or more of the terms given in http://www.ivoa.net/rdf/messenger.
             The constraint matches when a resource declares at least
             one of the messengers listed.
@@ -564,6 +565,7 @@ class Ivoid(Constraint):
         ----------
 
         ivoid : string
+            One or more string arguments.
             The IVOA identifier of the resource to match.  As RegTAP
             requires lowercasing ivoids on ingestion, the constraint
             lowercases the ivoid passed in, too.
@@ -593,7 +595,7 @@ class UCD(SubqueriedConstraint):
         Parameters
         ----------
 
-        patterns : tuple of strings
+        patterns : strings
             SQL patterns (i.e., ``%`` is 0 or more characters) for
             UCDs.  The constraint will match when a resource has
             at least one column matching one of the patterns.

--- a/pyvo/registry/rtcons.py
+++ b/pyvo/registry/rtcons.py
@@ -251,11 +251,16 @@ class Freetext(Constraint):
 
         Parameters
         ----------
-        *words : tuple of str
+        *words : str
             It is recommended to pass multiple words in multiple strings
             arguments.  You can pass in phrases (i.e., multiple words
             separated by space), but behaviour might then vary quite
             significantly between different registries.
+
+        Examples
+        --------
+        >>> from pyvo import registry
+        >>> registry.Freetext("Gamma", "Ray", "Burst") # doctest: +IGNORE_OUTPUT
         """
         self.words = words
 


### PR DESCRIPTION
Freetext does not expect a tuple of strings, but multiple string arguments, I know it's nitpicky but I'll teach the use of it soon and I'd expect this to be a bit confusing for the students if we don't change.

Edit: there were other occurences