### PR TITLE
ENH: Add timeout parameter to run_async method in tap module

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 Enhancements and Fixes
 ----------------------
 
+- Add timeout parameter to run_async method in tap module [#730]
+
 - Fix SIA2 overflow warnings [#727]
 
 - Add DEFAULT_JOB_POLL_TIMEOUT constant [#721]

--- a/pyvo/dal/tap.py
+++ b/pyvo/dal/tap.py
@@ -30,7 +30,7 @@ import io
 
 __all__ = [
     "search", "escape", "TAPService", "TAPQuery", "AsyncTAPJob", "TAPResults",
-    "DEFAULT_JOB_POLL_TIMEOUT"]
+    "DEFAULT_JOB_POLL_TIMEOUT", "DEFAULT_JOB_WAIT_TIMEOUT"]
 
 IVOA_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 
@@ -48,6 +48,9 @@ TRANSIENT_ERRORS = (requests.exceptions.ConnectionError,
 
 # Default timeout (in seconds) for job status polling requests.
 DEFAULT_JOB_POLL_TIMEOUT = 10
+
+# Default timeout (in seconds) for overall job wait.
+DEFAULT_JOB_WAIT_TIMEOUT = 600.
 
 
 def _from_ivoa_format(datetime_str):
@@ -296,7 +299,7 @@ class TAPService(DALService, AvailabilityMixin, CapabilityMixin):
 
     def run_async(
             self, query, *, language="ADQL", maxrec=None, uploads=None,
-            delete=True, timeout=600., **keywords):
+            delete=True, timeout=DEFAULT_JOB_WAIT_TIMEOUT, **keywords):
         """
         runs async query and returns its result
 
@@ -972,7 +975,7 @@ class AsyncTAPJob:
 
         return self
 
-    def wait(self, *, phases=None, timeout=600.):
+    def wait(self, *, phases=None, timeout=DEFAULT_JOB_WAIT_TIMEOUT):
         """
         waits for the job to reach the given phases.
 

--- a/pyvo/dal/tap.py
+++ b/pyvo/dal/tap.py
@@ -296,7 +296,7 @@ class TAPService(DALService, AvailabilityMixin, CapabilityMixin):
 
     def run_async(
             self, query, *, language="ADQL", maxrec=None, uploads=None,
-            delete=True, **keywords):
+            delete=True, timeout=600., **keywords):
         """
         runs async query and returns its result
 
@@ -313,6 +313,8 @@ class TAPService(DALService, AvailabilityMixin, CapabilityMixin):
             a mapping from table names to objects containing a votable
         delete : bool
             delete the job after fetching the results
+        timeout : float
+            maximum time to wait for job completion in seconds. Default is 600.
 
         Returns
         -------
@@ -336,7 +338,7 @@ class TAPService(DALService, AvailabilityMixin, CapabilityMixin):
         job = AsyncTAPJob.create(
             self.baseurl, query, language=language, maxrec=maxrec, uploads=uploads,
             session=self._session, **keywords)
-        job = job.run().wait()
+        job = job.run().wait(timeout=timeout)
 
         try:
             job.raise_if_error()


### PR DESCRIPTION
## Description

This exposes the timeout parameter to the `run_async` method, allowing a user to specify a maximum runtime for an asynchronous query before it times out.

This closes issue #720 