### PR TITLE
fix: remove alternate identifier

### DIFF
--- a/pyvo/registry/tests/test_regtap.py
+++ b/pyvo/registry/tests/test_regtap.py
@@ -727,7 +727,6 @@ def test_get_alt_identifier():
     rsc = _makeRegistryRecord(ivoid="ivo://cds.vizier/i/337")
     assert set(rsc.get_alt_identifiers()) == {
         'doi:10.26093/cds/vizier.1337',
-        'bibcode:doi:10.5270/esa-ogmeula',
         'bibcode:2016yCat.1337....0G'}
 
 


### PR DESCRIPTION
Some alternate identifiers were related to similar datasets but not exactly equivalent ones in some VizieR entries. 

With the evolution of the description of doi and bibcode, these identifiers have been moved into the section `isRelatedTo` and removed from `alternateIdentifier` in the CDS registry. 

This change has been caught by pyVO's CI but is not a bug.