### PR TITLE
DOC: post 1.5.3 changelog cleanup

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,14 +1,6 @@
 1.6 (unreleased)
 ================
 
-Bug Fixes
----------
-
-- cachedataset() and friends again produce reasonable file extensions.
-  [#553]
-- path separators are no longer taken over from image titles to file
-  system paths. [#557]
-
 Enhancements and Fixes
 ----------------------
 
@@ -40,25 +32,11 @@ Enhancements and Fixes
 - RegTAP constraints involving tables other than rr.resource are now
   done via subqueries for less duplication of interfaces. [#562, #572]
 
-- Where datalink records are made from table rows, the table row is
-  now accessible as datalinks.original_row. [#559]
-
-- Tables returned by RegistryResource.get_tables() now have a utype
-  attribute [#576]
- 
-- MIVOT module: If the MIVOT annotation block contains a valid instance of the ``mango:EpochPosition`` class,
-  the dynamic object describing the mapped data can generate a valid SkyCoord instance. [#591]
-
-
-- Registry Spatial constraint now supports Astropy Quantities for the
-  radius argument [#594]
-
-- iter_metadata() no longer crashes on tables with a datalink RESOURCE
-  and without obscore attributes [#599]
-
+- MIVOT module: If the MIVOT annotation block contains a valid instance of the
+  ``mango:EpochPosition`` class, the dynamic object describing the mapped
+  data can generate a valid SkyCoord instance. [#591]
 
 - New sub-package discover for global dataset discovery. [#470]
-
 
 
 Deprecations and Removals
@@ -69,12 +47,18 @@ Deprecations and Removals
 - Deprecating the use of "image" and "spectrum" in registry Servicetype
   constraints [#449]
 
-- Removed usage of the astropy TestRunner, therefore the unadvertised
-  ``pyvo.test()`` functionality. [#606]
 
-
-1.5.3 (unreleased)
+1.5.3 (2024-10-14)
 ==================
+
+Bug Fixes
+---------
+
+- ``cachedataset()`` and friends again produce reasonable file extensions.
+  [#553]
+
+- Path separators are no longer taken over from image titles to file
+  system paths. [#557]
 
 - Added `'sia1'` as servicetype for registry searches. [#583]
 
@@ -82,6 +66,27 @@ Deprecations and Removals
   an Interface into a service via ``Interface.to_service``. [#590]
 
 - Include port number if it is present in endpoint access URL. [#582]
+
+- Where datalink records are made from table rows, the table row is
+  now accessible as datalinks.original_row. [#559]
+
+- Tables returned by RegistryResource.get_tables() now have a utype
+  attribute. [#576]
+
+- Registry Spatial constraint now supports Astropy Quantities for the radius
+  argument. [#594]
+
+- ``iter_metadata()`` no longer crashes on tables with a datalink RESOURCE
+  and without obscore attributes. [#599]
+
+- Avoid assuming that ``'access_url'`` always exits. [#570]
+
+
+Deprecations and Removals
+-------------------------
+
+- Removed usage of the astropy TestRunner, therefore the unadvertised
+  ``pyvo.test()`` functionality. [#606]
 
 
 1.5.2 (2024-05-22)


### PR DESCRIPTION
I've released 1.5.3, it eventually got quite a lot of bugs fixes. 

This PR is the post-release changelog cleanup.