### PR TITLE
BUG: Include port number if present

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -70,6 +70,8 @@ Deprecations and Removals
 - Adding ``session`` kwarg to allow to pass a session along when turning
   an Interface into a service via ``Interface.to_service``. [#590]
 
+- Include port number if it is present in endpoint access URL. [#582]
+
 
 1.5.2 (2024-05-22)
 ==================

--- a/pyvo/dal/tests/test_tap.py
+++ b/pyvo/dal/tests/test_tap.py
@@ -790,3 +790,14 @@ class TestTAPCapabilities:
     def test_get_udf(self, tapservice):
         func = tapservice.get_tap_capability().get_adql().get_udf("IVO_hasword")  # case insensitive!
         assert func.form == "ivo_hasword(haystack TEXT, needle TEXT) -> INTEGER"
+
+def test_get_endpoint_candidates():
+    # Directly instantiate the TAPService with a known base URL
+    svc = pyvo.dal.TAPService("http://astroweb.projects.phys.ucl.ac.uk:8000/tap")
+    
+    # Check if the correct endpoint candidates are generated
+    expected_urls = [
+        "http://astroweb.projects.phys.ucl.ac.uk:8000/tap/capabilities",
+        "http://astroweb.projects.phys.ucl.ac.uk:8000/capabilities"
+    ]
+    assert svc._get_endpoint_candidates("capabilities") == expected_urls

--- a/pyvo/dal/tests/test_tap.py
+++ b/pyvo/dal/tests/test_tap.py
@@ -793,7 +793,7 @@ class TestTAPCapabilities:
 
 def test_get_endpoint_candidates():
     # Directly instantiate the TAPService with a known base URL
-    svc = pyvo.dal.TAPService("http://astroweb.projects.phys.ucl.ac.uk:8000/tap")
+    svc = TAPService("http://astroweb.projects.phys.ucl.ac.uk:8000/tap")
     
     # Check if the correct endpoint candidates are generated
     expected_urls = [

--- a/pyvo/dal/tests/test_tap.py
+++ b/pyvo/dal/tests/test_tap.py
@@ -791,10 +791,11 @@ class TestTAPCapabilities:
         func = tapservice.get_tap_capability().get_adql().get_udf("IVO_hasword")  # case insensitive!
         assert func.form == "ivo_hasword(haystack TEXT, needle TEXT) -> INTEGER"
 
+
 def test_get_endpoint_candidates():
     # Directly instantiate the TAPService with a known base URL
     svc = TAPService("http://astroweb.projects.phys.ucl.ac.uk:8000/tap")
-    
+
     # Check if the correct endpoint candidates are generated
     expected_urls = [
         "http://astroweb.projects.phys.ucl.ac.uk:8000/tap/capabilities",

--- a/pyvo/dal/vosi.py
+++ b/pyvo/dal/vosi.py
@@ -18,28 +18,24 @@ __all__ = ['CapabilityMixin', 'VOSITables']
 
 
 class EndpointMixin():
-    def _get_endpoint(self, endpoint):
-        # finds the endpoint relative to the base url or its parent
-        # and returns its content in raw format
-
-        # do not trust baseurl as it might contain query or fragments
+    def _get_endpoint_candidates(self, endpoint):
         urlcomp = urlparse(self.baseurl)
         # Include the port number if present
         netloc = urlcomp.hostname
         if urlcomp.port:
             netloc += f':{urlcomp.port}'
-        curated_baseurl = '{}://{}{}'.format(urlcomp.scheme,
-                                             netloc,
-                                             urlcomp.path)
+        curated_baseurl = '{}://{}{}'.format(urlcomp.scheme, netloc, urlcomp.path)
+
         if not endpoint:
             raise AttributeError('endpoint required')
-        ep_urls = [
-            '{baseurl}/{endpoint}'.format(baseurl=curated_baseurl,
-                                          endpoint=endpoint),
+        
+        return [
+            '{baseurl}/{endpoint}'.format(baseurl=curated_baseurl, endpoint=endpoint),
             url_sibling(curated_baseurl, endpoint)
         ]
 
-        for ep_url in ep_urls:
+    def _get_endpoint(self, endpoint):
+        for ep_url in self._get_endpoint_candidates(endpoint):
             try:
                 response = self._session.get(ep_url, stream=True)
                 response.raise_for_status()
@@ -48,8 +44,7 @@ class EndpointMixin():
                 continue
         else:
             raise DALServiceError(
-                "No working {endpoint} endpoint provided".format(
-                    endpoint=endpoint))
+                f"No working {endpoint} endpoint provided")
 
         return response.raw
 

--- a/pyvo/dal/vosi.py
+++ b/pyvo/dal/vosi.py
@@ -24,8 +24,12 @@ class EndpointMixin():
 
         # do not trust baseurl as it might contain query or fragments
         urlcomp = urlparse(self.baseurl)
+        # Include the port number if present
+        netloc = urlcomp.hostname
+        if urlcomp.port:
+            netloc += f':{urlcomp.port}'
         curated_baseurl = '{}://{}{}'.format(urlcomp.scheme,
-                                             urlcomp.hostname,
+                                             netloc,
                                              urlcomp.path)
         if not endpoint:
             raise AttributeError('endpoint required')

--- a/pyvo/dal/vosi.py
+++ b/pyvo/dal/vosi.py
@@ -24,15 +24,12 @@ class EndpointMixin():
         netloc = urlcomp.hostname
         if urlcomp.port:
             netloc += f':{urlcomp.port}'
-        curated_baseurl = '{}://{}{}'.format(urlcomp.scheme, netloc, urlcomp.path)
+        curated_baseurl = f'{urlcomp.scheme}://{netloc}{urlcomp.path}'
 
         if not endpoint:
             raise AttributeError('endpoint required')
-        
-        return [
-            '{baseurl}/{endpoint}'.format(baseurl=curated_baseurl, endpoint=endpoint),
-            url_sibling(curated_baseurl, endpoint)
-        ]
+
+        return [f'{curated_baseurl}/{endpoint}', url_sibling(curated_baseurl, endpoint)]
 
     def _get_endpoint(self, endpoint):
         for ep_url in self._get_endpoint_candidates(endpoint):
@@ -43,8 +40,7 @@ class EndpointMixin():
             except requests.RequestException:
                 continue
         else:
-            raise DALServiceError(
-                f"No working {endpoint} endpoint provided")
+            raise DALServiceError(f"No working {endpoint} endpoint provided")
 
         return response.raw
 
@@ -144,6 +140,7 @@ class VOSITables:
     Access to table names is like accessing dictionary keys. using iterator
     syntax or `keys()`
     """
+
     def __init__(self, vosi_tables, endpoint_url, *, session=None):
         self._vosi_tables = vosi_tables
         self._endpoint_url = endpoint_url


### PR DESCRIPTION
This is a quick fix to address the Issue #563, by including the port number if present 
in the provided URL.

The code checks if the `baseurl` has port number, and adds to the hostname in `curated_baseurl`.
This should fix the issue that the port number was missing as #563 described.