### PR TITLE
More information in error message when _get_endpoint requests fail

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Enhancements and Fixes
 
 - Make deletion of TAP jobs optional via a new ``delete`` kwarg. [#640]
 
+- Provide more informative exception message when requests to endpoints fail. [#641]
+
 - Change AsyncTAPJob.result to return None if no result is found explicitly [#644]
 
 

--- a/pyvo/dal/query.py
+++ b/pyvo/dal/query.py
@@ -20,7 +20,8 @@ other externally defined table.  In this case there is no VO defined
 standard data model.  Usually the field names are used to uniquely
 identify table columns.
 """
-__all__ = ["DALService", "DALQuery", "DALResults", "Record"]
+__all__ = ["DALService", "DALServiceError", "DALQuery", "DALQueryError",
+           "DALResults", "Record"]
 
 import os
 import shutil
@@ -64,7 +65,7 @@ class DALService:
            the base URL that should be used for forming queries to the service.
         session : object
            optional session to use for network requests
-        description : str, optional
+        capability_description : str, optional
            the description of the service.
         """
         self._baseurl = baseurl

--- a/pyvo/dal/tap.py
+++ b/pyvo/dal/tap.py
@@ -118,14 +118,18 @@ class TAPService(DALService, AvailabilityMixin, CapabilityMixin):
         session : object
            optional session to use for network requests
         """
-        super().__init__(baseurl, session=session, capability_description=capability_description)
+        try:
+            super().__init__(baseurl, session=session, capability_description=capability_description)
 
-        # Check if the session has an update_from_capabilities attribute.
-        # This means that the session is aware of IVOA capabilities,
-        # and can use this information in processing network requests.
-        # One such use case for this is auth.
-        if hasattr(self._session, 'update_from_capabilities'):
-            self._session.update_from_capabilities(self.capabilities)
+            # Check if the session has an update_from_capabilities attribute.
+            # This means that the session is aware of IVOA capabilities,
+            # and can use this information in processing network requests.
+            # One such use case for this is auth.
+            if hasattr(self._session, 'update_from_capabilities'):
+                self._session.update_from_capabilities(self.capabilities)
+        except DALServiceError as e:
+            raise DALServiceError(f"Cannot find TAP service at '"
+                                  f"{baseurl}'.\n\n{str(e)}") from None
 
     def get_tap_capability(self):
         """
@@ -373,8 +377,6 @@ class TAPService(DALService, AvailabilityMixin, CapabilityMixin):
 
         Parameters
         ----------
-        baseurl : str
-            the base URL for the TAP service
         query : str
             the query string / parameters
         mode : str
@@ -943,6 +945,8 @@ class AsyncTAPJob:
         ----------
         phases : list
             phases to wait for
+        timeout : float
+            maximum time to wait in seconds
 
         Raises
         ------

--- a/pyvo/io/vosi/endpoint.py
+++ b/pyvo/io/vosi/endpoint.py
@@ -67,6 +67,9 @@ def parse_tables(source, *, pedantic=None, filename=None,
         then *source* will be used as a filename for error messages.
         Therefore, *filename* is only required when source is a
         file-like object.
+    _debug_python_based_parser : bool, optional
+        If `True`, use the Python-based parser. This is useful for
+        debugging purposes.  Defaults to False.
 
     Returns
     -------
@@ -113,6 +116,9 @@ def parse_capabilities(source, *, pedantic=None, filename=None,
         then *source* will be used as a filename for error messages.
         Therefore, *filename* is only required when source is a
         file-like object.
+    _debug_python_based_parser : bool, optional
+        If `True`, use the Python-based parser. This is useful for
+        debugging purposes.  Defaults to False.
 
     Returns
     -------
@@ -159,6 +165,11 @@ def parse_availability(source, *, pedantic=None, filename=None,
         then *source* will be used as a filename for error messages.
         Therefore, *filename* is only required when source is a
         file-like object.
+    _debug_python_based_parser : bool, optional
+        If `True`, use the Python-based parser. This is useful for
+        debugging purposes.  Defaults to False.
+
+
 
     Returns
     -------


### PR DESCRIPTION
### Summary

Currently when a user provides an invalid TAP URL or encounters connection issues during instantiation:
`tap_service = pyvo.dal.TAPService(baseurl)` the error message is:

`DALServiceError: No working capabilities endpoint provided`

We've found that this is slightly confusing for our users and lacks a bit of information on what went wrong. 

### Changes

This PR:
- Provides more context to the error messages
- Shows what URLs were attempted when trying to connect to the TAP service  
- Suggests possible fixes (e.g., verify URL is correct, check service is running)
- Adds test coverage for various connection failure scenarios like:
  - Invalid/malformed URLs
  - HTTP error responses (403, 500, 502, 503)
  - Network-level connection failures

### Other Changes
- In the process I've also fixed a couple of issues with the docstrings where mostly there were missing or incorrect params.
- Added some classes to `__all__` in dal.query

### Example

Example improved error message:
```
pyvo.dal.exceptions.DALServiceError: Cannot find TAP service at 'https://data-dev.lsst.cloud/api/setap'.

Unable to access the capabilities endpoint at:
- https://data-dev.lsst.cloud/api/setap/capabilities: 404 Not Found
- https://data-dev.lsst.cloud/api/capabilities: 404 Not Found

This could mean:
1. The service URL is incorrect
2. The service is temporarily unavailable
3. The service doesn't support this protocol
```

### Related Issues

https://github.com/astropy/pyvo/issues/125
https://github.com/astropy/pyvo/issues/586

Interested to hear if these changes make sense or if you have any objections / alternative approaches you'd rather go with.
