### PR TITLE
Getdatalink - guess or return more informative error

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,8 @@ Enhancements and Fixes
 
 - New sub-package discover for global dataset discovery. [#470]
 
+- Updated getdatalink to be consistent with iter_datalinks. [#613]
+
 
 Deprecations and Removals
 -------------------------


### PR DESCRIPTION
This PR fixes #328 by mimicking the behavior of the related method `iter_datalinks` which guesses the access format and access url of the record/row. Finding no datalink results in a more informative error informing the user that no datalink could be found for record.

Note that the `guess_access_format` and `guess_access_url` are far from comprehensive and offer only a single guess for a given record. Subsequently, this PR cannot guarantee that failure to find a datalink indicates that no datalink exists. This PR makes behavior consistent between related methods and performs an attempt to find a datalink for a record where the information is not where expected.

This PR also used Ruff to format adhoc.py resulting in many stylistic changes.