### PR TITLE
Fix job result handling to prioritize standard URL structure

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Enhancements and Fixes
 
 - Add support for the jobInfo element for UWS jobs [#679]
 
+- Fix job result handling to prioritize standard URL structure [#684]
+
 Deprecations and Removals
 -------------------------
 

--- a/pyvo/dal/tap.py
+++ b/pyvo/dal/tap.py
@@ -870,15 +870,23 @@ class AsyncTAPJob:
     @property
     def result(self):
         """
-        Returns the UWS result with id='result' if it exists, otherwise None.
+        Returns the UWS result that corresponds to the standard TAP result
+        endpoint: "results/result".
+
+        If no such result is found it falls back to the old behavior of returning
+        the first result with id 'result'.
         """
         try:
             for r in self._job.results:
-                if r.id_ == 'result':
+                if r.href and r.href.endswith("results/result"):
+                    return r
+
+            for r in self._job.results:
+                if r.href and r.href.strip() and r.id_ == 'result':
                     return r
 
             return None
-        except IndexError:
+        except (IndexError, AttributeError):
             return None
 
     @property


### PR DESCRIPTION
### Description

As described by in #670 the `AsyncTAPJob.result` property was incorrectly looking for results with `id='result'` instead of checking the URL structure as specified by the TAP standard. This caused failures with services like CEFCA that correctly implement the standard URL structure but use different id values (for example `id='main'`)

### Fix

- Primary check now looks for href ending with "results/result" first
- Fallback to id-based lookup to maintain backwards compatibility
- Add validation to ensure href is not empty or whitespace-only, if it is return None

Added some tests as well to verify behaviour.

### Related Issue:

https://github.com/astropy/pyvo/issues/670