### PR TITLE
Add dot to extensions of added MIME types

### DIFF
--- a/pyvo/dal/mimetype.py
+++ b/pyvo/dal/mimetype.py
@@ -11,10 +11,10 @@ from astropy.io.fits import HDUList
 from ..utils.http import use_session
 
 
-mimetypes.add_type('application/fits', 'fits')
-mimetypes.add_type('application/x-fits', 'fits')
-mimetypes.add_type('image/fits', 'fits')
-mimetypes.add_type('text/plain', 'txt')
+mimetypes.add_type('application/fits', '.fits')
+mimetypes.add_type('application/x-fits', '.fits')
+mimetypes.add_type('image/fits', '.fits')
+mimetypes.add_type('text/plain', '.txt')
 
 
 def mime2extension(mimetype, default=None):


### PR DESCRIPTION
There's a suggestion in https://github.com/python/cpython/issues/75223 / https://github.com/python/cpython/pull/2895 to raise a `ValueError` when adding MIME type extensions with a dot.

This PR adds the dots.