### PR TITLE
DOC: ignore one more job.phase 

### DIFF
--- a/docs/dal/index.rst
+++ b/docs/dal/index.rst
@@ -299,7 +299,7 @@ the server is, it will immediately go to the EXECUTING status:
 
 .. doctest-remote-data::
 
-    >>> job.phase   # doctest: +IGNORE_OUTPUT
+    >>> job.phase  # doctest: +IGNORE_OUTPUT
     'EXECUTING'
 
 The job will eventually end up in one of the phases:
@@ -626,7 +626,7 @@ Get the current job phase:
 
 .. doctest-remote-data::
 
-    >>> print(job.phase)
+    >>> print(job.phase)  # doctest: +IGNORE_OUTPUT
     EXECUTING
 
 Maximum run time in seconds is available and can be changed with


### PR DESCRIPTION
as it's somewhat unpredictable whether EXECUTING or QUEUED

(this has come up before but the failure has disappeared, thus we didn't put in the ignore. Now I'll just go ahead and merge it once CI has run)