### PR TITLE
Adding `sia1` as servicetype

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -52,6 +52,12 @@ Deprecations and Removals
 - SodaRecordMixin no longer will use a datalink#links endpoint for soda [#580]
 
 
+1.5.3 (unreleased)
+==================
+
+- Added `'sia1'` as servicetype for registry searches. [#583]
+
+
 1.5.2 (2024-05-22)
 ==================
 

--- a/docs/registry/index.rst
+++ b/docs/registry/index.rst
@@ -48,7 +48,7 @@ keyword arguments.  The following constraints are available:
   freetext words, mached in the title, description or subject of the
   resource.
 * :py:class:`~pyvo.registry.Servicetype` (``servicetype``): constrain to
-  one of tap, ssa, sia, conesearch (or full ivoids for other service
+  one of tap, ssa, sia1, sia2, conesearch (or full ivoids for other service
   types).  This is the constraint you want
   to use for service discovery.
 * :py:class:`~pyvo.registry.UCD` (``ucd``): constrain by one or more UCD
@@ -358,7 +358,7 @@ it returns 33 matching services.
   >>> import warnings
   >>> warnings.filterwarnings('ignore', module="astropy.io.votable.*")
   >>>
-  >>> archives = vo.regsearch(servicetype='image', waveband='x-ray')
+  >>> archives = vo.regsearch(servicetype='sia1', waveband='x-ray')
   >>> pos = SkyCoord.from_name('Cas A')
   >>> len(archives)   # doctest: +IGNORE_OUTPUT
   33
@@ -404,7 +404,7 @@ NRAO VLA Sky Survey (NVSS):
 
 .. doctest-remote-data::
 
-  >>> colls = vo.regsearch(keywords=['NVSS'], servicetype='sia')
+  >>> colls = vo.regsearch(keywords=['NVSS'], servicetype='sia1')
   >>> for coll in colls:
   ...     print(coll.res_title, coll.access_url)
   NRA) VLA Sky Survey https://skyview.gsfc.nasa.gov/cgi-bin/vo/sia.pl?survey=nvss&
@@ -428,7 +428,7 @@ documentation).  Some attributes deserve a second look.
 .. doctest-remote-data::
 
   >>> import pyvo as vo
-  >>> colls = vo.regsearch(keywords=["NVSS"], servicetype='sia')
+  >>> colls = vo.regsearch(keywords=["NVSS"], servicetype='sia1')
   >>> nvss = colls["NVSS"]
   >>> nvss.res_title
   'NRA) VLA Sky Survey'
@@ -492,7 +492,7 @@ that takes the form of a
 
 .. doctest-remote-data::
 
-  >>> colls = vo.regsearch(keywords=["NVSS"], servicetype='sia')
+  >>> colls = vo.regsearch(keywords=["NVSS"], servicetype='sia1')
   >>> for coll in colls:
   ...     print(coll.ivoid)
   ivo://nasa.heasarc/skyview/nvss
@@ -503,7 +503,7 @@ registry.
 
 .. doctest-remote-data::
 
-  >>> nvss = vo.registry.search(ivoid='ivo://nasa.heasarc/skyview/nvss')[0].get_service(service_type='sia')
+  >>> nvss = vo.registry.search(ivoid='ivo://nasa.heasarc/skyview/nvss')[0].get_service(service_type='sia1')
   >>> nvss.search(pos=(350.85, 58.815),size=0.25,format="image/fits")
   <DALResultsTable length=1>
   Survey    Ra   ... LogicalName

--- a/pyvo/registry/rtcons.py
+++ b/pyvo/registry/rtcons.py
@@ -34,6 +34,7 @@ SERVICE_TYPE_MAP = dict((k, "ivo://ivoa.net/std/" + v)
                         for k, v in [
     ("image", "sia"),
     ("sia", "sia"),
+    ("sia1", "sia"),
     # SIA2 is irregular
     # funky scheme used by SIA2 without breaking everything else
     ("spectrum", "ssa"),
@@ -356,9 +357,9 @@ class Servicetype(Constraint):
 
     The constraint normally is a custom keyword, one of:
 
-    * ``image`` (image services; at this point equivalent to sia, but
-      scheduled to include sia2, too)
-    * ``sia`` (SIAP version 1 services)
+
+    * ``sia``, ``sia1`` (SIAP version 1 services; prefer ``sia1`` for symmetry,
+      although ``sia`` will be kept as the official IVOA short name for SIA1)
     * ``sia2`` (SIAP version 2 services)
     * ``spectrum``, ``ssa``, ``ssap`` (all synonymous for spectral
       services, prefer ``spectrum``)
@@ -366,6 +367,8 @@ class Servicetype(Constraint):
       ``scs``)
     * ``line`` (for SLAP services)
     * ``tap``, ``table`` (synonymous for TAP services, prefer ``tap``)
+    * ``image`` (a to be deprecated alias for sia1)
+    * ``spectrum`` (a to be deprecated alias for ssap)
 
     You can also pass in the standards' ivoid (which
     generally looks like

--- a/pyvo/registry/tests/test_rtcons.py
+++ b/pyvo/registry/tests/test_rtcons.py
@@ -147,7 +147,7 @@ class TestServicetypeConstraint:
                 " 'ivo://ivoa.net/std/sia')")
 
     def test_includeaux(self):
-        assert (rtcons.Servicetype("http://extstandards/invention", "image"
+        assert (rtcons.Servicetype("http://extstandards/invention", "sia1"
                                    ).include_auxiliary_services().get_search_condition(FAKE_GAVO)
                 == "standard_id IN ('http://extstandards/invention',"
                 " 'http://extstandards/invention#aux',"
@@ -159,7 +159,7 @@ class TestServicetypeConstraint:
             rtcons.Servicetype("junk")
         assert str(excinfo.value) == ("Service type junk is neither"
                                       " a full standard URI nor one of the bespoke identifiers"
-                                      " image, sia, spectrum, ssap, ssa, scs, conesearch, line, slap,"
+                                      " image, sia, sia1, spectrum, ssap, ssa, scs, conesearch, line, slap,"
                                       " table, tap, sia2")
 
     def test_legacy_term(self):


### PR DESCRIPTION
This pulls out the backportable portion of adding of sia1 as servicetype from #449 