### PR TITLE
Fixed DL excessive copy

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Enhancements and Fixes
 
 - Extending the MIVOT module with the ability to build annotations component by component
   and put them into a VOTable. [#627]
-  
+
 - Make deletion of TAP jobs optional via a new ``delete`` kwarg. [#640]
 
 - Change AsyncTAPJob.result to return None if no result is found explicitly [#644]
@@ -41,6 +41,8 @@ Bug Fixes
 - Switch to do minimal VOSI tables downloads for TAP metadata. [#634]
 
 - Provide more informative exception message when requests to endpoints fail. [#641]
+
+- Fix performance issues with datalink results. [#635]
 
 
 1.6 (2024-11-01)
@@ -86,8 +88,8 @@ Enhancements and Fixes
 
 - Updated getdatalink to be consistent with iter_datalinks. [#613]
 
-  
-  
+
+
 Deprecations and Removals
 -------------------------
 

--- a/docs/dal/index.rst
+++ b/docs/dal/index.rst
@@ -816,7 +816,7 @@ previews:
 .. doctest-remote-data::
     >>> rows = vo.dal.TAPService("http://dc.g-vo.org/tap"
     ... ).run_sync("select top 5 * from califadr3.cubes order by califaid")
-    >>> for dl in rows.iter_datalinks():  # doctest: +IGNORE_WARNINGS +IGNORE_OUTPUT
+    >>> for dl in rows.iter_datalinks(preserve_order=True):  # doctest: +IGNORE_WARNINGS
     ...     print(next(dl.bysemantics("#preview"))["access_url"])
     http://dc.g-vo.org/getproduct/califa/datadr3/V1200/IC5376.V1200.rscube.fits?preview=True
     http://dc.g-vo.org/getproduct/califa/datadr3/COMB/IC5376.COMB.rscube.fits?preview=True
@@ -833,7 +833,7 @@ generated from; use the ``original_row`` attribute for that (which may
 be None if pyvo does not know what row the datalink came from):
 
 .. doctest-remote-data::
-  >>> dl.original_row["obs_title"]  # doctest: +IGNORE_OUTPUT
+  >>> dl.original_row["obs_title"]
   'CALIFA V1200 UGC00005'
 
 Consider ``original_row`` read only.  We do not define what happens when

--- a/docs/dal/index.rst
+++ b/docs/dal/index.rst
@@ -816,7 +816,7 @@ previews:
 .. doctest-remote-data::
     >>> rows = vo.dal.TAPService("http://dc.g-vo.org/tap"
     ... ).run_sync("select top 5 * from califadr3.cubes order by califaid")
-    >>> for dl in rows.iter_datalinks():  # doctest: +IGNORE_WARNINGS
+    >>> for dl in rows.iter_datalinks():  # doctest: +IGNORE_WARNINGS +IGNORE_OUTPUT
     ...     print(next(dl.bysemantics("#preview"))["access_url"])
     http://dc.g-vo.org/getproduct/califa/datadr3/V1200/IC5376.V1200.rscube.fits?preview=True
     http://dc.g-vo.org/getproduct/califa/datadr3/COMB/IC5376.COMB.rscube.fits?preview=True
@@ -833,7 +833,7 @@ generated from; use the ``original_row`` attribute for that (which may
 be None if pyvo does not know what row the datalink came from):
 
 .. doctest-remote-data::
-  >>> dl.original_row["obs_title"]
+  >>> dl.original_row["obs_title"]  # doctest: +IGNORE_OUTPUT
   'CALIFA V1200 UGC00005'
 
 Consider ``original_row`` read only.  We do not define what happens when

--- a/pyvo/dal/adhoc.py
+++ b/pyvo/dal/adhoc.py
@@ -202,7 +202,7 @@ class DatalinkResultsMixin(AdhocServiceResultsMixin):
             tb.resources.append(results_resource)
             # now add all the other resources from the dl_batch_tb
             for resource in dl_batch_tb.resources:
-                if resource.type != "results":
+                if resource.type == "meta":
                     tb.resources.append(resource)
             return tb
 
@@ -216,17 +216,16 @@ class DatalinkResultsMixin(AdhocServiceResultsMixin):
                     original_row=row)
             return
 
-        # map of IDs to original rows needed to map the results back to the
-        # original rows
+        # results from batch calls are not guaranteed to be in the same order with
+        # the results rows. To map the links back to the original result rows,
+        # create a dictionary of IDs to result rows, where ID is the value of
+        # the column given by the ref field of the service descriptor (input parameter)
         original_rows = {}
         input_params = _get_input_params_from_resource(self._datalink)
         for name, input_param in input_params.items():
-            for row in self:
-                try:
-                    if row[input_param.ref]:
-                        original_rows[row[input_param.ref]] = row
-                except KeyError:
-                    pass
+            if input_param.ref:
+                for row in self:
+                    original_rows[row[input_param.ref]] = row
 
         self.query = DatalinkQuery.from_resource(
             [_ for _ in self],

--- a/pyvo/dal/tests/test_datalink.py
+++ b/pyvo/dal/tests/test_datalink.py
@@ -145,8 +145,9 @@ def test_datalink():
         'http://example.com/ssa_datalink', (30, 30))
 
     for preserve_order in [False, True]:
-        datalinks = next(results.iter_datalinks(preserve_order=preserve_order))
-
+        dl_res = set(results.iter_datalinks(preserve_order=preserve_order))
+        assert len(dl_res) == 1
+        datalinks = dl_res.pop()
         assert datalinks.original_row["accsize"] == 100800
 
         assert 4 == len(datalinks)

--- a/pyvo/dal/tests/test_datalink.py
+++ b/pyvo/dal/tests/test_datalink.py
@@ -148,17 +148,9 @@ def test_datalink():
 
     assert datalinks.original_row["accsize"] == 100800
 
-    row = datalinks[0]
-    assert row.semantics == "#progenitor"
-
-    row = datalinks[1]
-    assert row.semantics == "#proc"
-
-    row = datalinks[2]
-    assert row.semantics == "#this"
-
-    row = datalinks[3]
-    assert row.semantics == "#preview"
+    assert 4 == len(datalinks)
+    for dl in datalinks:
+        assert dl.semantics in ['#this', '#preview', '#progenitor', '#proc']
 
 
 @pytest.mark.usefixtures('obscore_datalink', 'res_datalink')

--- a/pyvo/dal/tests/test_datalink.py
+++ b/pyvo/dal/tests/test_datalink.py
@@ -144,13 +144,14 @@ def test_datalink():
     results = vo.spectrumsearch(
         'http://example.com/ssa_datalink', (30, 30))
 
-    datalinks = next(results.iter_datalinks())
+    for trivial in [False, True]:
+        datalinks = next(results.iter_datalinks(trivial=trivial))
 
-    assert datalinks.original_row["accsize"] == 100800
+        assert datalinks.original_row["accsize"] == 100800
 
-    assert 4 == len(datalinks)
-    for dl in datalinks:
-        assert dl.semantics in ['#this', '#preview', '#progenitor', '#proc']
+        assert 4 == len(datalinks)
+        for dl in datalinks:
+            assert dl.semantics in ['#this', '#preview', '#progenitor', '#proc']
 
 
 @pytest.mark.usefixtures('obscore_datalink', 'res_datalink')

--- a/pyvo/dal/tests/test_datalink.py
+++ b/pyvo/dal/tests/test_datalink.py
@@ -163,9 +163,10 @@ def test_datalink_batch():
     results = vo.dal.imagesearch(
         'http://example.com/obscore', (30, 30))
 
-    dls = list(results.iter_datalinks())
-    assert len(dls) == 3
-    assert dls[0].original_row["obs_collection"] == "MACHO"
+    for trivial in [False, True]:
+        dls = list(results.iter_datalinks(trivial=trivial))
+        assert len(dls) == 3
+        assert dls[0].original_row["obs_collection"] == "MACHO"
 
 
 @pytest.mark.usefixtures('proc', 'datalink_vocabulary')

--- a/pyvo/dal/tests/test_datalink.py
+++ b/pyvo/dal/tests/test_datalink.py
@@ -144,8 +144,8 @@ def test_datalink():
     results = vo.spectrumsearch(
         'http://example.com/ssa_datalink', (30, 30))
 
-    for trivial in [False, True]:
-        datalinks = next(results.iter_datalinks(trivial=trivial))
+    for preserve_order in [False, True]:
+        datalinks = next(results.iter_datalinks(preserve_order=preserve_order))
 
         assert datalinks.original_row["accsize"] == 100800
 
@@ -163,8 +163,8 @@ def test_datalink_batch():
     results = vo.dal.imagesearch(
         'http://example.com/obscore', (30, 30))
 
-    for trivial in [False, True]:
-        dls = list(results.iter_datalinks(trivial=trivial))
+    for preserve_order in [False, True]:
+        dls = list(results.iter_datalinks(preserve_order=preserve_order))
         assert len(dls) == 3
         assert dls[0].original_row["obs_collection"] == "MACHO"
 


### PR DESCRIPTION
Fix for #537 

@msdemlei - please check whether this makes sense. I have some question marks in the online comments. There's an improvement in the performance:

```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      201    0.001    0.000    8.605    0.043 adhoc.py:339(iter_datalinks)
      201    0.153    0.001    8.604    0.043 adhoc.py:172(_iter_datalinks_from_dlblock)
      200    0.107    0.001    6.090    0.030 adhoc.py:202(<listcomp>)
    41201    0.098    0.000    6.045    0.000 query.py:630(__iter__)
    40401    0.077    0.000    5.921    0.000 ssa.py:621(getrecord)
    41001    2.520    0.000    5.869    0.000 query.py:672(__init__)
  2258000    2.954    0.000    3.267    0.000 records.py:254(__getitem__)
        1    0.000    0.000    1.580    1.580 adhoc.py:592(execute)
        1    0.000    0.000    1.579    1.579 query.py:234(execute_votable)
        8    0.000    0.000    1.182    0.148 socket.py:692(readinto)
```

The question is if this solution is doing the right thing and if it's robust enough (I still have to give the latter a closer look).

With a batch size of 1, these are the performances mostly because of latencies and partially because of the overhead of 5-6 seconds that this code introduces. I left a commented out code where the batch size can be played with. 

```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      201    0.002    0.000   70.489    0.351 adhoc.py:346(iter_datalinks)
      201    0.127    0.001   70.487    0.351 adhoc.py:172(_iter_datalinks_from_dlblock)
      200    0.003    0.000   64.109    0.321 adhoc.py:599(execute)
      200    0.008    0.000   64.055    0.320 query.py:234(execute_votable)
      200    0.003    0.000   61.772    0.309 decorators.py:7(wrapper)
      200    0.001    0.000   61.770    0.309 query.py:201(execute_stream)
      200    0.002    0.000   61.767    0.309 query.py:219(submit)
      200    0.002    0.000   61.765    0.309 sessions.py:626(post)
      200    0.004    0.000   61.763    0.309 sessions.py:500(request)
      200    0.008    0.000   60.448    0.302 sessions.py:673(send)
```
