### PR TITLE
fix: prevent creating SIA2Service with an URL of an other service type

### DIFF
--- a/pyvo/dal/sia2.py
+++ b/pyvo/dal/sia2.py
@@ -20,6 +20,7 @@ from astropy.utils.exceptions import AstropyDeprecationWarning
 
 from .query import DALResults, DALQuery, DALService, Record
 from .adhoc import DatalinkResultsMixin, AxisParamMixin, SodaRecordMixin, DatalinkRecordMixin
+from .exceptions import DALServiceError
 from .params import IntervalQueryParam, StrQueryParam, EnumQueryParam
 from .vosi import AvailabilityMixin, CapabilityMixin
 from ..dam import ObsCoreMetadata, CALIBRATION_LEVELS
@@ -197,6 +198,8 @@ class SIA2Service(DALService, AvailabilityMixin, CapabilityMixin):
                     else:
                         continue
                     break
+            else:
+                raise DALServiceError("This URL does not seem to correspond to an SIA2 service.")
 
     def search(self, pos=None, *, band=None, time=None, pol=None,
                field_of_view=None, spatial_resolution=None,


### PR DESCRIPTION
## What's done here?

Since #669 , it is possible to create an `SIA2Service` from an url that does not correspond to an SIA2 at all, even with `check_baseurl=True`.

This used to fail (with an `AttributeError`, which was confusing):

```python
from pyvo import dal
sia_service = dal.SIA2Service("http://dc.g-vo.org/lswscans/res/positions/siap/siap.xml")
```

It now silently creates a bugged object that cannot be used (the URL is not SIA2 but SIA)

This PR makes the snippet fail again, but this time with a `DALServiceError` that explains the issue.

## Possible additions to the PR

As written in comment https://github.com/astropy/pyvo/pull/669#issuecomment-2842109588 , raising such an error would also be useful for every other service type. For example, I can do:

```python
from pyvo import dal
sia_service = dal.TAPService("http://dc.g-vo.org/lswscans/res/positions/siap/siap.xml")
```

Should we raise an error there? It would imply looping on the capabilities to check the mandatory standard id for this kind of service each time we create a service object. Maybe the other services types should have a `check_baseurl` option to turn this check on just like there is for SIA2? What are your thoughts?