### PR TITLE
Update authenticated TAPService example

### DIFF
--- a/docs/dal/index.rst
+++ b/docs/dal/index.rst
@@ -406,7 +406,7 @@ functionality is only available to authenticated (and authorized) users.
 
     >>> auth_session = vo.auth.AuthSession()
     >>> # authenticate. For ex: auth_session.credentials.set_client_certificate('<cert_file>')
-    >>> tap_service = vo.dal.TAPService("https://ws-cadc.canfar.net/youcat", auth_session)
+    >>> tap_service = vo.dal.TAPService("https://ws-cadc.canfar.net/youcat", session=auth_session)
     >>>
     >>> table_definition = '''
     ... <vosi:table xmlns:vosi="http://www.ivoa.net/xml/VOSITables/v1.0" xmlns:vod="http://www.ivoa.net/xml/VODataService/v1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" type="output">


### PR DESCRIPTION
At some point, the authenticated session changed from a positional argument to a keyword argument.    
The change here is a small documentation update so the provided example reflects that as otherwise you would get an error (`TAPService.__init__() takes 2 positional arguments but 3 were given`)