### PR TITLE
MAINT: ignoring IERS warnings

### DIFF
--- a/docs/dal/index.rst
+++ b/docs/dal/index.rst
@@ -264,7 +264,7 @@ starting it, it creates a new object :py:class:`~pyvo.dal.AsyncTAPJob`.
 .. doctest-remote-data::
 
     >>> job.url
-    'http://dc.g-vo.org/__system__/tap/run/async/0nh4f2pt'
+    'http://dc.g-vo.org/__system__/tap/run/async/...'
 
 The job URL mentioned before is available in the ``url`` attribute.
 Clicking on the URL leads you to the query itself, where you can check
@@ -818,7 +818,6 @@ previews:
     ... ).run_sync("select top 5 * from califadr3.cubes order by califaid")
     >>> for dl in rows.iter_datalinks():  # doctest: +IGNORE_WARNINGS
     ...     print(next(dl.bysemantics("#preview"))["access_url"])
-    http://dc.zah.uni-heidelberg.de/getproduct/califa/datadr3/V1200/IC5376.V1200.rscube.fits?preview=True
     http://dc.g-vo.org/getproduct/califa/datadr3/V1200/IC5376.V1200.rscube.fits?preview=True
     http://dc.g-vo.org/getproduct/califa/datadr3/COMB/IC5376.COMB.rscube.fits?preview=True
     http://dc.g-vo.org/getproduct/califa/datadr3/V500/IC5376.V500.rscube.fits?preview=True

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,9 @@ filterwarnings =
 # (adding it to conftest is ineffective as the PrototypeWarning line above already
 # triggers this warning at the time of collection
     ignore::astropy.utils.iers.iers.IERSStaleWarning
+# These two are also needed for python 3.8
+    ignore:Importing ErfaWarning:astropy.utils.exceptions.AstropyDeprecationWarning
+    ignore::astropy.utils.exceptions.ErfaWarning
 # We need to ignore this module level warning to not cause issues at collection time.
 # Remove it once warning is removed from code (in 1.7).
     ignore:pyvo.discover:pyvo.utils.prototype.PrototypeWarning

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,10 @@ filterwarnings =
 # Numpy 2.0 deprecations triggered by upstream libraries.
 # Exact warning messages differ, thus using a super generic filter.
     ignore:numpy.core:DeprecationWarning
+# Added for python 3.8, cleanup once old python version support is removed
+# (adding it to conftest is ineffective as the PrototypeWarning line above already
+# triggers this warning at the time of collection
+    ignore::astropy.utils.iers.iers.IERSStaleWarning
 # We need to ignore this module level warning to not cause issues at collection time.
 # Remove it once warning is removed from code (in 1.7).
     ignore:pyvo.discover:pyvo.utils.prototype.PrototypeWarning


### PR DESCRIPTION
Workaround to pass the old python tests: there are no updates for these, so the workaround is to ignore these warnings while we support python 3.8. Alternatively, we could ignore these warnings by default as I don't think they ever have any actual effect on pyvo functionality.

This should fix the python 3.8 job failure