### PR TITLE
MAINT: drop python 3.8 support

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -24,12 +24,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: py38 oldest dependencies, Linux
-            python-version: '3.8'
-            tox_env: py38-test-oldestdeps-alldeps
-          - name: py39 mandatory dependencies only, Linux
+          - name: py39 oldest dependencies, Linux
             python-version: '3.9'
-            tox_env: py39-test
+            tox_env: py39-test-oldestdeps-alldeps
+          - name: py310 mandatory dependencies only, Linux
+            python-version: '3.10'
+            tox_env: py310-test
           - name: py311 with online tests, Linux
             python-version: '3.11'
             tox_env: py311-test-alldeps-online
@@ -63,11 +63,11 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b  # v5.3.0
       with:
-        python-version: '3.10'
+        python-version: '3.12'
     - name: Install tox
       run: python -m pip install --upgrade tox
-    - name: Python 3.10 with latest astropy
-      run: tox -e py310-test-alldeps
+    - name: Python 3.12 with latest astropy
+      run: tox -e py312-test-alldeps
 
 
   stylecheck:
@@ -76,10 +76,10 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
-      - name: Set up Python 3.8
+      - name: Set up Python 3.12
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b  # v5.3.0
         with:
-          python-version: 3.8
+          python-version: '3.12'
       - name: Install tox
         run: python -m pip install --upgrade tox
       - name: Check codestyle

--- a/pyvo/auth/authsession.py
+++ b/pyvo/auth/authsession.py
@@ -22,7 +22,7 @@ class AuthSession:
     """
 
     def __init__(self):
-        super(AuthSession, self).__init__()
+        super().__init__()
         self.credentials = CredentialStore()
         self._auth_urls = AuthURLs()
 

--- a/pyvo/auth/authurls.py
+++ b/pyvo/auth/authurls.py
@@ -100,10 +100,9 @@ class AuthURLs():
         # the longest URLs (the most specific ones, if
         # there is a tie) are used to determine the
         # auth method.
-        for url, method in sorted(self.base_urls.items(),
+        yield from sorted(self.base_urls.items(),
                                   key=sort_by_len,
-                                  reverse=True):
-            yield url, method
+                                  reverse=True)
 
     def __repr__(self):
         urls = []

--- a/pyvo/auth/credentialstore.py
+++ b/pyvo/auth/credentialstore.py
@@ -7,7 +7,7 @@ from . import securitymethods
 __all__ = ["CredentialStore"]
 
 
-class CredentialStore(object):
+class CredentialStore:
     """
     The credential store takes user credentials, and uses them
     to create appropriate requests sessions for dispatching

--- a/pyvo/dal/adhoc.py
+++ b/pyvo/dal/adhoc.py
@@ -142,7 +142,7 @@ class AdhocServiceResultsMixin:
             ):
                 return adhocservice
         raise DALServiceError(
-            "No Adhoc Service with ivo-id {}!".format(ivo_id))
+            f"No Adhoc Service with ivo-id {ivo_id}!")
 
     def get_adhocservice_by_id(self, id_):
         """
@@ -162,7 +162,7 @@ class AdhocServiceResultsMixin:
             if adhocservice.ID == id_:
                 return adhocservice
         raise DALServiceError(
-            "No Adhoc Service with service_def id {}!".format(id_))
+            f"No Adhoc Service with service_def id {id_}!")
 
 
 class DatalinkResultsMixin(AdhocServiceResultsMixin):
@@ -683,7 +683,7 @@ class DatalinkResults(DatalinkResultsMixin, DALResults):
                     additional_terms.extend(voc["terms"][term]["narrower"])
             core_terms = core_terms + additional_terms
 
-        semantics = set("#" + term for term in core_terms) | set(other_terms)
+        semantics = {"#" + term for term in core_terms} | set(other_terms)
         for record in self:
             if record.semantics in semantics:
                 yield record

--- a/pyvo/dal/exceptions.py
+++ b/pyvo/dal/exceptions.py
@@ -50,7 +50,7 @@ class DALAccessError(Exception):
         return self._reason
 
     def __repr__(self):
-        return "{}: {}".format(self._typeName(self), self._reason)
+        return f"{self._typeName(self)}: {self._reason}"
 
     @property
     def reason(self):
@@ -188,13 +188,13 @@ class DALServiceError(DALProtocolError):
                 code = response.status_code
                 content_type = response.headers.get('content-type', None)
                 if content_type and 'text/plain' in content_type:
-                    message = '{} for {}'.format(response.text, url)
+                    message = f'{response.text} for {url}'
 
             # TODO votable handling
 
             return DALServiceError(message, code, exc, url)
         elif isinstance(exc, Exception):
-            return DALServiceError("{}: {}".format(cls._typeName(exc), str(exc)),
+            return DALServiceError(f"{cls._typeName(exc)}: {str(exc)}",
                                    cause=exc, url=url)
         else:
             raise TypeError("from_except: expected Exception")

--- a/pyvo/dal/mimetype.py
+++ b/pyvo/dal/mimetype.py
@@ -88,7 +88,7 @@ def mime_object_maker(url, mimetype, *, session=None):
     params = pp[1:]
     mtype = [x.strip() for x in full_type.split('/')] if '/' in full_type else None
     if not mtype or len(mtype) > 2:
-        raise ValueError("Can't parse mimetype \"{}\"".format(full_type))
+        raise ValueError(f"Can't parse mimetype \"{full_type}\"")
 
     if mtype[0] == 'text':
         return session.get(url).text

--- a/pyvo/dal/params.py
+++ b/pyvo/dal/params.py
@@ -32,7 +32,7 @@ def find_param_by_keyword(keyword, params):
     if keyword in params:
         return params[keyword]
 
-    raise KeyError('No param named {} defined'.format(keyword))
+    raise KeyError(f'No param named {keyword} defined')
 
 
 registry = dict()
@@ -332,7 +332,7 @@ class PosQueryParam(AbstractDalQueryParam):
             else:
                 radius = pos[1]
             if radius <= 0 * u.deg or radius.to(u.deg) > 90 * u.deg:
-                raise ValueError('Invalid circle radius: {}'.format(radius))
+                raise ValueError(f'Invalid circle radius: {radius}')
         elif len(pos) == 3:
             self._validate_ra(pos[0])
             self._validate_dec(pos[1])
@@ -341,7 +341,7 @@ class PosQueryParam(AbstractDalQueryParam):
             else:
                 radius = pos[2]
             if radius <= 0 * u.deg or radius.to(u.deg) > 90 * u.deg:
-                raise ValueError('Invalid circle radius: {}'.format(radius))
+                raise ValueError(f'Invalid circle radius: {radius}')
         elif len(pos) == 4:
             ra_min = pos[0] if isinstance(pos[0], Quantity) else pos[0] * u.deg
             ra_max = pos[1] if isinstance(pos[1], Quantity) else pos[1] * u.deg
@@ -370,13 +370,13 @@ class PosQueryParam(AbstractDalQueryParam):
         if not isinstance(ra, Quantity):
             ra = ra * u.deg
         if ra.to(u.deg).value < 0 or ra.to(u.deg).value > 360.0:
-            raise ValueError('Invalid ra: {}'.format(ra))
+            raise ValueError(f'Invalid ra: {ra}')
 
     def _validate_dec(self, dec):
         if not isinstance(dec, Quantity):
             dec = dec * u.deg
         if dec.to(u.deg).value < -90.0 or dec.to(u.deg).value > 90.0:
-            raise ValueError('Invalid dec: {}'.format(dec))
+            raise ValueError(f'Invalid dec: {dec}')
 
 
 class IntervalQueryParam(AbstractDalQueryParam):
@@ -425,7 +425,7 @@ class IntervalQueryParam(AbstractDalQueryParam):
                 # interval could become invalid during transform (e.g. GHz->m)
                 low, high = high, low
 
-        return '{} {}'.format(low, high)
+        return f'{low} {high}'
 
 
 class TimeQueryParam(AbstractDalQueryParam):
@@ -454,7 +454,7 @@ class TimeQueryParam(AbstractDalQueryParam):
             raise ValueError('Invalid time interval: min({}) > max({})'.format(
                 min_time, max_time
             ))
-        return '{} {}'.format(min_time.mjd, max_time.mjd)
+        return f'{min_time.mjd} {max_time.mjd}'
 
 
 class EnumQueryParam(AbstractDalQueryParam):

--- a/pyvo/dal/query.py
+++ b/pyvo/dal/query.py
@@ -129,7 +129,7 @@ class DALService:
         """
         describe the general information about the DAL service
         """
-        print('DAL Service at {}'.format(self.baseurl))
+        print(f'DAL Service at {self.baseurl}')
 
 
 class DALQuery(dict):
@@ -551,7 +551,7 @@ class DALResults:
 
             return self.resultstable.array[name]
         except KeyError:
-            raise KeyError("No such column: {}".format(name))
+            raise KeyError(f"No such column: {name}")
 
     def getrecord(self, index):
         """
@@ -686,7 +686,7 @@ class Record(Mapping):
 
             return self._mapping[key]
         except KeyError:
-            raise KeyError("No such column: {}".format(key))
+            raise KeyError(f"No such column: {key}")
 
     def __iter__(self):
         return iter(self._mapping)
@@ -889,7 +889,7 @@ class Record(Mapping):
         if not os.path.exists(dir):
             os.mkdir(dir)
         if not os.path.isdir(dir):
-            raise ValueError("{}: not a directory".format(dir))
+            raise ValueError(f"{dir}: not a directory")
 
         if not base:
             base = self.suggest_dataset_basename()
@@ -904,7 +904,7 @@ class Record(Mapping):
         n = self._dsname_no
 
         def mkpath(i):
-            return os.path.join(dir, "{}-{}.{}".format(base, i, ext))
+            return os.path.join(dir, f"{base}-{i}.{ext}")
 
         if n > 0:
             # find the last file written of the form, base-n.ext
@@ -914,7 +914,7 @@ class Record(Mapping):
             n += 1
         if n == 0:
             # never wrote a file of form, base-n.ext; try base.ext
-            path = os.path.join(dir, "{}.{}".format(base, ext))
+            path = os.path.join(dir, f"{base}.{ext}")
             if not os.path.exists(path):
                 return path
             n += 1

--- a/pyvo/dal/sia2.py
+++ b/pyvo/dal/sia2.py
@@ -339,7 +339,7 @@ class SIA2Query(DALQuery, AxisParamMixin):
             custom_arg = []
             for kw in _tolist(value):
                 if isinstance(kw, tuple):
-                    val = '{} {}'.format(kw[0], kw[1])
+                    val = f'{kw[0]} {kw[1]}'
                 else:
                     val = str(kw)
                 custom_arg.append(val)

--- a/pyvo/dal/tap.py
+++ b/pyvo/dal/tap.py
@@ -147,7 +147,7 @@ class TAPService(DALService, AvailabilityMixin, CapabilityMixin):
         returns tables as a dict-like object
         """
         if self._tables is None:
-            tables_url = '{}/tables'.format(self.baseurl)
+            tables_url = f'{self.baseurl}/tables'
 
             response = self._session.get(tables_url, stream=True)
 
@@ -201,7 +201,7 @@ class TAPService(DALService, AvailabilityMixin, CapabilityMixin):
         returns examples as a list of TAPQuery objects
         """
         if self._examples is None:
-            examples_url = '{}/examples'.format(self.baseurl)
+            examples_url = f'{self.baseurl}/examples'
 
             self._examples = self._parse_examples(examples_url)
         return self._examples
@@ -443,7 +443,7 @@ class TAPService(DALService, AvailabilityMixin, CapabilityMixin):
                 after = _from_ivoa_format(after)
             params['AFTER'] = after.strftime(IVOA_DATETIME_FORMAT)
 
-        response = self._session.get('{}/async'.format(self.baseurl),
+        response = self._session.get(f'{self.baseurl}/async',
                                      params=params,
                                      stream=True)
         response.raw.read = partial(response.raw.read, decode_content=True)
@@ -508,7 +508,7 @@ class TAPService(DALService, AvailabilityMixin, CapabilityMixin):
                 format(format, ' '.join(TABLE_DEF_FORMAT.keys())))
 
         headers = {'Content-Type': TABLE_DEF_FORMAT[format]}
-        response = self._session.put('{}/tables/{}'.format(self.baseurl, name),
+        response = self._session.put(f'{self.baseurl}/tables/{name}',
                                      headers=headers,
                                      data=definition)
         response.raise_for_status()
@@ -530,7 +530,7 @@ class TAPService(DALService, AvailabilityMixin, CapabilityMixin):
                 format(name))
 
         response = self._session.delete(
-            '{}/tables/{}'.format(self.baseurl, name))
+            f'{self.baseurl}/tables/{name}')
         response.raise_for_status()
 
     @prototype_feature('cadc-tb-upload')
@@ -559,7 +559,7 @@ class TAPService(DALService, AvailabilityMixin, CapabilityMixin):
 
         headers = {'Content-Type': TABLE_UPLOAD_FORMAT[format]}
         response = self._session.post(
-            '{}/load/{}'.format(self.baseurl, name),
+            f'{self.baseurl}/load/{name}',
             headers=headers,
             data=source)
         response.raise_for_status()
@@ -583,7 +583,7 @@ class TAPService(DALService, AvailabilityMixin, CapabilityMixin):
                 'table and column names are required in index: {}/{}'.
                 format(table_name, column_name))
 
-        result = self._session.post('{}/table-update'.format(self.baseurl),
+        result = self._session.post(f'{self.baseurl}/table-update',
                                     data={'table': table_name,
                                           'index': column_name,
                                           'unique': 'true' if unique
@@ -736,7 +736,7 @@ class AsyncTAPJob:
     def execution_duration(self, value):
         try:
             response = self._session.post(
-                "{}/executionduration".format(self.url),
+                f"{self.url}/executionduration",
                 data={"EXECUTIONDURATION": str(value)})
             response.raise_for_status()
         except requests.RequestException as ex:
@@ -769,7 +769,7 @@ class AsyncTAPJob:
 
         try:
             response = self._session.post(
-                "{}/destruction".format(self.url),
+                f"{self.url}/destruction",
                 data={"DESTRUCTION": value.strftime(IVOA_DATETIME_FORMAT)})
             response.raise_for_status()
         except requests.RequestException as ex:
@@ -808,7 +808,7 @@ class AsyncTAPJob:
     def query(self, query):
         try:
             response = self._session.post(
-                '{}/parameters'.format(self.url),
+                f'{self.url}/parameters',
                 data={"QUERY": query})
             response.raise_for_status()
         except requests.RequestException as ex:
@@ -829,7 +829,7 @@ class AsyncTAPJob:
 
         try:
             response = self._session.post(
-                '{}/parameters'.format(self.url),
+                f'{self.url}/parameters',
                 data={'UPLOAD': uploads.param()},
                 files=files
             )
@@ -900,7 +900,7 @@ class AsyncTAPJob:
         """
         try:
             response = self._session.post(
-                '{}/phase'.format(self.url), data={"PHASE": "RUN"})
+                f'{self.url}/phase', data={"PHASE": "RUN"})
             response.raise_for_status()
         except requests.RequestException as ex:
             raise DALServiceError.from_except(ex, self.url)
@@ -913,7 +913,7 @@ class AsyncTAPJob:
         """
         try:
             response = self._session.post(
-                '{}/phase'.format(self.url), data={"PHASE": "ABORT"})
+                f'{self.url}/phase', data={"PHASE": "ABORT"})
             response.raise_for_status()
         except requests.RequestException as ex:
             raise DALServiceError.from_except(ex, self.url)
@@ -1079,7 +1079,7 @@ class TAPQuery(DALQuery):
         queries.
 
         """
-        return '{baseurl}/{mode}'.format(baseurl=self.baseurl, mode=self._mode)
+        return f'{self.baseurl}/{self._mode}'
 
     def execute_stream(self, *, post=False):
         """

--- a/pyvo/dal/tests/test_tap.py
+++ b/pyvo/dal/tests/test_tap.py
@@ -198,7 +198,7 @@ class MockAsyncTAPServer:
         context.status_code = 303
         context.reason = 'See other'
         context.headers['Location'] = (
-            'http://example.com/tap/async/{}'.format(newid))
+            f'http://example.com/tap/async/{newid}')
 
         self._jobs[newid] = job
 
@@ -279,7 +279,7 @@ class MockAsyncTAPServer:
                         uploads1.update(uploads2)
 
                         param.content = ';'.join([
-                            '{}={}'.format(key, value) for key, value
+                            f'{key}={value}' for key, value
                             in uploads1.items()
                         ])
 
@@ -767,7 +767,7 @@ class TestTAPCapabilities:
     def test_get_featurelist(self, tapservice):
         features = tapservice.get_tap_capability().get_adql().get_feature_list(
             "ivo://ivoa.net/std/TAPRegExt#features-adqlgeo")
-        assert set(f.form for f in features) == {
+        assert {f.form for f in features} == {
             'CENTROID', 'CONTAINS', 'COORD1', 'POLYGON',
             'INTERSECTS', 'COORD2', 'BOX', 'AREA', 'DISTANCE',
             'REGION', 'CIRCLE', 'POINT'}

--- a/pyvo/dal/vosi.py
+++ b/pyvo/dal/vosi.py
@@ -113,7 +113,7 @@ class TablesMixin(CapabilityMixin):
             tables_urls = (_.value for _ in accessurls)
         except StopIteration:
             tables_urls = [
-                '{}/tables'.format(self.baseurl),
+                f'{self.baseurl}/tables',
                 url_sibling(self.baseurl, 'tables')
             ]
 
@@ -167,7 +167,7 @@ class VOSITables:
         table = self._vosi_tables.get_table_by_name(name)
 
         if not table.columns and not table.foreignkeys:
-            tables_url = '{}/{}'.format(self._endpoint_url, name)
+            tables_url = f'{self._endpoint_url}/{name}'
             response = self._get_table_file(tables_url)
 
             try:

--- a/pyvo/discover/image.py
+++ b/pyvo/discover/image.py
@@ -36,7 +36,8 @@ from ..registry import regtap
 
 
 # imports for type hints
-from typing import Callable, Generator, List, Optional, Set, Tuple
+from typing import Callable, List, Optional, Set, Tuple
+from collections.abc import Generator
 from astropy.units import quantity
 
 __all__ = ["ImageFound", "ImageDiscoverer", "images_globally"]
@@ -78,7 +79,7 @@ class Queriable:
         return str(self)
 
 
-@functools.lru_cache(maxsize=None)
+@functools.cache
 def obscore_column_names():
     """returns the names of obscore columns.
 
@@ -152,7 +153,7 @@ class ImageFound(obscore.ObsCoreMetadata):
             yield cls(origin_service, mapped)
 
 
-def _clean_for(records: List[Queriable], ivoids_to_remove: Set[str]):
+def _clean_for(records: list[Queriable], ivoids_to_remove: set[str]):
     """returns the Queriables in records the ivoids of which are
     not in ivoids_to_remove.
     """
@@ -210,10 +211,10 @@ class ImageDiscoverer:
 
         self.inclusive = inclusive
         self.already_queried, self.failed_services = 0, 0
-        self.results: List[obscore.ObsCoreMetadata] = []
+        self.results: list[obscore.ObsCoreMetadata] = []
         self.watcher = watcher
-        self.log_messages: List[str] = []
-        self.known_access_urls: Set[str] = set()
+        self.log_messages: list[str] = []
+        self.known_access_urls: set[str] = set()
 
         self._service_list_lock = threading.Lock()
         with self._service_list_lock:
@@ -239,7 +240,7 @@ class ImageDiscoverer:
         services from our current services lists.
         """
         def ids(recs):
-            return set(r.ivoid for r in recs)
+            return {r.ivoid for r in recs}
 
         self.sia1_recs = _clean_for(self.sia1_recs,
                 ids(self.sia2_recs) | ids(self.obscore_recs))
@@ -272,7 +273,7 @@ class ImageDiscoverer:
             self._log(f"Skipping {rec['ivoid']} because"
                 f" it is served by {rec['related_id']}")
 
-        collections_to_remove = set(r["ivoid"] for r in services_for)
+        collections_to_remove = {r["ivoid"] for r in services_for}
         self.sia1_recs = _clean_for(self.sia1_recs, collections_to_remove)
         self.sia2_recs = _clean_for(self.sia2_recs, collections_to_remove)
         self.obscore_recs = _clean_for(self.obscore_recs, collections_to_remove)
@@ -295,12 +296,12 @@ class ImageDiscoverer:
 
         new_style_access_urls = set()
         for rec in obscore_services:
-            new_style_access_urls |= set(
-                i.access_url for i in rec.list_interfaces("tap"))
+            new_style_access_urls |= {
+                i.access_url for i in rec.list_interfaces("tap")}
 
         for tap_rec in tap_services_with_obscore:
-            access_urls = set(
-                i.baseurl for i in rec.list_services("tap"))
+            access_urls = {
+                i.baseurl for i in rec.list_services("tap")}
             if new_style_access_urls.isdisjoint(access_urls):
                 obscore_services.append(obscore_services)
 
@@ -334,11 +335,11 @@ class ImageDiscoverer:
         with self._service_list_lock:
             self.sia1_recs = [Queriable(r) for r in registry.search(
                 registry.Servicetype("sia"), *constraints)]
-            self._info("Found {} SIA1 service(s)".format(len(self.sia1_recs)))
+            self._info(f"Found {len(self.sia1_recs)} SIA1 service(s)")
 
             self.sia2_recs = [Queriable(r) for r in registry.search(
                 registry.Servicetype("sia2"), *constraints)]
-            self._info("Found {} SIA2 service(s)".format(len(self.sia2_recs)))
+            self._info(f"Found {len(self.sia2_recs)} SIA2 service(s)")
 
             self.obscore_recs = self._discover_obscore_services(*constraints)
             self._info("Found {} Obscore service(s)".format(
@@ -436,7 +437,7 @@ class ImageDiscoverer:
                     return False
             return True
 
-        self._info("Querying SIA1 {}...".format(rec.title))
+        self._info(f"Querying SIA1 {rec.title}...")
         svc = rec.res_rec.get_service("sia", session=self.session, lax=True)
         n_found = self._add_records(
             ImageFound.from_sia1_recs(
@@ -471,7 +472,7 @@ class ImageDiscoverer:
     def _query_one_sia2(self, rec: Queriable):
         """runs our query against a SIA2 capability of rec.
         """
-        self._info("Querying SIA2 {}...".format(rec.title))
+        self._info(f"Querying SIA2 {rec.title}...")
 
         svc = rec.res_rec.get_service("sia2", session=self.session, lax=True)
         constraints = {}
@@ -505,7 +506,7 @@ class ImageDiscoverer:
     def _query_one_obscore(self, rec: Queriable, where_clause: str):
         """runs our query against a Obscore capability of rec.
         """
-        self._info("Querying Obscore {}...".format(rec.title))
+        self._info(f"Querying Obscore {rec.title}...")
         svc = rec.res_rec.get_service("tap", session=self.session, lax=True)
 
         n_found = self._add_records(
@@ -575,14 +576,14 @@ class ImageDiscoverer:
 
 def images_globally(
         *,
-        space: Optional[Tuple[float, float, float]] = None,
+        space: Optional[tuple[float, float, float]] = None,
         spectrum: Optional[quantity.Quantity] = None,
         time: Optional[time.Time] = None,
         inclusive: bool = False,
         watcher: Optional[Callable[['ImageDiscoverer', str], None]] = None,
         timeout: float = 20,
         services: Optional[registry.RegistryResults] = None)\
-        -> Tuple[List[obscore.ObsCoreMetadata], List[str]]:
+        -> tuple[list[obscore.ObsCoreMetadata], list[str]]:
     """returns a collection of ObsCoreMetadata-s matching certain constraints
     and a list of log lines.
 

--- a/pyvo/discover/image.py
+++ b/pyvo/discover/image.py
@@ -36,7 +36,7 @@ from ..registry import regtap
 
 
 # imports for type hints
-from typing import Callable, List, Optional, Set, Tuple
+from typing import Callable, Optional
 from collections.abc import Generator
 from astropy.units import quantity
 
@@ -67,6 +67,7 @@ class Queriable:
 
     They are constructed with a resource record.
     """
+
     def __init__(self, res_rec):
         self.res_rec = res_rec
         self.ivoid = res_rec.ivoid

--- a/pyvo/discover/tests/test_imagediscovery.py
+++ b/pyvo/discover/tests/test_imagediscovery.py
@@ -105,7 +105,7 @@ class TestTimeCondition:
                 time.Time("1970-10-13T17:00:00")))
         d._query_one_sia2(queriable)
 
-        assert set(queriable.search_kwargs) == set(["time"])
+        assert set(queriable.search_kwargs) == {"time"}
         assert abs(queriable.search_kwargs["time"][0].utc.value
             - 40872.54166667) < 1e-8
 
@@ -115,7 +115,7 @@ class TestTimeCondition:
             time=time.Time("1970-10-13T13:00:00"))
         d._query_one_sia2(queriable)
 
-        assert set(queriable.search_kwargs) == set(["time"])
+        assert set(queriable.search_kwargs) == {"time"}
         assert abs(queriable.search_kwargs["time"][0].utc.value
             - 40872.54166667) < 1e-8
         assert abs(queriable.search_kwargs["time"][1].utc.value

--- a/pyvo/io/uws/tree.py
+++ b/pyvo/io/uws/tree.py
@@ -27,7 +27,7 @@ def XSInDate(val):
     except ValueError:
         pass
 
-    raise ValueError('Cannot parse datetime {}'.format(val))
+    raise ValueError(f'Cannot parse datetime {val}')
 
 
 InDuration = partial(TimeDelta, format='sec')

--- a/pyvo/io/vosi/endpoint.py
+++ b/pyvo/io/vosi/endpoint.py
@@ -311,7 +311,7 @@ class TablesFile(Element):
         for table in self.iter_tables():
             if table.name == name:
                 return table
-        raise KeyError("No table with name {} found".format(name))
+        raise KeyError(f"No table with name {name} found")
 
 
 class CapabilitiesFile(Element, HomogeneousList):

--- a/pyvo/io/vosi/exceptions.py
+++ b/pyvo/io/vosi/exceptions.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-
 """
 .. _warnings:
 Warnings
@@ -26,8 +25,8 @@ from astropy.utils.exceptions import AstropyWarning
 from ...utils.xml.exceptions import XMLWarning
 
 __all__ = ["VOSIWarning"]
-__all__ += ["W{:0>2}".format(i) for i in range(1, 36)]
-__all__ += ["E{:0>2}".format(i) for i in range(1, 10)]
+__all__ += [f"W{i:0>2}" for i in range(1, 36)]
+__all__ += [f"E{i:0>2}" for i in range(1, 10)]
 
 
 class VOSIWarning(AstropyWarning):

--- a/pyvo/io/vosi/tapregext.py
+++ b/pyvo/io/vosi/tapregext.py
@@ -39,7 +39,7 @@ class DataModelType(ContentMixin, Element):
         """
         Prints out a human readable description
         """
-        print("Datamodel {}".format(self.content))
+        print(f"Datamodel {self.content}")
         print(indent(self.ivo_id, INDENT))
         print()
 
@@ -71,7 +71,7 @@ class OutputFormat(Element):
         """
         Prints out a human readable description
         """
-        print('Output format {}'.format(self.mime))
+        print(f'Output format {self.mime}')
 
         if self.aliases:
             print(indent('Also available as {}'.format(', '.join(self.aliases)),
@@ -100,7 +100,7 @@ class UploadMethod(Element):
         self.ivo_id = ivo_id
 
     def __repr__(self):
-        return '<UploadMethod ivo-id="{}"/>'.format(self.ivo_id)
+        return f'<UploadMethod ivo-id="{self.ivo_id}"/>'
 
     def describe(self):
         """
@@ -232,13 +232,13 @@ class Language(Element):
         self._languagefeaturelists = HomogeneousList(LanguageFeatureList)
 
     def __repr__(self):
-        return '<Language>{}</Language>'.format(self.name)
+        return f'<Language>{self.name}</Language>'
 
     def describe(self):
         """
         Prints out a human readable description
         """
-        print("Language {}".format(self.name))
+        print(f"Language {self.name}")
 
         for languagefeaturelist in self.languagefeaturelists:
             print(indent(languagefeaturelist.type, INDENT))
@@ -470,16 +470,16 @@ class TableAccess(TAPCapRestriction):
 
         if self.retentionperiod:
             print("Time a job is kept (in seconds)")
-            print(indent("Default {}".format(self.retentionperiod.default), INDENT))
+            print(indent(f"Default {self.retentionperiod.default}", INDENT))
             if self.retentionperiod.hard:
-                print(indent("Maximum {}".format(self.retentionperiod.hard), INDENT))
+                print(indent(f"Maximum {self.retentionperiod.hard}", INDENT))
             print()
 
         if self.executionduration:
             print("Maximal run time of a job")
-            print(indent("Default {}".format(self.executionduration.default), INDENT))
+            print(indent(f"Default {self.executionduration.default}", INDENT))
             if self.executionduration.hard:
-                print(indent("Maximum {}".format(self.executionduration.hard), INDENT))
+                print(indent(f"Maximum {self.executionduration.hard}", INDENT))
             print()
 
         if self.outputlimit:

--- a/pyvo/io/vosi/vodataservice.py
+++ b/pyvo/io/vosi/vodataservice.py
@@ -492,7 +492,7 @@ class BaseParam(Element):
         self._utype = None
 
     def __repr__(self):
-        return '<BaseParam name="{}"/>'.format(self.name)
+        return f'<BaseParam name="{self.name}"/>'
 
     @xmlelement(plain=True, multiple_exc=W05)
     def name(self):

--- a/pyvo/io/vosi/voresource.py
+++ b/pyvo/io/vosi/voresource.py
@@ -239,7 +239,7 @@ class Interface(ElementWithXSIType):
         """
         Prints out a human readable description
         """
-        print('Interface {}'.format(self._xsi_type))
+        print(f'Interface {self._xsi_type}')
 
         accessurls = '\n'.join(
             accessurl.content for accessurl in self.accessurls)
@@ -370,7 +370,7 @@ class Capability(ElementWithXSIType):
         """
         Prints out a human readable description
         """
-        print("Capability {}".format(self.standardid))
+        print(f"Capability {self.standardid}")
         print()
 
         if self.description:

--- a/pyvo/mivot/features/sky_coord_builder.py
+++ b/pyvo/mivot/features/sky_coord_builder.py
@@ -37,7 +37,7 @@ skycoord_param_galactic = {
     MangoRoles.RADIAL_VELOCITY: 'radial_velocity', MangoRoles.EPOCH: 'obstime'}
 
 
-class SkyCoordBuilder(object):
+class SkyCoordBuilder:
     '''
     Utility generating SkyCoord instances from MIVOT annotations
 

--- a/pyvo/mivot/utils/dict_utils.py
+++ b/pyvo/mivot/utils/dict_utils.py
@@ -27,13 +27,13 @@ class DictUtils:
         try:
             logging.debug("Reading json from %s", filename)
             from collections import OrderedDict
-            with open(filename, 'r') as file:
+            with open(filename) as file:
                 return json.load(file, object_pairs_hook=OrderedDict)
         except Exception as exception:
             if fatal:
-                raise MivotError("reading {}".format(filename))
+                raise MivotError(f"reading {filename}")
             else:
-                logging.error("{} reading {}".format(exception, filename))
+                logging.error(f"{exception} reading {filename}")
 
     @staticmethod
     def _get_pretty_json(dictionary):

--- a/pyvo/mivot/utils/json_encoder.py
+++ b/pyvo/mivot/utils/json_encoder.py
@@ -27,4 +27,4 @@ class MivotJsonEncoder(json.JSONEncoder):
         elif isinstance(obj, numpy.ndarray):
             return obj.tolist()
         else:
-            return super(MivotJsonEncoder, self).default(obj)
+            return super().default(obj)

--- a/pyvo/mivot/utils/mivot_utils.py
+++ b/pyvo/mivot/utils/mivot_utils.py
@@ -5,7 +5,7 @@ These dictionaries are used to generate ``MivotInstance`` objects
 import numpy
 
 
-class MivotUtils(object):
+class MivotUtils:
     @staticmethod
     def xml_to_dict(element):
         """

--- a/pyvo/mivot/viewer/mivot_instance.py
+++ b/pyvo/mivot/viewer/mivot_instance.py
@@ -194,9 +194,9 @@ class MivotInstance:
         elif hasattr(obj, "__iter__") and not isinstance(obj, str):
             return [self._get_class_dict(v, classkey, slim=slim) for v in obj]
         elif hasattr(obj, "__dict__"):
-            data = dict([(key, obj._get_class_dict(value, classkey, slim=slim))
+            data = {key: obj._get_class_dict(value, classkey, slim=slim)
                          for key, value in obj.__dict__.items()
-                         if not callable(value) and not key.startswith('_')])
+                         if not callable(value) and not key.startswith('_')}
             # remove the house keeping parameters
             if slim is True:
                 # data is atomic value (e.g. float): the type be hidden

--- a/pyvo/registry/regtap.py
+++ b/pyvo/registry/regtap.py
@@ -318,15 +318,15 @@ class RegistryResults(dalq.DALResults):
                 "Resource description",
                 "Access modes offered"))
 
-    @functools.lru_cache(maxsize=None)
+    @functools.cache
     def _get_ivo_index(self):
-        return dict((r.ivoid, index)
-                    for index, r in enumerate(self))
+        return {r.ivoid: index
+                    for index, r in enumerate(self)}
 
-    @functools.lru_cache(maxsize=None)
+    @functools.cache
     def _get_short_name_index(self):
-        return dict((r.short_name, index)
-                    for index, r in enumerate(self))
+        return {r.short_name: index
+                    for index, r in enumerate(self)}
 
     def __getitem__(self, item):
         """
@@ -728,10 +728,10 @@ class RegistryResource(dalq.Record):
 
         This will ignore VOSI (infrastructure) services.
         """
-        return set(shorten_stdid(intf.standard_id) or "web"
+        return {shorten_stdid(intf.standard_id) or "web"
                    for intf in self.interfaces
                    if (intf.standard_id or intf.type == "vr:webbrowser")
-                   and not intf.is_vosi)
+                   and not intf.is_vosi}
 
     def get_interface(self, *,
                       service_type: str,

--- a/pyvo/registry/rtcons.py
+++ b/pyvo/registry/rtcons.py
@@ -32,7 +32,7 @@ __all__ = ["build_regtap_query"]
 # corresponding standards.  This is mostly to keep legacy APIs.
 # In the future, preferably rely on shorten_stdid and expand_stdid
 # from regtap.
-SERVICE_TYPE_MAP = dict((k, "ivo://ivoa.net/std/" + v)
+SERVICE_TYPE_MAP = {k: "ivo://ivoa.net/std/" + v
                         for k, v in [
     ("image", "sia"),
     ("sia", "sia"),
@@ -48,7 +48,7 @@ SERVICE_TYPE_MAP = dict((k, "ivo://ivoa.net/std/" + v)
     ("slap", "slap"),
     ("table", "tap"),
     ("tap", "tap"),
-])
+]}
 
 
 class RegTAPFeatureMissing(dalq.DALQueryError):
@@ -106,7 +106,7 @@ def make_sql_literal(value):
         return f'{value}'
 
     elif isinstance(value, datetime.datetime):
-        return "'{}'".format(value.isoformat())
+        return f"'{value.isoformat()}'"
 
     else:
         raise ValueError("Cannot format {} as a SQL literal"
@@ -289,8 +289,8 @@ class Freetext(Constraint):
         self._fillers, subqueries = {}, []
 
         for index, word in enumerate(self.words):
-            parname = "fulltext{}".format(index)
-            parpatname = "fulltextpar{}".format(index)
+            parname = f"fulltext{index}"
+            parpatname = f"fulltextpar{index}"
             self._fillers[parname] = word
             self._fillers[parpatname] = '%' + word + '%'
             args = locals()
@@ -310,8 +310,8 @@ class Freetext(Constraint):
         self._fillers, conditions = {}, []
 
         for index, word in enumerate(self.words):
-            parname = "fulltext{}".format(index)
-            parpatname = "fulltextpar{}".format(index)
+            parname = f"fulltext{index}"
+            parpatname = f"fulltextpar{index}"
             self._fillers[parname] = word
             self._fillers[parpatname] = '%' + word + '%'
             args = locals()
@@ -456,8 +456,8 @@ class Servicetype(Constraint):
         This is a convenience to maintain registry.search's signature.
         """
         expanded = self.clone()
-        expanded.stdids |= set(
-            std + '#aux' for std in expanded.stdids)
+        expanded.stdids |= {
+            std + '#aux' for std in expanded.stdids}
         if "standard_id like 'ivo://ivoa.net/std/sia#query-2.%'" in expanded.extra_fragments:
             expanded.extra_fragments.append(
                 "standard_id like 'ivo://ivoa.net/std/sia#query-aux-2.%'")
@@ -633,8 +633,8 @@ class UCD(SubqueriedConstraint):
         """
         self._condition = " OR ".join(
             f"ucd LIKE {{ucd{i}}}" for i in range(len(patterns)))
-        self._fillers = dict((f"ucd{index}", pattern)
-                             for index, pattern in enumerate(patterns))
+        self._fillers = {f"ucd{index}": pattern
+                             for index, pattern in enumerate(patterns)}
 
 
 class Spatial(SubqueriedConstraint):
@@ -728,7 +728,7 @@ class Spatial(SubqueriedConstraint):
         self.inclusive = inclusive
 
         def tomoc(s):
-            return _AsIs("MOC({}, {})".format(order, s))
+            return _AsIs(f"MOC({order}, {s})")
 
         if isinstance(geom_spec, str):
             geom = _AsIs("MOC({})".format(

--- a/pyvo/registry/rtcons.py
+++ b/pyvo/registry/rtcons.py
@@ -34,21 +34,21 @@ __all__ = ["build_regtap_query"]
 # from regtap.
 SERVICE_TYPE_MAP = {k: "ivo://ivoa.net/std/" + v
                         for k, v in [
-    ("image", "sia"),
-    ("sia", "sia"),
-    ("sia1", "sia"),
-    # SIA2 is irregular
-    # funky scheme used by SIA2 without breaking everything else
-    ("spectrum", "ssa"),
-    ("ssap", "ssa"),
-    ("ssa", "ssa"),
-    ("scs", "conesearch"),
-    ("conesearch", "conesearch"),
-    ("line", "slap"),
-    ("slap", "slap"),
-    ("table", "tap"),
-    ("tap", "tap"),
-]}
+                            ("image", "sia"),
+                            ("sia", "sia"),
+                            ("sia1", "sia"),
+                            # SIA2 is irregular
+                            # funky scheme used by SIA2 without breaking everything else
+                            ("spectrum", "ssa"),
+                            ("ssap", "ssa"),
+                            ("ssa", "ssa"),
+                            ("scs", "conesearch"),
+                            ("conesearch", "conesearch"),
+                            ("line", "slap"),
+                            ("slap", "slap"),
+                            ("table", "tap"),
+                            ("tap", "tap"),
+                        ]}
 
 
 class RegTAPFeatureMissing(dalq.DALQueryError):

--- a/pyvo/utils/prototype.py
+++ b/pyvo/utils/prototype.py
@@ -1,14 +1,15 @@
 import inspect
 import warnings
 from functools import wraps
-from typing import Dict, Iterable
+from typing import Dict
+from collections.abc import Iterable
 from .protofeature import Feature
 
 from pyvo.dal.exceptions import PyvoUserWarning
 
 __all__ = ['features', 'prototype_feature', 'activate_features', 'PrototypeWarning', 'PrototypeError']
 
-features: Dict[str, "Feature"] = {
+features: dict[str, "Feature"] = {
     'cadc-tb-upload': Feature('cadc-tb-upload',
                               'https://wiki.ivoa.net/twiki/bin/view/IVOA/TAP-1_1-Next',
                               False),

--- a/pyvo/utils/prototype.py
+++ b/pyvo/utils/prototype.py
@@ -1,7 +1,6 @@
 import inspect
 import warnings
 from functools import wraps
-from typing import Dict
 from collections.abc import Iterable
 from .protofeature import Feature
 

--- a/pyvo/utils/vocabularies.py
+++ b/pyvo/utils/vocabularies.py
@@ -26,7 +26,7 @@ class VocabularyError(Exception):
     """
 
 
-@functools.lru_cache()
+@functools.lru_cache
 def get_vocabulary(voc_name, force_update=False):
     """returns an IVOA vocabulary in its "desise" form.
 
@@ -61,7 +61,7 @@ def get_vocabulary(voc_name, force_update=False):
                           f" {voc_name} failed: {msg}",
                           category=PyvoUserWarning)
 
-    with open(src_name, "r", encoding="utf-8") as f:
+    with open(src_name, encoding="utf-8") as f:
         return json.load(f)
 
 

--- a/pyvo/utils/xml/exceptions.py
+++ b/pyvo/utils/xml/exceptions.py
@@ -12,7 +12,7 @@ def _format_message(message, name, config=None, pos=None):
         pos = ('?', '?')
     filename = config.get('filename', '?')
 
-    return '{}:{}:{}: {}: {}'.format(filename, pos[0], pos[1], name, message)
+    return f'{filename}:{pos[0]}:{pos[1]}: {name}: {message}'
 
 
 class XMLWarning(AstropyWarning):

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,7 +65,7 @@ packages = find:
 zip_safe = False
 setup_requires = setuptools_scm
 install_requires =
-    astropy>=4.1
+    astropy>=4.2
     requests
 python_requires = >=3.9
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,13 +17,6 @@ filterwarnings =
 # Numpy 2.0 deprecations triggered by upstream libraries.
 # Exact warning messages differ, thus using a super generic filter.
     ignore:numpy.core:DeprecationWarning
-# Added for python 3.8, cleanup once old python version support is removed
-# (adding it to conftest is ineffective as the PrototypeWarning line above already
-# triggers this warning at the time of collection
-    ignore::astropy.utils.iers.iers.IERSStaleWarning
-# These two are also needed for python 3.8
-    ignore:Importing ErfaWarning:astropy.utils.exceptions.AstropyDeprecationWarning
-    ignore::astropy.utils.exceptions.ErfaWarning
 # We need to ignore this module level warning to not cause issues at collection time.
 # Remove it once warning is removed from code (in 1.7).
     ignore:pyvo.discover:pyvo.utils.prototype.PrototypeWarning
@@ -74,7 +67,7 @@ setup_requires = setuptools_scm
 install_requires =
     astropy>=4.1
     requests
-python_requires = >=3.8
+python_requires = >=3.9
 
 [options.extras_require]
 all =

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 # as oldestdeps and devastropy might not support the full python range
 # listed here
 envlist =
-    py{38,39,310,311,312,313}-test{,-alldeps,-oldestdeps,-devdeps}{,-online}{,-cov}
+    py{39,310,311,312,313}-test{,-alldeps,-oldestdeps,-devdeps}{,-online}{,-cov}
     linkcheck
     codestyle
     build_docs

--- a/tox.ini
+++ b/tox.ini
@@ -39,10 +39,10 @@ deps =
     # astropy doesn't yet have a 3.13 compatible release
     py313: astropy>=0.0dev0
 
-    oldestdeps: astropy==4.1
+    oldestdeps: astropy==4.2
     # We set a suitably old numpy along with an old astropy, no need to pick up
     # deprecations and errors due to their unmatching versions
-    oldestdeps: numpy==1.19
+    oldestdeps: numpy==1.20
 
     online: pytest-rerunfailures
 


### PR DESCRIPTION
This PR drops python 3.8 support. I also run pyupgrade to cleanup code, and accepted most of the changes into the second commit. I feel it indeed become cleaner by switching to use fstrings, but please let me know if you dislike this and I'm happy to drop the commit or to tune it back to a smaller collection of changes.

Python 3.9 is not yet EOL, but it is also close to it, so we could in fact drop that one, too. 

[edit]: This also bumps minimum astropy to 4.2, as prior versions didn't support python 3.9