### PR TITLE
Fix sia2 to not display warnings when user-provided maxrec use case

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 Enhancements and Fixes
 ----------------------
 
+- Fix SIA2 overflow warnings [#727]
+
 - Add DEFAULT_JOB_POLL_TIMEOUT constant [#721]
 
 - Pass session through to DatalinkService requests (#715)


### PR DESCRIPTION
## Description

Modify SIA2 execute to check for overflows via `check_overflow_warning` before returning the result

This closes issue #728

## Tests
Added unit tests for testing various scenarios of use with maxrec
