### PR TITLE
BUG: pass on environment variables to CI and revert skipping OSX tests

### DIFF
--- a/pyvo/samp/tests/test_client.py
+++ b/pyvo/samp/tests/test_client.py
@@ -1,7 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import os
-import sys
 import pytest
 
 # By default, tests should not use the internet.
@@ -11,21 +9,16 @@ from pyvo.samp.hub import SAMPHubServer
 from pyvo.samp.hub_proxy import SAMPHubProxy
 from pyvo.samp.integrated_client import SAMPIntegratedClient
 
-CI = os.environ.get("CI", "false") == "true"
-IS_MACOS = sys.platform == "darwin"
-
 
 def setup_module(module):
     conf.use_internet = False
 
 
-@pytest.mark.skipif(IS_MACOS and CI, reason="This test hangs on MacOS GHA.")
 def test_SAMPHubProxy():
     """Test that SAMPHubProxy can be instantiated"""
     SAMPHubProxy()
 
 
-@pytest.mark.skipif(IS_MACOS and CI, reason="This test hangs on MacOS GHA.")
 @pytest.mark.slow
 def test_SAMPClient():
     """Test that SAMPClient can be instantiated"""
@@ -33,7 +26,6 @@ def test_SAMPClient():
     SAMPClient(proxy)
 
 
-@pytest.mark.skipif(IS_MACOS and CI, reason="This test hangs on MacOS GHA.")
 def test_SAMPIntegratedClient():
     """Test that SAMPIntegratedClient can be instantiated"""
     SAMPIntegratedClient()
@@ -48,7 +40,6 @@ def samp_hub():
     my_hub.stop()
 
 
-@pytest.mark.skipif(IS_MACOS and CI, reason="This test hangs on MacOS GHA.")
 @pytest.mark.filterwarnings("ignore:unclosed <socket:ResourceWarning")
 def test_SAMPIntegratedClient_notify_all(samp_hub):
     """Test that SAMP returns a warning if no receiver got the message."""
@@ -60,7 +51,6 @@ def test_SAMPIntegratedClient_notify_all(samp_hub):
     client.disconnect()
 
 
-@pytest.mark.skipif(IS_MACOS and CI, reason="This test hangs on MacOS GHA.")
 def test_reconnect(samp_hub):
     """Test that SAMPIntegratedClient can reconnect.
     This is a regression test for bug [#2673]

--- a/pyvo/samp/tests/test_client.py
+++ b/pyvo/samp/tests/test_client.py
@@ -1,5 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+import os
+import sys
+
 import pytest
 
 # By default, tests should not use the internet.
@@ -8,6 +11,10 @@ from pyvo.samp.client import SAMPClient
 from pyvo.samp.hub import SAMPHubServer
 from pyvo.samp.hub_proxy import SAMPHubProxy
 from pyvo.samp.integrated_client import SAMPIntegratedClient
+
+
+CI = os.environ.get("CI", "false") == "true"
+IS_MACOS = sys.platform == "darwin"
 
 
 def setup_module(module):
@@ -40,6 +47,7 @@ def samp_hub():
     my_hub.stop()
 
 
+@pytest.mark.skipif(IS_MACOS and CI, reason="This test hangs on MacOS GHA.")
 @pytest.mark.filterwarnings("ignore:unclosed <socket:ResourceWarning")
 def test_SAMPIntegratedClient_notify_all(samp_hub):
     """Test that SAMP returns a warning if no receiver got the message."""
@@ -51,6 +59,7 @@ def test_SAMPIntegratedClient_notify_all(samp_hub):
     client.disconnect()
 
 
+@pytest.mark.skipif(IS_MACOS and CI, reason="This test hangs on MacOS GHA.")
 def test_reconnect(samp_hub):
     """Test that SAMPIntegratedClient can reconnect.
     This is a regression test for bug [#2673]

--- a/pyvo/samp/tests/test_hub.py
+++ b/pyvo/samp/tests/test_hub.py
@@ -1,29 +1,22 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import os
 import time
-import sys
 
 import pytest
 
 from pyvo.samp import conf
 from pyvo.samp.hub import SAMPHubServer
 
-CI = os.environ.get("CI", "false") == "true"
-IS_MACOS = sys.platform == "darwin"
-
 
 def setup_module(module):
     conf.use_internet = False
 
 
-@pytest.mark.skipif(IS_MACOS and CI, reason="This test hangs on MacOS GHA.")
 def test_SAMPHubServer():
     """Test that SAMPHub can be instantiated"""
     SAMPHubServer(web_profile=False, mode="multiple", pool_size=1)
 
 
-@pytest.mark.skipif(IS_MACOS and CI, reason="This test hangs on MacOS GHA.")
 @pytest.mark.slow
 def test_SAMPHubServer_run():
     """Test that SAMPHub can be run"""
@@ -33,7 +26,6 @@ def test_SAMPHubServer_run():
     hub.stop()
 
 
-@pytest.mark.skipif(IS_MACOS and CI, reason="This test hangs on MacOS GHA.")
 @pytest.mark.slow
 def test_SAMPHubServer_run_repeated():
     """

--- a/pyvo/samp/tests/test_hub_proxy.py
+++ b/pyvo/samp/tests/test_hub_proxy.py
@@ -16,6 +16,7 @@ def setup_module(module):
     conf.use_internet = False
 
 
+@pytest.mark.skipif(IS_MACOS and CI, reason="This test hangs on MacOS GHA.")
 class TestHubProxy:
     def setup_method(self, method):
         self.hub = SAMPHubServer(web_profile=False, mode="multiple", pool_size=1)

--- a/pyvo/samp/tests/test_hub_proxy.py
+++ b/pyvo/samp/tests/test_hub_proxy.py
@@ -1,6 +1,15 @@
+import os
+import sys
+
+import pytest
+
 from pyvo.samp import conf
 from pyvo.samp.hub import SAMPHubServer
 from pyvo.samp.hub_proxy import SAMPHubProxy
+
+
+CI = os.environ.get("CI", "false") == "true"
+IS_MACOS = sys.platform == "darwin"
 
 
 def setup_module(module):
@@ -35,6 +44,7 @@ class TestHubProxy:
         self.proxy.unregister(result["samp.private-key"])
 
 
+@pytest.mark.skipif(IS_MACOS and CI, reason="This test hangs on MacOS GHA.")
 def test_custom_lockfile(tmp_path):
     lockfile = str(tmp_path / ".samptest")
 

--- a/pyvo/samp/tests/test_hub_proxy.py
+++ b/pyvo/samp/tests/test_hub_proxy.py
@@ -1,18 +1,12 @@
-import sys
-import pytest
-
 from pyvo.samp import conf
 from pyvo.samp.hub import SAMPHubServer
 from pyvo.samp.hub_proxy import SAMPHubProxy
-
-IS_MACOS = sys.platform == "darwin"
 
 
 def setup_module(module):
     conf.use_internet = False
 
 
-@pytest.mark.skipif(IS_MACOS, reason="This test hangs on MacOS.")
 class TestHubProxy:
     def setup_method(self, method):
         self.hub = SAMPHubServer(web_profile=False, mode="multiple", pool_size=1)

--- a/setup.cfg
+++ b/setup.cfg
@@ -93,6 +93,10 @@ pyvo.mivot.tests = data/*.xml, data/input/*.xml, data/output/*.xml, data/referen
 pyvo.dal.tests = data/*.xml, data/*/*
 pyvo.samp = data/astropy_icon.png, data/*xml
 
+[options.entry_points]
+console_scripts =
+    samp_hub = astropy.samp.hub_script:hub_script
+
 [coverage:run]
 source = pyvo
 omit =

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,8 @@ description =
     devdeps: with development version of dependencies
     cov: determine the code coverage
 
+passenv = CI
+
 setenv =
     PYTEST_ARGS = -rsxf --show-capture=no
     online: PYTEST_ARGS = --remote-data=any --reruns=1 --reruns-delay 10 -rsxf --show-capture=no


### PR DESCRIPTION
I separated this one out from #732, so the other one can be backported if needed. The changes here need only affect 1.9 along with the SAMP module.

This works around #731, but I am not convinced that we don't have an actual problem (though I don't see these errors locally on an OSX, they are very consistent for CI)