### PR TITLE
MAINT: post v1.6.2 consistency cleanups

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,17 +15,21 @@ Enhancements and Fixes
   subjects [#649]
 
 
-
 Deprecations and Removals
 -------------------------
 
+- Versions of Python <3.9 are no longer supported. [#639]
 
-1.6.2 (unreleased)
+
+1.6.2 (2025-04-07)
 ==================
 
 Bug Fixes
 ---------
 
+- Fix performance issues with datalink results. [#654]
+
+- More careful NULL value handling in tapregext data limits. [#659]
 
 
 1.6.1 (2025-02-12)
@@ -41,8 +45,6 @@ Bug Fixes
 - Switch to do minimal VOSI tables downloads for TAP metadata. [#634]
 
 - Provide more informative exception message when requests to endpoints fail. [#641]
-
-- Fix performance issues with datalink results. [#635]
 
 
 1.6 (2024-11-01)
@@ -76,18 +78,16 @@ Enhancements and Fixes
 - MIVOT module: the model references in the dictionaries that are used to build ``MivotInstance``
   objects are made more consistent [#551]
 
+- RegTAP constraints involving tables other than rr.resource are now
+  done via subqueries for less duplication of interfaces. [#562, #572]
+
 - MIVOT module: If the MIVOT annotation block contains a valid instance of the
   ``mango:EpochPosition`` class, the dynamic object describing the mapped
   data can generate a valid SkyCoord instance. [#591]
 
-- RegTAP constraints involving tables other than rr.resource are now
-  done via subqueries for less duplication of interfaces. [#562, #572]
-
-
 - New sub-package discover for global dataset discovery. [#470]
 
 - Updated getdatalink to be consistent with iter_datalinks. [#613]
-
 
 
 Deprecations and Removals

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ name = pyvo
 description = Astropy affiliated package for accessing Virtual Observatory data and services
 long_description = file: README.rst
 author = the PyVO Developers
-license = BSD
+license = BSD-3-Clause
 license_file = LICENSE.rst
 edit_on_github = False
 github_project = astropy/pyvo
@@ -50,14 +50,12 @@ project_urls =
     Documentation = https:/pyvo.readthedocs.io
 classifiers =
     Intended Audience :: Science/Research
-    License :: OSI Approved :: BSD License
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
     Topic :: Database
     Topic :: Scientific/Engineering :: Astronomy
     Topic :: Software Development :: Libraries
-    License :: OSI Approved :: BSD License
 
 
 [options]


### PR DESCRIPTION
The first commit is to cleanup the deprecated usage of the licence classifier (noticed while doing the release), and then a changelog consistency cleanup to match what we released and will release.

I opened this PR for visibility rather than directly pushing under the radar directly onto main, but this doesn't really require a review as most of the changes are ended up in releases already. 