### PR TITLE
MAINT: fix doctest typoes fixed upstream

### DIFF
--- a/docs/registry/index.rst
+++ b/docs/registry/index.rst
@@ -536,7 +536,7 @@ least an e-Mail address:
 .. doctest-remote-data::
 
   >>> res.get_contact()
-  'GAVO Data Center Team (++49 6221 54 1837) <gavo@ari.uni-heidelberg.de>'
+  'GAVO Data Centre Team (+49 6221 54 1837) <gavo@ari.uni-heidelberg.de>'
 
 Finally, the registry has an idea of what kind of tables are published
 through a resource, much like the VOSI tables endpoint (as a matter of

--- a/pyvo/registry/tests/test_regtap.py
+++ b/pyvo/registry/tests/test_regtap.py
@@ -717,7 +717,7 @@ def test_get_contact():
     rsc = _makeRegistryRecord(
         ivoid="ivo://org.gavo.dc/flashheros/q/ssa")
     assert (rsc.get_contact()
-            == "GAVO Data Center Team (++49 6221 54 1837)"
+            == "GAVO Data Centre Team (+49 6221 54 1837)"
             " <gavo@ari.uni-heidelberg.de>")
 
 


### PR DESCRIPTION
This should fix the CI on `main`