### PR TITLE
[Issue 668] [SIA2 service] check existence of standardid

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,9 @@ Enhancements and Fixes
 - Correctly delete jobs in ``TAPService.run_async`` even when the server returns an
   error [#667]
 
+- Fixed AttributeError when a capability has None standardID in SIA2Service. [#669]
+
+
 Deprecations and Removals
 -------------------------
 

--- a/pyvo/dal/sia2.py
+++ b/pyvo/dal/sia2.py
@@ -186,7 +186,7 @@ class SIA2Service(DALService, AvailabilityMixin, CapabilityMixin):
                 # assumes that the access URL is the same regardless of the
                 # authentication method except BasicAA which is not supported
                 # in pyvo. So pick any access url as long as it's not
-                if cap.standardid.lower() == SIA2_STANDARD_ID.lower():
+                if cap.standardid and cap.standardid.lower() == SIA2_STANDARD_ID.lower():
                     for interface in cap.interfaces:
                         if interface.accessurls and \
                                 not (len(interface.securitymethods) == 1

--- a/pyvo/dal/tests/test_sia2.py
+++ b/pyvo/dal/tests/test_sia2.py
@@ -213,3 +213,34 @@ def test_variable_deprecation():
     with pytest.warns(AstropyDeprecationWarning):
         from pyvo.dal.sia2 import SIA_PARAMETERS_DESC
         assert SIA_PARAMETERS_DESC
+
+def test_none_standardid_capability():
+    """Test that SIA2Service handles capabilities with None standardID."""
+    from pyvo.dal.sia2 import SIA2Service
+    import requests_mock
+    
+    # Mock a capabilities response with a None standardID
+    with requests_mock.Mocker() as m:
+        # Mock the capabilities endpoint
+        m.get('http://example.com/sia/capabilities',
+              content=b'''<?xml version="1.0" encoding="UTF-8"?>
+<vosi:capabilities xmlns:vosi="http://www.ivoa.net/xml/VOSICapabilities/v1.0">
+  <capability>
+    <!-- This capability has no standardID attribute -->
+    <interface>
+      <accessURL use="full">http://example.com/sia/query</accessURL>
+    </interface>
+  </capability>
+  <capability standardID="ivo://ivoa.net/std/SIA#query-2.0">
+    <interface>
+      <accessURL use="full">http://example.com/sia/query</accessURL>
+    </interface>
+  </capability>
+</vosi:capabilities>''')
+        
+        # This should not raise an AttributeError
+        sia2_service = SIA2Service('http://example.com/sia')
+        
+        # Basic verification that the service was created successfully
+        assert sia2_service is not None
+        assert sia2_service.query_ep is not None

--- a/pyvo/dal/tests/test_sia2.py
+++ b/pyvo/dal/tests/test_sia2.py
@@ -214,11 +214,11 @@ def test_variable_deprecation():
         from pyvo.dal.sia2 import SIA_PARAMETERS_DESC
         assert SIA_PARAMETERS_DESC
 
+
 def test_none_standardid_capability():
     """Test that SIA2Service handles capabilities with None standardID."""
     from pyvo.dal.sia2 import SIA2Service
     import requests_mock
-    
     # Mock a capabilities response with a None standardID
     with requests_mock.Mocker() as m:
         # Mock the capabilities endpoint
@@ -237,10 +237,8 @@ def test_none_standardid_capability():
     </interface>
   </capability>
 </vosi:capabilities>''')
-        
         # This should not raise an AttributeError
         sia2_service = SIA2Service('http://example.com/sia')
-        
         # Basic verification that the service was created successfully
         assert sia2_service is not None
         assert sia2_service.query_ep is not None


### PR DESCRIPTION
As in Issue #668 stated, when using SIA2Service with a service that has capabilities without standardID,
an AttributeError is raised: 'NoneType' object has no attribute 'lower'.

Adding a check for the existence of `standardid` would fix this issue:

```
if cap.standardid and cap.standardid.lower() == SIA2_STANDARD_ID.lower():
```