### PR TITLE
CI: fix coverage command

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -89,6 +89,7 @@ pyvo.mivot.tests = data/*.xml, data/input/*.xml, data/output/*.xml, data/referen
 pyvo.dal.tests = data/*.xml, data/*/*
 
 [coverage:run]
+source = pyvo
 omit =
     pyvo/_astropy_init*
     pyvo/conftest.py

--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,9 @@ deps =
 commands =
     pip freeze
     !cov: pytest --pyargs {env:PYTEST_ARGS}
-    cov: pytest --pyargs --cov pyvo --cov-config={toxinidir}/setup.cfg {env:PYTEST_ARGS}
+    # Run pytest with coverage to include module imports in report
+    # See https://github.com/pytest-dev/pytest-cov/issues/455 for more info
+    cov: coverage run -m pytest --pyargs --cov-config={toxinidir}/setup.cfg {env:PYTEST_ARGS}
     cov: coverage xml -o {toxinidir}/coverage.xml
 
 [testenv:linkcheck]


### PR DESCRIPTION
This should close #618 

@pllim - I don't see why this isn't a problem for astropy as we do use `remote-data` fixtures there, maybe you remember a different fix?