### PR TITLE
Added content type check for getdatalink

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -56,6 +56,9 @@ Enhancements and Fixes
 - iter_metadata() no longer crashes on tables with a datalink RESOURCE
   and without obscore attributes [#599]
 
+- getdatalink() now checks content type of urls and raises a more informative error
+  when no datalink is found [#328]
+
 
 Deprecations and Removals
 -------------------------

--- a/pyvo/dal/tests/test_datalink.py
+++ b/pyvo/dal/tests/test_datalink.py
@@ -8,10 +8,11 @@ from functools import partial
 import pytest
 
 import pyvo as vo
-from pyvo.dal.adhoc import DatalinkResults
+from pyvo.dal.adhoc import DatalinkResults, DALServiceError
 from pyvo.dal.sia2 import SIA2Results
 from pyvo.dal.tap import TAPResults
 from pyvo.utils import testing, vocabularies
+from pyvo.dal.sia import search
 
 from astropy.utils.data import get_pkg_data_contents, get_pkg_data_filename
 
@@ -307,3 +308,14 @@ class TestIterDatalinksProducts:
         assert len(links) == 1
         assert (next(links[0].bysemantics("#this"))["access_url"]
             == "http://dc.zah.uni-heidelberg.de/getproduct/flashheros/data/ca90/f0011.mt")
+
+
+@pytest.mark.usefixtures('sia', 'register_mocks')
+@pytest.mark.filterwarnings("ignore::astropy.io.votable.exceptions.W06")
+def test_search():
+    # for issue #328 getdatalink() exits messily when there isn't a datalink
+
+    results = search('http://example.com/sia', pos=(288, 15), format="all")
+    result = results[0]
+    with pytest.raises(DALServiceError, match="No datalink found for record."):
+        result.getdatalink()

--- a/pyvo/dal/tests/test_datalink.py
+++ b/pyvo/dal/tests/test_datalink.py
@@ -4,6 +4,7 @@
 Tests for pyvo.dal.datalink
 """
 from functools import partial
+import re
 
 import pytest
 
@@ -30,6 +31,24 @@ def ssa_datalink(mocker):
     ) as matcher:
         yield matcher
 
+sia_re = re.compile('http://example.com/sia.*')
+
+
+@pytest.fixture()
+def register_mocks(mocker):
+    with mocker.register_uri(
+        'GET', 'http://example.com/querydata/image.fits',
+        content=get_pkg_data_contents('data/querydata/image.fits')
+    ) as matcher:
+        yield matcher
+
+
+@pytest.fixture()
+def sia(mocker):
+    with mocker.register_uri(
+        'GET', sia_re, content=get_pkg_data_contents('data/sia/dataset.xml')
+    ) as matcher:
+        yield matcher
 
 @pytest.fixture()
 def datalink(mocker):


### PR DESCRIPTION
This PR seeks to address issue #328 and the associated discussion by checking if the `access_format` property is present and a datalink or a votable. Failing that, this update checks the headers of URLs in the record with the `meta.ref.url` UCD, if the content type is found to be a datalink or a votable, the link is provided as the `datalink_url` for the record.
Where no datalink is found, a `DALServiceError` is raised informing the user that no datalink was found for the record. 

Fixes #328 