### PR TITLE
More careful NULL value handling in tapregext data limits.

### DIFF
--- a/pyvo/io/vosi/tapregext.py
+++ b/pyvo/io/vosi/tapregext.py
@@ -369,6 +369,9 @@ class DataLimit(ContentMixin, Element):
 
         self.unit = unit
 
+    def __str__(self):
+        return f"{self.unit}:{self.content}"
+
     @xmlattribute
     def unit(self):
         return self._unit
@@ -400,12 +403,12 @@ class DataLimits(Element):
         self.hard = None
 
     def __repr__(self):
-        return '<DataLimits default={}:{} hard={}:{}/>'.format(
-            self.default.unit,
-            self.default.content,
-            self.hard.unit,
-            self.hard.content
-        )
+        parts = []
+        if self.default is not None:
+            parts.append("default={self.default}")
+        if self.hard is not None:
+            parts.append("hard={self.hard}")
+        return '<DataLimits {}/>'.format(" ".join(parts))
 
     @xmlelement(cls=DataLimit, multiple_exc=W29)
     def default(self):
@@ -494,7 +497,7 @@ class TableAccess(TAPCapRestriction):
                 )
             print()
 
-        if self.uploadlimit:
+        if self.uploadlimit and self.uploadlimit.hard:
             print("Maximal size of uploads")
             print(indent("Maximum {} {}".format(
                 self.uploadlimit.hard.content, self.uploadlimit.hard.unit), INDENT))

--- a/pyvo/io/vosi/tests/data/capabilities/minimal-tapregext.xml
+++ b/pyvo/io/vosi/tests/data/capabilities/minimal-tapregext.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<?xml-stylesheet href='/static/xsl/vosi.xsl' type='text/xsl'?>
+<cap:capabilities xmlns:cap="http://www.ivoa.net/xml/VOSICapabilities/v1.0" xmlns:tr="http://www.ivoa.net/xml/TAPRegExt/v1.0" xmlns:vg="http://www.ivoa.net/xml/VORegistry/v1.0" xmlns:vr="http://www.ivoa.net/xml/VOResource/v1.0" xmlns:vs="http://www.ivoa.net/xml/VODataService/v1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.ivoa.net/xml/VOSICapabilities/v1.0 http://vo.ari.uni-heidelberg.de/docs/schemata/VOSICapabilities-v1.0.xsd http://www.ivoa.net/xml/TAPRegExt/v1.0 http://vo.ari.uni-heidelberg.de/docs/schemata/TAPRegExt-v1.0.xsd http://www.ivoa.net/xml/VORegistry/v1.0 http://vo.ari.uni-heidelberg.de/docs/schemata/VORegistry-v1.0.xsd http://www.ivoa.net/xml/VOResource/v1.0 http://vo.ari.uni-heidelberg.de/docs/schemata/VOResource-v1.1.xsd http://www.ivoa.net/xml/VODataService/v1.1 http://vo.ari.uni-heidelberg.de/docs/schemata/VODataService-v1.1.xsd">
+  <capability standardID="ivo://ivoa.net/std/VOSI#capabilities">
+    <interface xsi:type="vs:ParamHTTP">
+      <accessURL use="full">http://example.org/tap/capabilities</accessURL>
+    </interface>
+  </capability>
+  <capability standardID="ivo://ivoa.net/std/VOSI#tables">
+    <interface xsi:type="vs:ParamHTTP">
+      <accessURL use="full">http://example.org/tap/tables</accessURL>
+    </interface>
+  </capability>
+  <capability standardID="ivo://ivoa.net/std/TAP" xsi:type="tr:TableAccess">
+    <interface role="std" xsi:type="vs:ParamHTTP">
+      <accessURL use="base">http://example.org/tap</accessURL>
+    </interface>
+    <language>
+      <name>ADQL</name>
+      <version ivo-id="ivo://ivoa.net/std/ADQL#v2.0">2.0</version>
+      <description>ADQL 2.0</description>
+    </language>
+    <outputFormat ivo-id="ivo://ivoa.net/std/TAPRegExt#output-votable-binary">
+      <mime>text/xml</mime>
+    </outputFormat>
+  </capability>
+</cap:capabilities>


### PR DESCRIPTION
This ought to fix bug #658.

Actually, I considered including the (perhaps more relevant) default upload limit in the describe() output, too.  I will if someone asks for it here...