### PR TITLE
MAINT: moving the str input validation out to avoid astropy deprecation

### DIFF
--- a/pyvo/dal/params.py
+++ b/pyvo/dal/params.py
@@ -367,18 +367,12 @@ class PosQueryParam(AbstractDalQueryParam):
                     self._validate_ra(m)
 
     def _validate_ra(self, ra):
-        if isinstance(ra, str):
-            ra = Unit(ra)
-        if not isinstance(ra, Quantity):
-            ra = ra * u.deg
+        ra = Quantity(ra, u.deg)
         if ra.to(u.deg).value < 0 or ra.to(u.deg).value > 360.0:
             raise ValueError('Invalid ra: {}'.format(ra))
 
     def _validate_dec(self, dec):
-        if isinstance(dec, str):
-            dec = Unit(dec)
-        if not isinstance(dec, Quantity):
-            dec = dec * u.deg
+        dec = Quantity(dec, u.deg)
         if dec.to(u.deg).value < -90.0 or dec.to(u.deg).value > 90.0:
             raise ValueError('Invalid dec: {}'.format(dec))
 
@@ -418,15 +412,12 @@ class IntervalQueryParam(AbstractDalQueryParam):
             raise ValueError('Invalid interval: min({}) > max({})'.format(
                 low, high))
         if self._unit:
-            if isinstance(low, str):
-                low = Unit(low)
             if not isinstance(low, Quantity):
-                low = low * self._unit
+                low = u.Quantity(low, self._unit)
             low = low.to(self._unit, equivalencies=self._equivalencies).value
-            if isinstance(high, str):
-                high = Unit(high)
+
             if not isinstance(high, Quantity):
-                high = high * self._unit
+                high = Quantity(high, self._unit)
             high = high.to(self._unit, equivalencies=self._equivalencies).value
 
             if low > high:

--- a/pyvo/dal/params.py
+++ b/pyvo/dal/params.py
@@ -367,12 +367,16 @@ class PosQueryParam(AbstractDalQueryParam):
                     self._validate_ra(m)
 
     def _validate_ra(self, ra):
+        if isinstance(ra, str):
+            ra = Unit(ra)
         if not isinstance(ra, Quantity):
             ra = ra * u.deg
         if ra.to(u.deg).value < 0 or ra.to(u.deg).value > 360.0:
             raise ValueError('Invalid ra: {}'.format(ra))
 
     def _validate_dec(self, dec):
+        if isinstance(dec, str):
+            dec = Unit(dec)
         if not isinstance(dec, Quantity):
             dec = dec * u.deg
         if dec.to(u.deg).value < -90.0 or dec.to(u.deg).value > 90.0:
@@ -414,9 +418,13 @@ class IntervalQueryParam(AbstractDalQueryParam):
             raise ValueError('Invalid interval: min({}) > max({})'.format(
                 low, high))
         if self._unit:
+            if isinstance(low, str):
+                low = Unit(low)
             if not isinstance(low, Quantity):
                 low = low * self._unit
             low = low.to(self._unit, equivalencies=self._equivalencies).value
+            if isinstance(high, str):
+                high = Unit(high)
             if not isinstance(high, Quantity):
                 high = high * self._unit
             high = high.to(self._unit, equivalencies=self._equivalencies).value

--- a/pyvo/dal/tests/test_adhoc.py
+++ b/pyvo/dal/tests/test_adhoc.py
@@ -62,7 +62,7 @@ def test_pos():
 
     # errors
     test_obj.pos.pop()
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         test_obj.pos.add(('A', 2, 3))
     with pytest.raises(ValueError):
         test_obj.pos.add((-2, 7, 3))
@@ -116,7 +116,7 @@ def test_band():
         test_obj.band.add(())
     with pytest.raises(ValueError):
         test_obj.band.add((1, 2, 3))
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         test_obj.band.add(('INVALID', 6))
     with pytest.raises(ValueError):
         test_obj.band.add((3, 1))
@@ -216,7 +216,7 @@ def test_soda_query():
     assert not hasattr(test_obj, '_range')
 
     # error cases
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         test_obj.circle = ('A', 1, 2)
     with pytest.raises(ValueError):
         test_obj.circle = (1, 1, 2, 2)


### PR DESCRIPTION
This fixes the branch new astropy deprecation warnings. We only had the string input checked for cases where it should raise an exception, but there could be some cases where it's part of a valid input. 

@andamian wrote the original code, so I would like to hear if he is OK with this workaround or have something else in mind instead (I mean this is not a nice workaround).

```
_________________________________________________ test_pos _________________________________________________

    def test_pos():
        class TestClass(dict, AxisParamMixin):
            pass
        test_obj = TestClass()
        test_obj.pos.add((1, 2, 3) * u.deg)
        assert len(test_obj._pos) == 1
        assert test_obj['POS'] == ['CIRCLE 1.0 2.0 3.0']
    
        test_obj.pos.add((1, 2, 3, 4))
        assert len(test_obj._pos) == 2
        assert test_obj['POS'] == ['CIRCLE 1.0 2.0 3.0', 'RANGE 1.0 2.0 3.0 4.0']
    
        # duplicates are ignored
        test_obj.pos.add((1, 2, 3))
        assert len(test_obj._pos) == 2
        assert test_obj['POS'] == ['CIRCLE 1.0 2.0 3.0', 'RANGE 1.0 2.0 3.0 4.0']
    
        # polygon
        test_obj.pos.add((1, 2, 3, 4, 5, 6))
        assert len(test_obj._pos) == 3
        assert test_obj['POS'] == ['CIRCLE 1.0 2.0 3.0', 'RANGE 1.0 2.0 3.0 4.0',
                                   'POLYGON 1.0 2.0 3.0 4.0 5.0 6.0']
    
        # deletes
        test_obj.pos.remove((1, 2, 3, 4))
        assert len(test_obj._pos) == 2
        assert test_obj['POS'] == ['CIRCLE 1.0 2.0 3.0',
                                   'POLYGON 1.0 2.0 3.0 4.0 5.0 6.0']
    
        # test borders
        test_obj.pos.discard((1, 2, 3) * u.deg)
        test_obj.pos.discard((1, 2, 3, 4, 5, 6))
        assert (len(test_obj._pos) == 0)
        test_obj.pos.add((0, 90, 90))
        assert len(test_obj._pos) == 1
        assert test_obj['POS'] == ['CIRCLE 0.0 90.0 90.0']
        test_obj.pos.pop()
        test_obj.pos.add((360, -90, 1))
        assert len(test_obj._pos) == 1
        assert test_obj['POS'] == ['CIRCLE 360.0 -90.0 1.0']
        test_obj.pos.pop()
        test_obj.pos.add((0, 360, -90, 90))
        assert len(test_obj._pos) == 1
        assert test_obj['POS'] == ['RANGE 0.0 360.0 -90.0 90.0']
        test_obj.pos.pop()
        test_obj.pos.add((0, 0, 180, 90, 270, -90))
        assert len(test_obj._pos) == 1
        assert test_obj['POS'] == ['POLYGON 0.0 0.0 180.0 90.0 270.0 -90.0']
    
        # errors
        test_obj.pos.pop()
        with pytest.raises(ValueError):
>           test_obj.pos.add(('A', 2, 3))

pyvo/dal/tests/test_adhoc.py:66: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
pyvo/dal/params.py:259: in add
    if item in self:
pyvo/dal/params.py:280: in __contains__
    return self.get_dal_format(item) in self.dal
pyvo/dal/params.py:304: in get_dal_format
    self._validate_pos(val)
pyvo/dal/params.py:337: in _validate_pos
    self._validate_ra(pos[0])
pyvo/dal/params.py:371: in _validate_ra
    ra = ra * u.deg
../astropy/astropy/units/core.py:861: in __rmul__
    self._warn_about_operation_with_deprecated_type("products", m)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

op = 'products', other = 'A'

    @staticmethod
    def _warn_about_operation_with_deprecated_type(op: str, other: bytes | str) -> None:
>       warnings.warn(
            AstropyDeprecationWarning(
                f"{op} involving a unit and a '{type(other).__name__}' instance are "
                f"deprecated since v7.1. Convert {other!r} to a unit explicitly."
            ),
            stacklevel=3,
        )
E       astropy.utils.exceptions.AstropyDeprecationWarning: products involving a unit and a 'str' instance are deprecated since v7.1. Convert 'A' to a unit explicitly.

../astropy/astropy/units/core.py:791: AstropyDeprecationWarning
```