### PR TITLE
Update repo URL

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -2,7 +2,7 @@ PyVO Contributors
 -----------------
 
 PyVO is an open source project developed through GitHub at
-https://github.com/pyvirtobs; community contributions are welcome.
+https://github.com/astropy/pyvo; community contributions are welcome.
 
 This project began in 2012 as a product of the US Virtual Astronomical
 Observatory, funded through a cooperative agreement with the US National

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,7 +41,7 @@ Source Installation
 ^^^^^^^^^^^^^^^^^^^
 .. code-block:: bash
 
-  git clone http://github.com/pyvirtobs/pyvo
+  git clone http://github.com/astropy/pyvo
   cd pyvo
   python setup.py install
 


### PR DESCRIPTION
This PR updates mentions of the project's repository to point to the current *astropy/pyvo* URL instead of the old _pyvirtobs_ one