### PR TITLE
Add prefer_async param to TAPService constructor to control what mode uses

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@ Enhancements and Fixes
 
 - Fix job result handling to prioritize standard URL structure [#684]
 
+- Add prefer_async param to TAPService constructor to control what mode uses [#686]
+
+
 Deprecations and Removals
 -------------------------
 

--- a/docs/io/uws.rst
+++ b/docs/io/uws.rst
@@ -382,7 +382,7 @@ While the examples above focus on individual jobs, you can also parse job lists:
     >>> # Iterate through jobs (each is a JobSummary object)
     >>> for job in jobs:  # doctest: +ELLIPSIS
     ...     print(f"Job {job.jobid}: {job.phase}")
-    Job ...: COMPLETED
+    Job ...: ...
 
 
 Error Handling


### PR DESCRIPTION
## Description

Adds an optional `prefer_async` parameter to `TAPService` that allows users to specify that they want search to default to async execution.
This change should be backwards-compatbile.

**Problem:** Currently, `TAPService.search()` always uses sync regardless. Some TAP service providers prefer asynchronous execution for better stability and resource management.

**Solution:** Implements approach 2 from [issue #685](https://github.com/astropy/pyvo/issues/685) - an opt-in `prefer_async` parameter that:
- Defaults to `False` (no behavior change for existing code)
- When set to `True`, makes `search()` use `run_async()` automatically  
- Includes `force_sync=True` parameter to override async preference when needed

**Usage:**
```python
# Default behavior (unchanged)
service = TAPService("http://example.com/tap")
results = service.search("SELECT * FROM table")  # Uses sync

# Opt-in to async-first behavior  
service = TAPService("http://example.com/tap", prefer_async=True)
results = service.search("SELECT * FROM table")  # Uses async
results = service.search("SELECT * FROM table", force_sync=True)  # Forces sync
```

## Docs
Slightly modified/extended the dal/index.rst documentation with additional content describing the new parameter and how it can be used.
I've also included a small change/fix to UWS to make the pattern check more generic for the job list output.

## Tests
Added a few unit tests to validate behaviour

**Closes**
https://github.com/astropy/pyvo/issues/685

Is this a reasonable enhancement? Any thing I should change in the implementation or documentation?