### PR TITLE
Add DEFAULT_JOB_POLL_TIMEOUT constant and use it in _update method

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 Enhancements and Fixes
 ----------------------
 
+- Add DEFAULT_JOB_POLL_TIMEOUT constant [#721]
+
 - Pass session through to DatalinkService requests (#715)
 
 - Add DALRateLimitError for HTTP 429 responses with retry timing info [#718]

--- a/docs/dal/index.rst
+++ b/docs/dal/index.rst
@@ -668,6 +668,20 @@ Besides ``run`` there are also several other job control methods:
     The destruction time can be obtained and changed with
     :py:attr:`~pyvo.dal.AsyncTAPJob.destruction`
 
+Job polling timeout
+-------------------
+When polling for job status, pyVO uses a default timeout of 10 seconds for
+each request. Some services may occasionally respond slowly, causing
+``ReadTimeout`` errors during polling. If you experience intermittent timeout
+failures when polling job status, you can try increasing this timeout::
+
+    import pyvo.dal.tap
+    pyvo.dal.tap.DEFAULT_JOB_POLL_TIMEOUT = 30  # seconds
+
+This is a module-level setting that affects all follow-up async job operations.
+Note that a response time of 10 or more seconds for a status request
+would likely indicate that the service may be experiencing issues.
+
 Also, :py:class:`pyvo.dal.AsyncTAPJob` works as a context manager which
 takes care of this automatically:
 

--- a/pyvo/dal/tap.py
+++ b/pyvo/dal/tap.py
@@ -29,7 +29,8 @@ import xml.etree.ElementTree
 import io
 
 __all__ = [
-    "search", "escape", "TAPService", "TAPQuery", "AsyncTAPJob", "TAPResults"]
+    "search", "escape", "TAPService", "TAPQuery", "AsyncTAPJob", "TAPResults",
+    "DEFAULT_JOB_POLL_TIMEOUT"]
 
 IVOA_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 
@@ -44,6 +45,9 @@ TABLE_DEF_FORMAT = {'VOSITable': 'text/xml',
 # common transient errors that can be retried
 TRANSIENT_ERRORS = (requests.exceptions.ConnectionError,
                     requests.exceptions.Timeout)
+
+# Default timeout (in seconds) for job status polling requests.
+DEFAULT_JOB_POLL_TIMEOUT = 10
 
 
 def _from_ivoa_format(datetime_str):
@@ -704,10 +708,12 @@ class AsyncTAPJob:
             except DALServiceError:
                 pass
 
-    def _update(self, wait_for_statechange=False, timeout=10.):
+    def _update(self, wait_for_statechange=False, timeout=None):
         """
         updates local job infos with remote values
         """
+        if timeout is None:
+            timeout = DEFAULT_JOB_POLL_TIMEOUT
         try:
             if wait_for_statechange:
                 response = self._session.get(


### PR DESCRIPTION
## Description

This is an approach to somewhat address issue https://github.com/astropy/pyvo/issues/713

The proposed changes here add a `DEFAULT_JOB_POLL_TIMEOUT` module-level constant and updates the `_update()` method to  use that when the timeout parameter is not provided.

I have not modified the default value to > 10 seconds because I think we concluded that that anything more than that in these requests indicates a service-level problem.

### Usage

For users who want to overwrite this, they can use it as:
```
import pyvo.dal.tap
pyvo.dal.tap.DEFAULT_JOB_POLL_TIMEOUT = 30
service = pyvo.dal.TAPService("https://irsa.ipac.caltech.edu/TAP")
```