### PR TITLE
fix: delete jobs when delete=True even on DALQueryErrors

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ Enhancements and Fixes
 - Add a UAT constraint to the registry interface for constraining
   subjects [#649]
 
+- Correctly delete jobs in ``TAPService.run_async`` even when the server returns an
+  error [#667]
 
 Deprecations and Removals
 -------------------------

--- a/pyvo/dal/tap.py
+++ b/pyvo/dal/tap.py
@@ -327,7 +327,14 @@ class TAPService(DALService, AvailabilityMixin, CapabilityMixin):
             self.baseurl, query, language=language, maxrec=maxrec, uploads=uploads,
             session=self._session, **keywords)
         job = job.run().wait()
-        job.raise_if_error()
+
+        try:
+            job.raise_if_error()
+        except DALQueryError:
+            if delete:
+                job.delete()
+            raise
+
         result = job.fetch_result()
 
         if delete:


### PR DESCRIPTION
This is a follow up of #640 

When `job.raise_if_error()` raises an error, we still want the job to be deleted when `delete=True`

The bug was there before #640, the new parameter just made it obvious. Should we add a changelog?