### PR TITLE
MAINT: adding Python 3.13 to CI

### DIFF
--- a/.github/workflows/ci_devtests.yml
+++ b/.github/workflows/ci_devtests.yml
@@ -32,7 +32,7 @@ jobs:
         run: tox -e py312-test-devdeps-alldeps-cov
 
       - name: Upload coverage to codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           file: ./coverage.xml
           verbose: true

--- a/.github/workflows/ci_devtests.yml
+++ b/.github/workflows/ci_devtests.yml
@@ -36,3 +36,16 @@ jobs:
         with:
           file: ./coverage.xml
           verbose: true
+
+  py313:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13-dev"
+      - name: Install tox
+        run: python -m pip install --upgrade tox
+      - name: Run tests against dev dependencies
+        run: tox -e py313-test

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 # as oldestdeps and devastropy might not support the full python range
 # listed here
 envlist =
-    py{38,39,310,311,312}-test{,-alldeps,-oldestdeps,-devdeps}{,-online}{,-cov}
+    py{38,39,310,311,312,313}-test{,-alldeps,-oldestdeps,-devdeps}{,-online}{,-cov}
     linkcheck
     codestyle
     build_docs
@@ -26,6 +26,8 @@ setenv =
     PYTEST_ARGS = -rsxf --show-capture=no
     online: PYTEST_ARGS = --remote-data=any --reruns=1 --reruns-delay 10 -rsxf --show-capture=no
     devdeps: PIP_EXTRA_INDEX_URL =  https://pypi.anaconda.org/scientific-python-nightly-wheels/simple https://pypi.anaconda.org/liberfa/simple https://pypi.anaconda.org/astropy/simple
+    # astropy doesn't yet have a 3.13 compatible release
+    py313: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/liberfa/simple https://pypi.anaconda.org/astropy/simple
 
 deps =
     cov: coverage
@@ -33,6 +35,9 @@ deps =
     devdeps: numpy>=0.0.dev0
     devdeps: pyerfa>=0.0.dev0
     devdeps: astropy>=0.0.dev0
+
+    # astropy doesn't yet have a 3.13 compatible release
+    py313: astropy>=0.0dev0
 
     oldestdeps: astropy==4.1
     # We set a suitably old numpy along with an old astropy, no need to pick up


### PR DESCRIPTION
We are likely compatible out of the box, but it better run through CI...