### PR TITLE
fix: conesearch is now https

### DIFF
--- a/docs/registry/index.rst
+++ b/docs/registry/index.rst
@@ -240,7 +240,7 @@ constraint on the description ``get_service(service_type='conesearch', keyword='
   ...     print(interface)
   Interface(type='tap#aux', description='', url='http://tapvizier.cds.unistra.fr/TAPVizieR/tap')
   Interface(type='vr:webbrowser', description='', url='http://vizier.cds.unistra.fr/viz-bin/VizieR-2?-source=J/ApJ/727/14')
-  Interface(type='conesearch', description='Cone search capability for table J/ApJ/727/14/table2 (AKARI IRC 3-24{mu}m, and Spitzer MIPS 24/70{mu}m photometry of Abell 2255 member galaxies)', url='http://vizier.cds.unistra.fr/viz-bin/conesearch/J/ApJ/727/14/table2?')
+  Interface(type='conesearch', description='Cone search capability for table J/ApJ/727/14/table2 (AKARI IRC 3-24{mu}m, and Spitzer MIPS 24/70{mu}m photometry of Abell 2255 member galaxies)', url='https://vizier.cds.unistra.fr/viz-bin/conesearch/J/ApJ/727/14/table2?')
 
 Or construct the service object directly from the list of interfaces with:
 


### PR DESCRIPTION
Hello,

This fixes #642 
The conesearch urls are now correct thanks to the harvest that happened last week. The output is still different as VizieR now declares the HTTPS version.