### PR TITLE
fix: Change the message of the DALOverflowWarning when overflow is encountered

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Enhancements and Fixes
 
 - Fix job result handling to prioritize standard URL structure [#684]
 
+- Fix DALOverflowWarning error message to only indicate the cause as limits from user or server. [#689]
+
 Deprecations and Removals
 -------------------------
 

--- a/docs/dal/index.rst
+++ b/docs/dal/index.rst
@@ -354,7 +354,7 @@ you reach the ``maxrec`` limit:
 .. doctest-remote-data::
 
     >>> tap_results = tap_service.search("SELECT * FROM arihip.main", maxrec=5)  # doctest: +SHOW_WARNINGS
-    DALOverflowWarning: Partial result set. Potential causes MAXREC, async storage space, etc.
+    DALOverflowWarning: Result set limited by user- or server-supplied MAXREC parameter.
 
 Services will not let you raise maxrec beyond the hard match limit:
 

--- a/pyvo/dal/query.py
+++ b/pyvo/dal/query.py
@@ -338,7 +338,7 @@ class DALResults:
             raise DALQueryError(self._status[1], self._status[0], url)
 
         if self._status[0].lower() == "overflow":
-            warn("Partial result set. Potential causes MAXREC, async storage space, etc.",
+            warn("Result set limited by user- or server-supplied MAXREC parameter.",
                  category=DALOverflowWarning)
 
         self._resultstable = self._findresultstable(votable)

--- a/pyvo/registry/tests/test_regtap.py
+++ b/pyvo/registry/tests/test_regtap.py
@@ -712,7 +712,7 @@ def test_maxrec():
     with pytest.warns(DALOverflowWarning) as w:
         _ = regsearch(servicetype="tap", maxrec=1)
     assert len(w) == 1
-    assert str(w[0].message).startswith("Partial result set.")
+    assert str(w[0].message).startswith("Result set limited")
 
 
 @pytest.mark.remote_data


### PR DESCRIPTION
### Description
Currently when pyvo encounters an OVERFLOW INFO message from a TAP query, it will issue a warning message with this content:
`Partial result set. Potential causes MAXREC, async storage space, etc.`

This error should only occur when:

> the number of rows in the table of results may exceed a limit requested by the user (using the MAXREC parameter) or a limit set by the service implementation (the default or maximum value of MAXREC).

https://www.ivoa.net/documents/TAP/20190927/REC-TAP-1.1.html#tth_sEc3.4

This PR attempts to clarify the message which otherwise may confuse the user.

### Github issue:
#687