### PR TITLE
Fix bug #543

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,11 +46,15 @@ Enhancements and Fixes
 - Tables returned by RegistryResource.get_tables() now have a utype
   attribute [#576]
 
-- Registry Spatial constraint now supports Astropy Quantities for the radius argument [#594]
+- Registry Spatial constraint now supports Astropy Quantities for the
+  radius argument [#594]
+
+- iter_metadata() no longer crashes on tables with a datalink RESOURCE
+  and without obscore attributes [#599]
+
 
 Deprecations and Removals
 -------------------------
-
 
 - SodaRecordMixin no longer will use a datalink#links endpoint for soda [#580]
 

--- a/pyvo/dal/adhoc.py
+++ b/pyvo/dal/adhoc.py
@@ -227,11 +227,13 @@ class DatalinkResultsMixin(AdhocServiceResultsMixin):
         if "access_format" in row:
             return row["access_format"]
 
-        access_format = row.getbyutype("obscore:access.format")
+        access_format = row.getbyutype("obscore:access.format"
+            ) or row.getbyutype("ssa:Access.Format")
         if access_format:
             return access_format
 
-        access_format = row.getbyucd("meta.code.mime")
+        access_format = row.getbyucd("meta.code.mime"
+            ) or row.getbyucd("VOX:Image_Format")
         if access_format:
             return access_format
 
@@ -251,11 +253,13 @@ class DatalinkResultsMixin(AdhocServiceResultsMixin):
         if "access_url" in row:
             return row["access_url"]
 
-        access_url = row.getbyutype("obscore:access.reference")
+        access_url = row.getbyutype("obscore:access.reference"
+            ) or row.getbyutype("ssa:Access.Reference")
         if access_url:
             return access_url
 
-        access_url = row.getbyucd("meta.ref.url")
+        access_url = row.getbyucd("meta.ref.url"
+            ) or row.getbyucd("VOX:Image_AccessReference")
         if access_url:
             return access_url
 

--- a/pyvo/dal/adhoc.py
+++ b/pyvo/dal/adhoc.py
@@ -169,7 +169,7 @@ class DatalinkResultsMixin(AdhocServiceResultsMixin):
     """
     Mixin for datalink functionallity for results classes.
     """
-    def iter_datalinks_from_dlblock(self, datalink_service):
+    def _iter_datalinks_from_dlblock(self, datalink_service):
         """yields datalinks from the current rows using a datalink
         service RESOURCE.
         """
@@ -259,7 +259,7 @@ class DatalinkResultsMixin(AdhocServiceResultsMixin):
         if access_url:
             return access_url
 
-    def iter_datalinks_from_product_rows(self):
+    def _iter_datalinks_from_product_rows(self):
         """yield datalinks from self's rows if they describe datalink-valued
         products.
         """
@@ -291,10 +291,10 @@ class DatalinkResultsMixin(AdhocServiceResultsMixin):
                 self._datalink = None
 
         if self._datalink is None:
-            yield from self.iter_datalinks_from_product_rows()
+            yield from self._iter_datalinks_from_product_rows()
 
         else:
-            yield from self.iter_datalinks_from_dlblock(self._datalink)
+            yield from self._iter_datalinks_from_dlblock(self._datalink)
 
 
 class DatalinkRecordMixin:

--- a/pyvo/dal/query.py
+++ b/pyvo/dal/query.py
@@ -530,10 +530,11 @@ class DALResults:
         return the field name that has a given UType value or None if the UType
         is not found.
         """
+        utype = utype.lower()
         try:
             iterchain = (
                 self.getdesc(fieldname) for fieldname in self.fieldnames)
-            iterchain = (field for field in iterchain if field.utype == utype)
+            iterchain = (field for field in iterchain if (field.utype or "").lower() == utype)
             return next(iterchain).name
         except StopIteration:
             return None

--- a/pyvo/dal/tests/test_datalink.py
+++ b/pyvo/dal/tests/test_datalink.py
@@ -9,7 +9,9 @@ import pytest
 
 import pyvo as vo
 from pyvo.dal.adhoc import DatalinkResults
-from pyvo.utils import vocabularies
+from pyvo.dal.sia2 import SIA2Results
+from pyvo.dal.tap import TAPResults
+from pyvo.utils import testing, vocabularies
 
 from astropy.utils.data import get_pkg_data_contents, get_pkg_data_filename
 
@@ -35,6 +37,17 @@ def datalink(mocker):
 
     with mocker.register_uri(
         'POST', 'http://example.com/datalink', content=callback
+    ) as matcher:
+        yield matcher
+
+
+@pytest.fixture()
+def datalink_product(mocker):
+    def callback(request, context):
+        return get_pkg_data_contents('data/datalink/datalink.xml')
+
+    with mocker.register_uri(
+        'GET', 'http://example.com/datalink.xml', content=callback
     ) as matcher:
         yield matcher
 
@@ -198,3 +211,85 @@ class TestSemanticsRetrieval:
         assert res[1].endswith("comb_avg.0001.fits.fz?preview=True")
         assert res[2].endswith("http://dc.zah.uni-heidelberg.de/wider.dat")
         assert res[3].endswith("when-will-it-be-back")
+
+
+@pytest.mark.filterwarnings("ignore::astropy.io.votable.exceptions.E02")
+@pytest.mark.usefixtures('datalink_product', 'datalink_vocabulary')
+class TestIterDatalinksProducts:
+    """Tests for producing datalinks from tables containing links to
+    datalink documents.
+    """
+    def test_no_access_format(self):
+        res = testing.create_dalresults([
+            {"name": "access_url", "datatype": "char", "arraysize": "*",
+                "utype": "obscore:access.reference"}],
+            [("http://foo.bar/baz.jpeg",)],
+            resultsClass=TAPResults)
+        assert list(res.iter_datalinks()) == []
+
+    def test_obscore_utype(self):
+        res = testing.create_dalresults([
+            {"name": "data_product", "datatype": "char", "arraysize": "*",
+                "utype": "obscore:access.reference"},
+            {"name": "content_type", "datatype": "char", "arraysize": "*",
+                "utype": "obscore:access.format"},],
+            [("http://example.com/datalink.xml",
+                "application/x-votable+xml;content=datalink")],
+            resultsClass=TAPResults)
+        links = list(res.iter_datalinks())
+        assert len(links) == 1
+        assert (next(links[0].bysemantics("#this"))["access_url"]
+            == "http://dc.zah.uni-heidelberg.de/getproduct/flashheros/data/ca90/f0011.mt")
+
+    def test_sia2_record(self):
+        res = testing.create_dalresults([
+            {"name": "access_url", "datatype": "char", "arraysize": "*",
+                "utype": "obscore:access.reference"},
+            {"name": "access_format", "datatype": "char", "arraysize": "*",
+                "utype": "obscore:access.format"},],
+            [("http://example.com/datalink.xml",
+                "application/x-votable+xml;content=datalink")],
+            resultsClass=SIA2Results)
+        links = list(res.iter_datalinks())
+        assert len(links) == 1
+        assert (next(links[0].bysemantics("#this"))["access_url"]
+            == "http://dc.zah.uni-heidelberg.de/getproduct/flashheros/data/ca90/f0011.mt")
+
+    def test_sia1_record(self):
+        res = testing.create_dalresults([
+            {"name": "access_url", "datatype": "char", "arraysize": "*",
+                "ucd": "VOX:Image_AccessReference"},
+            {"name": "access_format", "datatype": "char", "arraysize": "*",
+                "utype": "VOX:Image_Format"},],
+            [("http://example.com/datalink.xml",
+                "application/x-votable+xml;content=datalink")],
+            resultsClass=TAPResults)
+        links = list(res.iter_datalinks())
+        assert len(links) == 1
+        assert (next(links[0].bysemantics("#this"))["access_url"]
+            == "http://dc.zah.uni-heidelberg.de/getproduct/flashheros/data/ca90/f0011.mt")
+
+    def test_generic_record(self):
+        # The meta.code.mime and meta.ref.url UCDs are perhaps too
+        # generic.  To ensure a somewhat predictable behaviour,
+        # we at least make sure we pick the first of possibly multiple
+        # pairs (not that this would preclude arbitrary amounts of
+        # chaos).
+        res = testing.create_dalresults([
+            {"name": "access_url", "datatype": "char", "arraysize": "*",
+                "ucd": "meta.ref.url"},
+            {"name": "access_format", "datatype": "char", "arraysize": "*",
+                "utype": "meta.code.mime"},
+            {"name": "alt_access_url", "datatype": "char", "arraysize": "*",
+                "ucd": "meta.ref.url"},
+            {"name": "alt_access_format", "datatype": "char", "arraysize": "*",
+                "utype": "meta.code.mime"},],
+            [("http://example.com/datalink.xml",
+                "application/x-votable+xml;content=datalink",
+                "http://example.com/bad-pick.xml",
+                "application/x-votable+xml;content=datalink",)],
+            resultsClass=TAPResults)
+        links = list(res.iter_datalinks())
+        assert len(links) == 1
+        assert (next(links[0].bysemantics("#this"))["access_url"]
+            == "http://dc.zah.uni-heidelberg.de/getproduct/flashheros/data/ca90/f0011.mt")

--- a/pyvo/dal/tests/test_datalink.py
+++ b/pyvo/dal/tests/test_datalink.py
@@ -257,10 +257,24 @@ class TestIterDatalinksProducts:
 
     def test_sia1_record(self):
         res = testing.create_dalresults([
-            {"name": "access_url", "datatype": "char", "arraysize": "*",
+            {"name": "product", "datatype": "char", "arraysize": "*",
                 "ucd": "VOX:Image_AccessReference"},
-            {"name": "access_format", "datatype": "char", "arraysize": "*",
-                "utype": "VOX:Image_Format"},],
+            {"name": "mime", "datatype": "char", "arraysize": "*",
+                "ucd": "VOX:Image_Format"},],
+            [("http://example.com/datalink.xml",
+                "application/x-votable+xml;content=datalink")],
+            resultsClass=TAPResults)
+        links = list(res.iter_datalinks())
+        assert len(links) == 1
+        assert (next(links[0].bysemantics("#this"))["access_url"]
+            == "http://dc.zah.uni-heidelberg.de/getproduct/flashheros/data/ca90/f0011.mt")
+
+    def test_ssap_record(self):
+        res = testing.create_dalresults([
+            {"name": "product", "datatype": "char", "arraysize": "*",
+                "utype": "ssa:access.reference"},
+            {"name": "mime", "datatype": "char", "arraysize": "*",
+                "utype": "ssa:access.format"},],
             [("http://example.com/datalink.xml",
                 "application/x-votable+xml;content=datalink")],
             resultsClass=TAPResults)

--- a/pyvo/utils/testing.py
+++ b/pyvo/utils/testing.py
@@ -6,6 +6,12 @@ from astropy.io.votable import tree
 from pyvo.dal import query as dalquery
 
 
+try:
+    TABLE_ELEMENT = tree.TableElement
+except AttributeError:
+    TABLE_ELEMENT = tree.Table
+
+
 def create_votable(field_descs, records):
     """returns a VOTableFile with a a single table containing records,
     described by field_descs.
@@ -13,7 +19,7 @@ def create_votable(field_descs, records):
     votable = tree.VOTableFile()
     resource = tree.Resource(type="results")
     votable.resources.append(resource)
-    table = tree.Table(votable)
+    table = TABLE_ELEMENT(votable)
     resource.tables.append(table)
     table.fields.extend(
         tree.Field(votable, **desc) for desc in field_descs)
@@ -35,6 +41,6 @@ def create_dalresults(
 
     The arguments are as for create_votable.
     """
-    return  resultsClass(
+    return resultsClass(
         create_votable(field_descs, records),
         url="http://testing.pyvo/test-url")

--- a/pyvo/utils/testing.py
+++ b/pyvo/utils/testing.py
@@ -1,0 +1,40 @@
+"""
+Miscellenaneous utilities for writing tests.
+"""
+
+from astropy.io.votable import tree
+from pyvo.dal import query as dalquery
+
+
+def create_votable(field_descs, records):
+    """returns a VOTableFile with a a single table containing records,
+    described by field_descs.
+    """
+    votable = tree.VOTableFile()
+    resource = tree.Resource(type="results")
+    votable.resources.append(resource)
+    table = tree.Table(votable)
+    resource.tables.append(table)
+    table.fields.extend(
+        tree.Field(votable, **desc) for desc in field_descs)
+    table.create_arrays(len(records))
+
+    for index, rec in enumerate(records):
+        table.array[index] = rec
+
+    return votable
+
+
+def create_dalresults(
+        field_descs,
+        records,
+        *,
+        resultsClass=dalquery.DALResults):
+    """returns a DALResults instance for a query returning records
+    described by field_descs.
+
+    The arguments are as for create_votable.
+    """
+    return  resultsClass(
+        create_votable(field_descs, records),
+        url="http://testing.pyvo/test-url")


### PR DESCRIPTION
Upfront for the record, there is a possible API change here: iter_datalink would have returned [None] rather than [] when it did not find datalink-returnable things.  But this seems (a) insane and (b) it couldn't happen because pyVO would crash before it did this.

Having said that, this is a (possible) fix for bug #543.  The code in (2) in the bug now runs but yields no datalinks; that is the correct behaviour in this case because the media type is not datalink's.

There is in addition quite a bit of new heuristics in here to recognise possible pairs of product urls and media types.  I'm afraid these kinds of heuristics are the best we can do.

Also in here are testing utilities, which currently are undocumented; I'd first like to see whether they are actually useful.  Their purpose is to make it as simple as possible to produce DALResult-s for tests, which should allow to reduce the amount of test data in our repo.