### PR TITLE
CI: ignore milestone for changelog check 

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -18,3 +18,4 @@ jobs:
       env:
         CHANGELOG_FILENAME: CHANGES.rst
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        CHECK_MILESTONE: false


### PR DESCRIPTION
As sometimes it's not clear if there if a bugfix or feature release comes next, and nevertheless, we do consistency checks prior a release. ==> This will allow a changelog to be placed anywhere, and the rest is not up to the contributor but the maintainers/release manager.