### PR TITLE
BUG: fix float string literal issues

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,8 @@ Bug Fixes
 
 - Fix propagating some previously swallowed exceptions. [#614]
 
+- Fix string literal generation for SQL query when using numpy >=2.0. [#624]
+
 
 1.6 (2024-11-01)
 ================

--- a/conftest.py
+++ b/conftest.py
@@ -40,11 +40,6 @@ from astropy.utils.iers import conf as iers_conf
 iers_conf.auto_download = False
 
 
-# Keep this until we require numpy to be >=2.0
-if minversion(np, "2.0.0.dev0+git20230726"):
-    np.set_printoptions(legacy="1.25")
-
-
 def pytest_configure(config):
     """Configure Pytest with Astropy.
 

--- a/pyvo/dal/query.py
+++ b/pyvo/dal/query.py
@@ -695,7 +695,7 @@ class Record(Mapping):
         return len(self._mapping)
 
     def __repr__(self):
-        return repr(tuple(self.values()))
+        return repr(tuple(f'{val}' for val in self.values()))
 
     def get(self, key, default=None, decode=False):
         """

--- a/pyvo/dal/tests/test_query.py
+++ b/pyvo/dal/tests/test_query.py
@@ -461,7 +461,7 @@ class TestRecord:
         record = DALResults.from_result_url(
             'http://example.com/query/basic')[0]
         truth = 'Illuminatus'
-        assert repr(record) == repr((23, truth))
+        assert repr(record) == repr(('23', truth))
 
     def test_get(self):
         record = DALResults.from_result_url(

--- a/pyvo/registry/rtcons.py
+++ b/pyvo/registry/rtcons.py
@@ -106,7 +106,7 @@ def make_sql_literal(value):
         return "{:d}".format(value)
 
     elif isinstance(value, (float, numpy.floating)):
-        return repr(value)
+        return f'{value}'
 
     elif isinstance(value, datetime.datetime):
         return "'{}'".format(value.isoformat())

--- a/pyvo/registry/rtcons.py
+++ b/pyvo/registry/rtcons.py
@@ -102,10 +102,7 @@ def make_sql_literal(value):
     elif isinstance(value, bytes):
         return "'{}'".format(value.decode("ascii").replace("'", "''"))
 
-    elif isinstance(value, (int, numpy.integer)):
-        return "{:d}".format(value)
-
-    elif isinstance(value, (float, numpy.floating)):
+    elif isinstance(value, (int, numpy.integer, float, numpy.floating)):
         return f'{value}'
 
     elif isinstance(value, datetime.datetime):

--- a/pyvo/registry/tests/test_rtcons.py
+++ b/pyvo/registry/tests/test_rtcons.py
@@ -11,7 +11,7 @@ from astropy import units as u
 from astropy.coordinates import SkyCoord
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
-import numpy
+import numpy as np
 import pytest
 
 from pyvo import registry
@@ -19,6 +19,10 @@ from pyvo.registry import rtcons
 from pyvo.dal import query as dalq
 
 from .commonfixtures import messenger_vocabulary, FAKE_GAVO, FAKE_PLAIN  # noqa: F401
+
+
+# We should make sure non-legacy numpy works as expected for string literal generation
+np.set_printoptions(legacy=False)
 
 
 def _build_regtap_query_with_fake(
@@ -52,7 +56,7 @@ class TestSQLLiterals:
                 "bytes": b"keep this ascii for now",
                 "anInt": 210,
                 "aFloat": 5e7,
-                "numpyStuff": numpy.float64(23.7),
+                "numpyStuff": np.float64(23.7),
                 "timestamp": datetime.datetime(2021, 6, 30, 9, 1), }
 
         return _WithFillers()._get_sql_literals()


### PR DESCRIPTION
This logic was introduced in the big registry overhaul PR #289, and I see no review discussion for this part of the code.

Looking at it now, I think f-strings should be powerful enough when generating the SQL string. If not, we will definitely need some use case coverage in the tests, too.

First commit fixes #623, but I think the cleanup in the second commit should work, too.

The changes in numpy printoptions in the tests ensure that we indeed trigger the bug (it does have ample test coverage with existing tests). I expect some other places may be affected and will rely on CI to smoke out the version dependencies of them and will see whether they are bugs or the fixes can be included here, too.