### PR TITLE
MAINT: removing python 3.9 support

### DIFF
--- a/.github/workflows/ci_devtests.yml
+++ b/.github/workflows/ci_devtests.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Set up Python 3.14
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
-          python-version: "3.14-dev"
+          python-version: "3.14"
       - name: Install tox
         run: python -m pip install --upgrade tox
       - name: Run tests

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -25,10 +25,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python-version: '3.9'
-            tox_env: py39-test-oldestdeps-alldeps
           - python-version: '3.10'
-            tox_env: py310-test
+            tox_env: py310-test-oldestdeps-alldeps
           - python-version: '3.11'
             tox_env: py311-test-alldeps
           - python-version: '3.13'

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,9 @@ Enhancements and Fixes
 Deprecations and Removals
 -------------------------
 
+- Versions of Python <3.10 are no longer supported. [#724]
+
+- Versions of Astropy <5.0 are no longer supported. [#724]
 
 
 1.8.1 (unreleased)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 #
 # Astropy documentation build configuration file.
@@ -125,7 +124,7 @@ html_theme_options = {
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-html_title = '{} v{}'.format(project, release)
+html_title = f'{project} v{release}'
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = project + 'doc'

--- a/pyvo/auth/tests/test_auth.py
+++ b/pyvo/auth/tests/test_auth.py
@@ -83,7 +83,7 @@ def certificate_auth_service(mocker):
 
 class MockBasicAuthTAPServer(MockAsyncTAPServer):
     def validator(self, request):
-        pw = 'testuser:hunter2'.encode('ascii')
+        pw = b'testuser:hunter2'
         basic_encoded = 'Basic ' + base64.b64encode(pw).decode('ascii')
 
         assert request.cert is None

--- a/pyvo/discover/image.py
+++ b/pyvo/discover/image.py
@@ -36,7 +36,7 @@ from ..registry import regtap
 
 
 # imports for type hints
-from typing import Callable, Optional
+from collections.abc import Callable
 from collections.abc import Generator
 from astropy.units import quantity
 
@@ -577,13 +577,13 @@ class ImageDiscoverer:
 
 def images_globally(
         *,
-        space: Optional[tuple[float, float, float]] = None,
-        spectrum: Optional[quantity.Quantity] = None,
-        time: Optional[time.Time] = None,
+        space: tuple[float, float, float] | None = None,
+        spectrum: quantity.Quantity | None = None,
+        time: time.Time | None = None,
         inclusive: bool = False,
-        watcher: Optional[Callable[['ImageDiscoverer', str], None]] = None,
+        watcher: Callable[['ImageDiscoverer', str], None] | None = None,
         timeout: float = 20,
-        services: Optional[registry.RegistryResults] = None)\
+        services: registry.RegistryResults | None = None)\
         -> tuple[list[obscore.ObsCoreMetadata], list[str]]:
     """returns a collection of ObsCoreMetadata-s matching certain constraints
     and a list of log lines.

--- a/pyvo/mivot/writer/instances_from_models.py
+++ b/pyvo/mivot/writer/instances_from_models.py
@@ -28,7 +28,7 @@ from pyvo.mivot.glossary import (
     VodmlUrl, IvoaType, ModelPrefix, Url, CoordSystems)
 
 
-class InstancesFromModels(object):
+class InstancesFromModels:
     """
     **Top-level API class** that allows to create VOTable annotations with objects issued
     from the Mango model and its imported classes.

--- a/pyvo/mivot/writer/mango_object.py
+++ b/pyvo/mivot/writer/mango_object.py
@@ -52,7 +52,7 @@ class Property(MivotInstance):
             self.add_instance(semantics_instance)
 
 
-class MangoObject(object):
+class MangoObject:
     """
     This class handles all the components of a MangoObject (properties, origin, instance identifier).
      It is meant to be used by `pyvo.mivot.writer.InstancesFromModels` but not by end users.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [tool:pytest]
-minversion = 6.0
+minversion = 7.0
 norecursedirs = build docs/_build
 testpaths = "pyvo" "docs"
 astropy_header = true
@@ -63,9 +63,9 @@ packages = find:
 zip_safe = False
 setup_requires = setuptools_scm
 install_requires =
-    astropy>=4.2
+    astropy>=5.0
     requests
-python_requires = >=3.9
+python_requires = >=3.10
 
 [options.extras_require]
 all =

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,9 @@ filterwarnings =
 # We need to ignore this module level warning to not cause issues at collection time.
 # Remove it once warning is removed from code (in 1.7).
     ignore:pyvo.discover:pyvo.utils.prototype.PrototypeWarning
+# These started to show up in CI for the oldestdeps run, however it has nothing to do with
+# anything in pyvo, so we just do the blanket ignore
+    ignore:leap-second auto-update failed::astropy
 
 [flake8]
 max-line-length = 110

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 # as oldestdeps and devastropy might not support the full python range
 # listed here
 envlist =
-    py{39,310,311,312,313,314}-test{,-alldeps,-oldestdeps,-devdeps}{,-online}{,-cov}
+    py{310,311,312,313,314}-test{,-alldeps,-oldestdeps,-devdeps}{,-online}{,-cov}
     linkcheck
     codestyle
     build_docs
@@ -36,11 +36,11 @@ deps =
     devdeps: pyerfa>=0.0.dev0
     devdeps: astropy>=0.0.dev0
 
-    oldestdeps: astropy==4.2
+    oldestdeps: astropy==5.0
 
     # We set a suitably old numpy along with an old astropy, no need to pick up
     # deprecations and errors due to their unmatching versions
-    oldestdeps: numpy==1.20
+    oldestdeps: numpy==1.22
 
     online: pytest-rerunfailures
 


### PR DESCRIPTION
Python 3.9 has passed EOL.

This PR also bumps the minimum required version of astropy to be 5.0, the first one that supported python 3.10. Similarly, minimum pytest was bumped.


