### PR TITLE
BUG: explicitely allow bytes streams to be passed

### DIFF
--- a/pyvo/dal/query.py
+++ b/pyvo/dal/query.py
@@ -27,6 +27,7 @@ import shutil
 import re
 import requests
 from collections.abc import Mapping
+from io import BytesIO
 
 import collections
 
@@ -1033,15 +1034,18 @@ class Upload:
 
         # astropy table
         if isinstance(self._content, Table):
-            from io import BytesIO
+
             fileobj = BytesIO()
 
             self._content.write(output=fileobj, format="votable")
             fileobj.seek(0)
 
             return fileobj
+
+        elif isinstance(self._content, BytesIO):
+            return self._content
+
         elif isinstance(self._content, DALResults):
-            from io import BytesIO
             fileobj = BytesIO()
 
             table = self._content.to_table()

--- a/pyvo/dal/tests/test_query.py
+++ b/pyvo/dal/tests/test_query.py
@@ -526,3 +526,9 @@ class TestUpload:
         assert fileobj
 
         fileobj.close()
+
+    def test_upload_nonfileobj(self):
+        upload = Upload('up', 'some text that is not a resource')
+
+        with pytest.raises(ValueError):
+            upload.fileobj()

--- a/pyvo/dal/tests/test_query.py
+++ b/pyvo/dal/tests/test_query.py
@@ -6,7 +6,7 @@ Tests for pyvo.dal.query
 from functools import partial
 
 from contextlib import ExitStack
-
+from io import BytesIO
 from os import listdir
 
 import pytest
@@ -15,11 +15,12 @@ import numpy as np
 
 import platform
 
-from pyvo.dal.query import DALService, DALQuery, DALResults, Record
+from pyvo.dal.query import DALService, DALQuery, DALResults, Record, Upload
 from pyvo.dal.exceptions import DALServiceError, DALQueryError, DALFormatError, DALOverflowWarning
 from pyvo.version import version
 
 from astropy.table import Table, QTable
+from astropy.io.votable import parse as votableparse
 from astropy.io.votable.tree import VOTableFile
 
 try:
@@ -29,7 +30,7 @@ except ImportError:
     from astropy.io.votable.tree import Table as TableElement
 
 from astropy.io.fits import HDUList
-from astropy.utils.data import get_pkg_data_contents
+from astropy.utils.data import get_pkg_data_contents, get_pkg_data_filename
 
 get_pkg_data_contents = partial(
     get_pkg_data_contents, package=__package__, encoding='binary')
@@ -511,4 +512,17 @@ class TestRecord:
 
 
 class TestUpload:
-    pass
+    bytesio = BytesIO(get_pkg_data_contents('data/query/dataset.xml', encoding='binary'))
+    filename = get_pkg_data_filename('data/query/dataset.xml')
+    astropy_table = Table.read(filename)
+    records = DALResults(votableparse(filename))
+
+    @pytest.mark.parametrize('content', (bytesio, filename, astropy_table, records))
+    def test_upload(self, content):
+        upload = Upload('up', content)
+
+        fileobj = upload.fileobj()
+
+        assert fileobj
+
+        fileobj.close()


### PR DESCRIPTION
This is a follow-up for #614; where the finally implicitly returned the stream.

This issue has been recovered in CI for the navo notebooks. 