### PR TITLE
MAINT: Corrections to some of the parameter types in the docs and a couple lint-related fixes 

### DIFF
--- a/pyvo/dal/adhoc.py
+++ b/pyvo/dal/adhoc.py
@@ -123,7 +123,7 @@ class AdhocServiceResultsMixin:
 
         Parameters
         ----------
-        ivoid : str
+        ivo_id : str
            the ivoid of the service we want to have.
 
         Returns
@@ -417,8 +417,6 @@ class DatalinkService(DALService, AvailabilityMixin, CapabilityMixin):
 
         Parameters
         ----------
-        baseurl : str
-            the base URL for the Datalink service
         id : str
             the dataset identifier
         responseformat : str
@@ -936,7 +934,7 @@ class DatalinkRecord(DatalinkRecordMixin, SodaRecordMixin, Record):
         return list(_get_input_params_from_resource(proc_resource).values())
 
 
-class AxisParamMixin():
+class AxisParamMixin:
     """
     Stores the axis parameters (pos, band, time and pol) used in SODA
     or SIA2 queries

--- a/pyvo/dal/exceptions.py
+++ b/pyvo/dal/exceptions.py
@@ -84,9 +84,7 @@ class DALProtocolError(DALAccessError):
         ----------
         reason : str
            a message describing the cause of the error
-        code : int
-           the HTTP error code (as an integer)
-        cause : str
+        cause : Exception
            an exception issued as the underlying cause.  A value
            of None indicates that no underlying exception was
            caught.
@@ -117,7 +115,7 @@ class DALFormatError(DALProtocolError):
 
         Parameters
         ----------
-        cause : str
+        cause : Exception
            an exception issued as the underlying cause.  A value
            of None indicates that no underlying exception was caught.
         url
@@ -150,7 +148,7 @@ class DALServiceError(DALProtocolError):
            a message describing the cause of the error
         code : int
            the HTTP error code (as an integer)
-        cause : str
+        cause : Exception
            an exception issued as the underlying cause.  A value
            of None indicates that no underlying exception was
            caught.

--- a/pyvo/dal/query.py
+++ b/pyvo/dal/query.py
@@ -21,7 +21,7 @@ standard data model.  Usually the field names are used to uniquely
 identify table columns.
 """
 __all__ = ["DALService", "DALServiceError", "DALQuery", "DALQueryError",
-           "DALResults", "Record"]
+           "DALResults", "Record", "UploadList"]
 
 import os
 import shutil
@@ -311,7 +311,7 @@ class DALResults:
 
         Parameters
         ----------
-        votable : str
+        votable : astropy.io.votable.tree.VOTableFile
            the service response parsed into an
            astropy.io.votable.tree.VOTableFile instance.
         url : str

--- a/pyvo/dal/tap.py
+++ b/pyvo/dal/tap.py
@@ -186,12 +186,12 @@ class TAPService(DALService, AvailabilityMixin, CapabilityMixin):
         try:
             root = xml.etree.ElementTree.parse(
                 io.BytesIO(response.content)).getroot()
-            exampleElements = root.findall('.//*[@property="query"]')
+            example_elements = root.findall('.//*[@property="query"]')
         except Exception as ex:
             raise DALServiceError.from_except(ex, examples_uri)
 
         examples = [TAPQuery(self.baseurl, example.text)
-            for example in exampleElements]
+            for example in example_elements]
 
         for continuation in root.findall('.//*[@property="continuation"]'):
             examples.extend(
@@ -468,7 +468,7 @@ class TAPService(DALService, AvailabilityMixin, CapabilityMixin):
         Print a summary description of this service.
 
         This includes the interface capabilities, and the content description
-        if it doesn't contains multiple data collections (in other words, it is
+        if it doesn't contain multiple data collections (in other words, it is
         not a TAP service).
         """
         if len(self.tables) == 1:
@@ -1018,7 +1018,8 @@ class AsyncTAPJob:
         if result_uri is None:
             self._update()
             self.raise_if_error()
-            raise DALServiceError("No result URI available", self.url)
+            raise DALServiceError(reason="No result URI available",
+                                  url=self.url)
 
         try:
             response = self._session.get(self.result_uri, stream=True)

--- a/pyvo/dal/vosi.py
+++ b/pyvo/dal/vosi.py
@@ -14,7 +14,7 @@ from ..utils.url import url_sibling
 from ..utils.decorators import stream_decode_content, response_decode_content
 from ..utils.http import use_session
 
-__all__ = ['AvailabilityMixin', 'CapabilityMixin', 'VOSITables']
+__all__ = ['CapabilityMixin', 'VOSITables']
 
 
 class EndpointMixin:

--- a/pyvo/dal/vosi.py
+++ b/pyvo/dal/vosi.py
@@ -14,10 +14,10 @@ from ..utils.url import url_sibling
 from ..utils.decorators import stream_decode_content, response_decode_content
 from ..utils.http import use_session
 
-__all__ = ['CapabilityMixin', 'VOSITables']
+__all__ = ['AvailabilityMixin', 'CapabilityMixin', 'VOSITables']
 
 
-class EndpointMixin():
+class EndpointMixin:
     def _get_endpoint_candidates(self, endpoint):
         """Construct endpoint URLs from base URL and endpoint"""
         urlcomp = urlparse(self.baseurl)


### PR DESCRIPTION
## Summary

This PR mostly is just to cleanup some of the documentation and specifically the parameter types. as well as a couple linting issues like classes missing from `__all__` declaration, unneeded parenthesis and changing camel-case to snake-case in one instance.

Assuming these changes make sense, am I right to assume this doesn't need a changelog entry?