### PR TITLE
Update MAST alt registry links

### DIFF
--- a/docs/registry/index.rst
+++ b/docs/registry/index.rst
@@ -597,7 +597,7 @@ You can pre-select the URL by setting the ``IVOA_REGISTRY`` environment
 variable to the TAP access URL of the service you would like to use.  In
 a bash-like shell, you would say::
 
-  export IVOA_REGISTRY="http://vao.stsci.edu/RegTAP/TapService.aspx"
+  export IVOA_REGISTRY="https://mast.stsci.edu/vo-tap/api/v0.1/registry"
 
 before starting python (or the notebook processor).
 
@@ -620,7 +620,7 @@ RegTAP services using:
   http://gavo.aip.de/tap
   http://voparis-rr.obspm.fr/tap
   https://registry.euro-vo.org/regtap/tap
-  https://vao.stsci.edu/RegTAP/TapService.aspx
+  https://mast.stsci.edu/vo-tap/api/v0.1/registry
 
 
 

--- a/docs/registry/index.rst
+++ b/docs/registry/index.rst
@@ -619,8 +619,8 @@ RegTAP services using:
   http://dc.g-vo.org/tap
   http://gavo.aip.de/tap
   http://voparis-rr.obspm.fr/tap
-  https://registry.euro-vo.org/regtap/tap
   https://mast.stsci.edu/vo-tap/api/v0.1/registry
+  https://registry.euro-vo.org/regtap/tap
 
 
 

--- a/pyvo/registry/tests/test_regtap.py
+++ b/pyvo/registry/tests/test_regtap.py
@@ -930,7 +930,7 @@ def test_sia2_service_operation():
 
 @pytest.mark.remote_data
 def test_endpoint_switching():
-    alt_svc = "http://vao.stsci.edu/RegTAP/TapService.aspx"
+    alt_svc = "https://mast.stsci.edu/vo-tap/api/v0.1/registry"
     previous_url = regtap.REGISTRY_BASEURL
     try:
         regtap.choose_RegTAP_service(alt_svc)


### PR DESCRIPTION
MAST's searchable registry is moving from its long running home on http://vao.stsci.edu to new Python based services on https://mast.stsci.edu, one component at a time. 

October 2024, I updated the registry self-identification resource to point RegTAP queries to the new [https://mast.stsci.edu/vo-tap/api/v0.1/registry/](https://mast.stsci.edu/vo-tap/api/v0.1/registry). Mar 11 2025, I updated our resource just for RegTAP as well ([ivo://archive.stsci.edu/regtap](https://vao.stsci.edu/directory/getRecord.aspx?id=ivo://archive.stsci.edu/regtap)).

That change then drives an update the alt_registry links inside pyvo to match.

The URL as supplied in the ivo://archive.stsci.edu/regtap resource gets tested against a listing of RegTAP services in pyvo CI, and I think that mismatch may cause issues with the main CI once the updated resource propagates to GAVO as the default registry for searching. This is foretold in the docs [here](https://github.com/astropy/pyvo/blob/beea0718d93fbc4103748ec37246e138f433749b/docs/registry/index.rst?plain=1#L611C1-L622C47)
`.. We probably shouldn't test the result of the next code block; this
   will change every time someone registers a new RegTAP service...   
.. doctest-remote-data::`
  >>> res = registry.search(datamodel="regtap")
  >>> print("\n".join(sorted(r.get_interface(service_type="tap", lax=True).access_url
  ...   for r in res)))
  http://dc.g-vo.org/tap
  http://gavo.aip.de/tap
  http://voparis-rr.obspm.fr/tap
  https://vao.stsci.edu/RegTAP/TapService.aspx
  
 Given the potential ramifications of leaving CI broken, I can work on any remaining issues that pop up in a tight loop, and if needed I can revert the MAST RegTAP record  to the old link temporarily.
 
I know this needs a CHANGES.rst component; what should the target version be?
