### PR TITLE
Change to not display overflow warning when user has set a maxrec

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 Enhancements and Fixes
 ----------------------
 
+- No longer show a warning when an overflow status is encountered with a maxrec set by the user [#690]
+
 - Add support for the jobInfo element for UWS jobs [#679]
 
 - Fix job result handling to prioritize standard URL structure [#684]

--- a/docs/dal/index.rst
+++ b/docs/dal/index.rst
@@ -348,13 +348,23 @@ rows they will return before overflowing:
     20000
 
 To retrieve more rows than that (often conservative) default limit, you
-must override maxrec in the call to ``search``. A warning can be expected if
-you reach the ``maxrec`` limit:
+must override maxrec in the call to ``search``. PyVO will only warn about 
+truncation when it's unexpected. If you request 5 records and get 5 records,
+no warning is issued:
 
 .. doctest-remote-data::
 
-    >>> tap_results = tap_service.search("SELECT * FROM arihip.main", maxrec=5)  # doctest: +SHOW_WARNINGS
-    DALOverflowWarning: Result set limited by user- or server-supplied MAXREC parameter.
+    >>> tap_results = tap_service.search("SELECT * FROM arihip.main", maxrec=5)
+    >>> len(tap_results)
+    5
+
+However, if results are truncated by server limits without you specifying 
+maxrec, you'll receive a helpful warning:
+
+.. doctest-remote-data::
+
+    >>> tap_results = tap_service.search("SELECT * FROM arihip.main")  # doctest: +SHOW_WARNINGS
+    DALOverflowWarning: Results truncated due to server limits. Consider setting a maxrec value.
 
 Services will not let you raise maxrec beyond the hard match limit:
 

--- a/pyvo/dal/tap.py
+++ b/pyvo/dal/tap.py
@@ -654,7 +654,7 @@ class AsyncTAPJob:
             uploads=uploads, session=session, **keywords)
         response = tapquery.submit()
         job = cls(response.url, session=session)
-        job._user_maxrec = maxrec
+        job._client_set_maxrec = maxrec
         return job
 
     def __init__(self, url, *, session=None, delete=True):
@@ -673,7 +673,7 @@ class AsyncTAPJob:
         self._url = url
         self._session = use_session(session)
         self._delete_on_exit = delete
-        self._user_maxrec = None
+        self._client_set_maxrec = None
         self._update()
 
     def __enter__(self):
@@ -1050,7 +1050,7 @@ class AsyncTAPJob:
         response.raw.read = partial(
             response.raw.read, decode_content=True)
         result = TAPResults(votableparse(response.raw.read), url=self.result_uri, session=self._session)
-        result.check_overflow_warning(self._user_maxrec)
+        result.check_overflow_warning(self._client_set_maxrec)
         return result
 
 
@@ -1107,7 +1107,7 @@ class TAPQuery(DALQuery):
         self["REQUEST"] = "doQuery"
         self["LANG"] = language
 
-        self._user_maxrec = maxrec
+        self._client_set_maxrec = maxrec
 
         if maxrec:
             self["MAXREC"] = maxrec
@@ -1166,7 +1166,7 @@ class TAPQuery(DALQuery):
             url=self.queryurl,
             session=self._session
         )
-        result.check_overflow_warning(self._user_maxrec)
+        result.check_overflow_warning(self._client_set_maxrec)
 
         return result
 
@@ -1278,7 +1278,7 @@ class TAPResults(DatalinkResultsMixin, DALResults):
         """
         return TAPRecord(self, index, session=self._session)
 
-    def _handle_overflow_warning(self, user_maxrec=None):
+    def _handle_overflow_warning(self, client_set_maxrec=None):
         """
         TAP-specific overflow warning handling.
 

--- a/pyvo/dal/tests/test_query.py
+++ b/pyvo/dal/tests/test_query.py
@@ -433,20 +433,20 @@ class TestDALResults:
 
         with warnings.catch_warnings():
             warnings.simplefilter("error")
-            dalresults.check_overflow_warning(user_maxrec=3)
+            dalresults.check_overflow_warning(client_set_maxrec=3)
 
     def test_check_overflow_warning_service_truncation(self):
         with pytest.warns(DALOverflowWarning):
             dalresults = DALResults.from_result_url('http://example.com/query/overflowstatus')
 
         with pytest.warns(DALOverflowWarning, match="Results truncated at 3 records by service limits"):
-            dalresults.check_overflow_warning(user_maxrec=1000)
+            dalresults.check_overflow_warning(client_set_maxrec=1000)
 
     def test_check_overflow_warning_uses_stored_maxrec(self):
         with pytest.warns(DALOverflowWarning):
             dalresults = DALResults.from_result_url('http://example.com/query/overflowstatus')
 
-        dalresults._user_maxrec = 1000
+        dalresults._client_set_maxrec = 1000
 
         with pytest.warns(DALOverflowWarning, match="Results truncated at 3 records by service limits"):
             dalresults.check_overflow_warning()
@@ -455,18 +455,18 @@ class TestDALResults:
         with pytest.warns(DALOverflowWarning):
             dalresults = DALResults.from_result_url('http://example.com/query/overflowstatus')
 
-        dalresults._user_maxrec = 1000
+        dalresults._client_set_maxrec = 1000
 
         with warnings.catch_warnings():
             warnings.simplefilter("error")
-            dalresults.check_overflow_warning(user_maxrec=3)
+            dalresults.check_overflow_warning(client_set_maxrec=3)
 
     def test_check_overflow_warning_no_overflow_status(self):
         dalresults = DALResults.from_result_url('http://example.com/query/basic')
 
         with warnings.catch_warnings():
             warnings.simplefilter("error")
-            dalresults.check_overflow_warning(user_maxrec=1000)
+            dalresults.check_overflow_warning(client_set_maxrec=1000)
 
     def test_handle_overflow_warning_default_behavior(self):
         votable = votableparse(BytesIO(get_pkg_data_contents('data/query/overflowstatus.xml')))
@@ -475,14 +475,14 @@ class TestDALResults:
                           match="Result set limited by user- or server-supplied MAXREC parameter."):
             _ = DALResults(votable, url='http://test.com')
 
-    def test_stored_user_maxrec_initialization(self):
+    def test_stored_client_set_maxrec_initialization(self):
         votable = votableparse(BytesIO(get_pkg_data_contents('data/query/basic.xml')))
 
-        result = DALResults(votable, url='http://test.com', user_maxrec=100)
-        assert result._user_maxrec == 100
+        result = DALResults(votable, url='http://test.com', client_set_maxrec=100)
+        assert result._client_set_maxrec == 100
 
         result2 = DALResults(votable, url='http://test.com')
-        assert result2._user_maxrec is None
+        assert result2._client_set_maxrec is None
 
 
 @pytest.mark.filterwarnings('ignore::astropy.io.votable.exceptions.W03')

--- a/pyvo/dal/tests/test_tap.py
+++ b/pyvo/dal/tests/test_tap.py
@@ -1434,18 +1434,18 @@ class TestTAPOverflowWarnings:
         service = TAPService('http://example.com/tap')
 
         query = service.create_query("SELECT * FROM ivoa.obscore", maxrec=10)
-        assert query._user_maxrec == 10
+        assert query._client_set_maxrec == 10
         assert query["MAXREC"] == 10
 
         query2 = service.create_query("SELECT * FROM ivoa.obscore")
-        assert query2._user_maxrec is None
+        assert query2._client_set_maxrec is None
         assert "MAXREC" not in query2
 
     def test_edge_case_maxrec_zero(self):
         service = TAPService('http://example.com/tap')
 
         query = service.create_query("SELECT * FROM ivoa.obscore", maxrec=0)
-        assert query._user_maxrec == 0
+        assert query._client_set_maxrec == 0
         assert "MAXREC" not in query
 
 
@@ -1457,7 +1457,7 @@ class TestTAPAsyncOverflowWarnings:
         service = TAPService('http://example.com/tap')
         job = service.submit_job("SELECT * FROM ivoa.obscore", maxrec=5)
 
-        assert job._user_maxrec == 5
+        assert job._client_set_maxrec == 5
 
     def test_async_job_manual_creation_no_maxrec(self):
         job_response = '''<?xml version="1.0" encoding="UTF-8"?>
@@ -1477,7 +1477,7 @@ class TestTAPAsyncOverflowWarnings:
 
             job = AsyncTAPJob('http://example.com/tap/async/123')
 
-            assert job._user_maxrec is None
+            assert job._client_set_maxrec is None
             assert job.job_id == '123'
             assert job.phase == 'PENDING'
 
@@ -1487,4 +1487,4 @@ def test_tap_integration_with_existing_tests():
 
     query = service.create_query("SELECT * FROM ivoa.obscore")
     assert query is not None
-    assert hasattr(query, '_user_maxrec')
+    assert hasattr(query, '_client_set_maxrec')


### PR DESCRIPTION
## Description
As described in https://github.com/astropy/pyvo/issues/687 PyVO currently will show a `DALOverflowWarning` whenever a TAP service returns `OVERFLOW` status even when users explicitly set maxrec (and thus expect truncation). This can potentially cause confusion since warnings should indicate unexpected conditions.

## Fix
Implement smart overflow warnings that distinguish between expected and unexpected truncation:

### New behaviour: 
User sets maxrec = 10, gets 10 records -> No warning (expected)
User sets maxrec = 20 gets 10 records -> Gets warning about service limits
User doesn't set maxrec, gets truncated -> Warning with suggestion to consider setting maxrec

Summary of the approach i went for:

`TAPResults` suppresses default overflow warnings during construction. `TAPQuery.execute()` calls `result.check_overflow_warning(user_maxrec)` with proper context. Other DAL services (SIA, SCS etc) continue to get default overflow warnings

## Implementation Details

Added `check_overflow_warning` public method to `DALResults` for new warning logic
`TAPResults` overrides _handle_overflow_warning() to suppress init-time warnings
`TAPQuery` and `AsyncTAPJob` track `_user_maxrec` and apply smart warnings post-construction
Both sync and async TAP queries now respect user intent

## Alternatives Considered

I initially looked into threading maxrec through the inheritance chain, but that got pretty complicated and I had to touch various classes which felt like the wrong approach.

## Backward Compatibility
There should be no breaking changes with this approach. Other DAL services  should continue to receive overflow warnings  as before

Other services can also adopt the same pattern when needed.

## Testing
Added a number of unit tests to verify above expected behavior.

Resolves #687 

Any thoughts on this approach? Are there better ones I haven't considered? Is the behavior reasonable?
