### PR TITLE
CI: bump oldest numpy version in CI

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ deps =
     oldestdeps: astropy==4.1
     # We set a suitably old numpy along with an old astropy, no need to pick up
     # deprecations and errors due to their unmatching versions
-    oldestdeps: numpy==1.16
+    oldestdeps: numpy==1.19
 
     online: pytest-rerunfailures
 


### PR DESCRIPTION
This should close #596 