### PR TITLE
SodaRecordMixin no longer will use a datalink#links endpoint for soda

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,6 +49,8 @@ Enhancements and Fixes
 Deprecations and Removals
 -------------------------
 
+- SodaRecordMixin no longer will use a datalink#links endpoint for soda [#580]
+
 
 1.5.2 (2024-05-22)
 ==================

--- a/pyvo/dal/adhoc.py
+++ b/pyvo/dal/adhoc.py
@@ -671,13 +671,6 @@ class SodaRecordMixin:
         except DALServiceError:
             pass
 
-        # let it count as soda resource
-        try:
-            return self._results.get_adhocservice_by_ivoid(
-                "ivo://ivoa.net/std/datalink#links")
-        except DALServiceError:
-            pass
-
         dataformat = self.getdataformat()
         if dataformat is None:
             raise DALServiceError(


### PR DESCRIPTION
It is unclear why it ever did this, as I really do not see how this would ever have a beneficial effect (the only parameter understood by both links and SODA is ID, and even that is interpreted in totally different ways).  It has, however, a detrimental effect; see bug #578.

Fixes #578