### PR TITLE
MAINT: update URLs for gavo dc results

### DIFF
--- a/docs/dal/index.rst
+++ b/docs/dal/index.rst
@@ -264,7 +264,7 @@ starting it, it creates a new object :py:class:`~pyvo.dal.AsyncTAPJob`.
 .. doctest-remote-data::
 
     >>> job.url
-    'http://dc.zah.uni-heidelberg.de/__system__/tap/run/async/...'
+    'http://dc.g-vo.org/__system__/tap/run/async/0nh4f2pt'
 
 The job URL mentioned before is available in the ``url`` attribute.
 Clicking on the URL leads you to the query itself, where you can check
@@ -819,10 +819,11 @@ previews:
     >>> for dl in rows.iter_datalinks():  # doctest: +IGNORE_WARNINGS
     ...     print(next(dl.bysemantics("#preview"))["access_url"])
     http://dc.zah.uni-heidelberg.de/getproduct/califa/datadr3/V1200/IC5376.V1200.rscube.fits?preview=True
-    http://dc.zah.uni-heidelberg.de/getproduct/califa/datadr3/COMB/IC5376.COMB.rscube.fits?preview=True
-    http://dc.zah.uni-heidelberg.de/getproduct/califa/datadr3/V500/IC5376.V500.rscube.fits?preview=True
-    http://dc.zah.uni-heidelberg.de/getproduct/califa/datadr3/COMB/UGC00005.COMB.rscube.fits?preview=True
-    http://dc.zah.uni-heidelberg.de/getproduct/califa/datadr3/V1200/UGC00005.V1200.rscube.fits?preview=True
+    http://dc.g-vo.org/getproduct/califa/datadr3/V1200/IC5376.V1200.rscube.fits?preview=True
+    http://dc.g-vo.org/getproduct/califa/datadr3/COMB/IC5376.COMB.rscube.fits?preview=True
+    http://dc.g-vo.org/getproduct/califa/datadr3/V500/IC5376.V500.rscube.fits?preview=True
+    http://dc.g-vo.org/getproduct/califa/datadr3/COMB/UGC00005.COMB.rscube.fits?preview=True
+    http://dc.g-vo.org/getproduct/califa/datadr3/V1200/UGC00005.V1200.rscube.fits?preview=True
 
 The call to ``next`` in this example picks the first link marked
 *preview*.  For previews, this may be enough, but in general there can

--- a/docs/registry/index.rst
+++ b/docs/registry/index.rst
@@ -600,7 +600,7 @@ RegTAP services using:
   >>> res = registry.search(datamodel="regtap")
   >>> print("\n".join(sorted(r.get_interface(service_type="tap", lax=True).access_url
   ...   for r in res)))
-  http://dc.zah.uni-heidelberg.de/tap
+  http://dc.g-vo.org/tap
   http://gavo.aip.de/tap
   http://voparis-rr.obspm.fr/tap
   https://vao.stsci.edu/RegTAP/TapService.aspx

--- a/pyvo/discover/tests/test_imagediscovery.py
+++ b/pyvo/discover/tests/test_imagediscovery.py
@@ -201,7 +201,7 @@ def test_single_sia1():
     assert abs(im.s_dec+29) < 2
     assert im.instrument_name == 'Robotic Bochum Twin Telescope (RoBoTT)'
     assert "BGDS GDS_" in im.obs_title
-    assert "dc.zah.uni-heidelberg.de/getproduct/bgds/data" in im.access_url
+    assert "dc.g-vo.org/getproduct/bgds/data" in im.access_url
 
 
 @pytest.mark.remote_data


### PR DESCRIPTION
This should fix many of the failures in the remote-data job. Along with the #637 and #636 all the test failures should be addressed.