### PR TITLE
DOC: examples have changed upstream, change index in docs

### DIFF
--- a/docs/dal/index.rst
+++ b/docs/dal/index.rst
@@ -189,7 +189,7 @@ the ``examples`` attribute.
 
 .. doctest-remote-data::
 
-    >>> print(tap_service.examples[0]['QUERY'])
+    >>> print(tap_service.examples[1]['QUERY'])
     SELECT TOP 50 l.id, l.pmra as lpmra, l.pmde as lpmde,
     g.source_id, g.pmra as gpmra, g.pmdec as gpmde
     FROM


### PR DESCRIPTION
The index was quite deterministic so far, so let's change it for now, and only skip the output checking when/if it keeps failing again.