### PR TITLE
Make TAP job deletion optional defaulting to True

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@
 Enhancements and Fixes
 ----------------------
 
+- Make deletion of TAP jobs optional via a delete flag. Default: True
 
 Deprecations and Removals
 -------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@
 Enhancements and Fixes
 ----------------------
 
-- Make deletion of TAP jobs optional via a delete flag. Default: True
+- Make deletion of TAP jobs optional via a new ``delete`` kwarg. [#640]
 
 Deprecations and Removals
 -------------------------

--- a/pyvo/dal/tap.py
+++ b/pyvo/dal/tap.py
@@ -680,7 +680,7 @@ class AsyncTAPJob:
         if self._delete_on_exit:
             try:
                 self.delete()
-            except Exception:
+            except DALServiceError:
                 pass
 
     def _update(self, wait_for_statechange=False, timeout=10.):


### PR DESCRIPTION
**Motivation for change**

We have a requirement for the Rubin Observatory TAP services to maintain and provide history of queries run through the TAP service, for which we plan on utilizing the UWS jobs list. However, since many of our users will be querying our services via pyvo, query jobs will be deleted by default after being run as it currently stands.

**PR Summary**

This PR adds a `delete` parameter to control whether TAP jobs are automatically deleted after completion. 
By default, jobs are still deleted (to maintain backward compatibility), but users can now set `delete=False` 
to keep jobs.

**Changes**

- Added `delete` parameter to `run_async` method in TAPService
- Added `delete` parameter to AsyncTAPJob context manager
- Updated docstrings to document new parameter

**Example usage**
```python
# Default behavior - job is deleted after completion
result = service.run_async(query)

# Keep job after completion
result = service.run_async(query, delete=False)

# Context manager with job retention
with AsyncTAPJob(url, delete=False) as job:
    results = job.run().wait().fetch_result()
```
