### PR TITLE
DOC: using shorter ellipse

### DIFF
--- a/docs/dal/index.rst
+++ b/docs/dal/index.rst
@@ -212,7 +212,7 @@ to see the tables available on the Simbad TAP service, say:
 
     >>> simbad = vo.dal.TAPService("http://simbad.cds.unistra.fr/simbad/sim-tap")
     >>> print([tab_name for tab_name in simbad.tables.keys()])  # doctest: +IGNORE_WARNINGS
-    ['TAP_SCHEMA.schemas', 'TAP_SCHEMA.tables', 'TAP_SCHEMA.columns', 'TAP_SCHEMA.keys', ... 'mesVelocities', 'mesXmm', 'otypedef', 'otypes', 'ref']
+    ['TAP_SCHEMA.schemas', 'TAP_SCHEMA.tables', ... 'otypedef', 'otypes', 'ref']
 
 
 If you know a TAP service's access URL, you can directly pass it to


### PR DESCRIPTION
The output has changed (I think it was due to changes on the server rather than being an unordered output), so I went ahead and cut the example shorter. 

This should fix the remaining CI failure.