### PR TITLE
BUG: adding all mivot tests files

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -85,7 +85,7 @@ pyvo.auth.tests = data/tap/*.xml
 pyvo.io.uws.tests = data/*.xml
 pyvo.io.vosi.tests = data/*.xml, data/tables/*.xml, data/capabilities/*.xml
 pyvo.registry.tests = data/*.xml, data/*.desise
-pyvo.mivot.tests = data/*.xml, data/input/*.xml, data/output/*.xml
+pyvo.mivot.tests = data/*.xml, data/input/*.xml, data/output/*.xml, data/reference/*json, data/reference/*xml
 pyvo.dal.tests = data/*.xml, data/*/*
 
 [coverage:run]


### PR DESCRIPTION
This should fix the test issues we started to see recently. 

It's still a puzzle why it didn't come up earlier when these files and their tests were added but only resurfaced during the totally unrelated global discovery PR.

