### PR TITLE
Install VOTable schemas

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -83,6 +83,7 @@ pyvo.auth.tests = data/tap/*.xml
 pyvo.io.uws.tests = data/*.xml
 pyvo.io.vosi.tests = data/*.xml, data/tables/*.xml, data/capabilities/*.xml
 pyvo.registry.tests = data/*.xml, data/*.desise
+pyvo.mivot.writer = *.xsd
 pyvo.mivot.tests = data/*.xml, data/input/*.xml, data/output/*.xml, data/reference/*json, data/reference/*xml
 pyvo.dal.tests = data/*.xml, data/*/*
 


### PR DESCRIPTION
Follow up on GH-698, bug was [found while packaging version 1.8](https://codeberg.org/guix/guix/issues/4393).

Fixes: fd700322edad ("Use of local copies of VOTable schemas")
