### PR TITLE
CI: ignore leap-second warning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,9 @@ filterwarnings =
 # We need to ignore this module level warning to not cause issues at collection time.
 # Remove it once warning is removed from code (in 1.7).
     ignore:pyvo.discover:pyvo.utils.prototype.PrototypeWarning
+# These started to show up in CI for the oldestdeps run, however it has nothing to do with
+# anything in pyvo, so we just do the blanket ignore
+    ignore:leap-second auto-update failed::astropy
 
 [flake8]
 max-line-length = 110


### PR DESCRIPTION
We started seeing leap-second warnings in CI, so this PR just ignore  them as it's purely upstream astropy related.

I separated out the commit from #724 as this one will likely be useful to get backported, too.