### PR TITLE
MAINT: adding the usage of pytest-timeout

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,7 @@ doctest_plus = enabled
 text_file_format = rst
 addopts = --doctest-rst --doctest-continue-on-failure
 remote_data_strict = true
+timeout = 30
 filterwarnings =
     error
     ignore:numpy.ndarray size changed:RuntimeWarning
@@ -78,6 +79,7 @@ test =
     pytest-doctestplus>=0.13
     pytest-astropy
     requests-mock
+    pytest-timeout
 docs =
     sphinx-astropy
 


### PR DESCRIPTION
This is to prevent jobs to hang indefinitely without providing any actual tracebacks, using this to smoke out issues with #731 

