### PR TITLE
[Issue 504] add "detail=min" parameter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,8 @@ Bug Fixes
 
 - Fix string literal generation for SQL query when using numpy >=2.0. [#624]
 
+- Try minimal VOSI tables downloads by default for TAP metadata [#634]
+
 
 1.6 (2024-11-01)
 ================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,7 +19,7 @@ Bug Fixes
 
 - Fix string literal generation for SQL query when using numpy >=2.0. [#624]
 
-- Try minimal VOSI tables downloads by default for TAP metadata [#634]
+- Switch to do minimal VOSI tables downloads for TAP metadata. [#634]
 
 
 1.6 (2024-11-01)

--- a/pyvo/dal/tap.py
+++ b/pyvo/dal/tap.py
@@ -149,7 +149,7 @@ class TAPService(DALService, AvailabilityMixin, CapabilityMixin):
         if self._tables is None:
             tables_url = '{}/tables'.format(self.baseurl)
 
-            response = self._session.get(tables_url, stream=True)
+            response = self._session.get(tables_url, params={"detail":"min"}, stream=True)
 
             try:
                 response.raise_for_status()

--- a/pyvo/dal/tap.py
+++ b/pyvo/dal/tap.py
@@ -149,7 +149,7 @@ class TAPService(DALService, AvailabilityMixin, CapabilityMixin):
         if self._tables is None:
             tables_url = '{}/tables'.format(self.baseurl)
 
-            response = self._session.get(tables_url, params={"detail":"min"}, stream=True)
+            response = self._session.get(tables_url, params={"detail": "min"}, stream=True)
 
             try:
                 response.raise_for_status()


### PR DESCRIPTION
This is an attempt to address the Issue #504 by adding an additional parameter "detail=min" to the `tables` function.
When running the following code:
```
from pyvo import registry
registry.search(registry.Spatial((10, 10)), registry.Freetext("egal")) 
```
The runtime improves from 2s down to 1.2s (on my machine), while the output size is unchanged.