### PR TITLE
fix: preserve text/plain error body in raise_if_error() after stream is consumed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,11 +4,13 @@
 Enhancements and Fixes
 ----------------------
 
+- Preserve text/plain error body in raise_if_error() after stream is consumed. [#736]
+
 - Provide an API for SoftId-compliant management of the 'User-Agent'
-  header [#719]
+  header. [#719]
 
 - The ``astropy.samp`` module has been relocated and is now accessible under
-  ``pyvo.samp`` [#729]
+  ``pyvo.samp``. [#729]
 
 
 Deprecations and Removals

--- a/pyvo/dal/query.py
+++ b/pyvo/dal/query.py
@@ -211,7 +211,10 @@ class DALQuery(dict):
         try:
             response.raise_for_status()
         except requests.RequestException as ex:
-            # save for later use
+            # Cache the response body before returning the raw stream. If the
+            # caller consumes the stream before calling raise_if_error()
+            # this would lead to an empty error message
+            _ = response.content
             self._ex = ex
 
         return response.raw

--- a/pyvo/dal/query.py
+++ b/pyvo/dal/query.py
@@ -211,11 +211,7 @@ class DALQuery(dict):
         try:
             response.raise_for_status()
         except requests.RequestException as ex:
-            # Cache the response body before returning the raw stream. If the
-            # caller consumes the stream before calling raise_if_error()
-            # this would lead to an empty error message
-            _ = response.content
-            self._ex = ex
+            self._ex = DALServiceError.from_except(ex, self.queryurl)
 
         return response.raw
 
@@ -270,8 +266,7 @@ class DALQuery(dict):
         Raise if there was an error on http level.
         """
         if self._ex:
-            e = self._ex
-            raise DALServiceError.from_except(e, self.queryurl)
+            raise self._ex
 
     @property
     def queryurl(self):

--- a/pyvo/dal/tests/test_query.py
+++ b/pyvo/dal/tests/test_query.py
@@ -94,6 +94,12 @@ def register_mocks(mocker):
                 text='Error', status_code=500
             )),
             stack.enter_context(mocker.register_uri(
+                'GET', 'http://example.com/query/plaintext_error',
+                content=b'No intersection between cutout and image',
+                headers={'Content-Type': 'text/plain; charset=utf-8'},
+                status_code=500
+            )),
+            stack.enter_context(mocker.register_uri(
                 'GET', 'http://example.com/query/errorstatus',
                 content=get_pkg_data_contents('data/query/errorstatus.xml')
             )),
@@ -224,6 +230,14 @@ class TestDALService:
             assert exc.code == 500
         else:
             assert False
+
+    def test_http_exception_message_preserved(self):
+        query = DALQuery('http://example.com/query/plaintext_error')
+        stream = query.execute_stream()
+        stream.read()
+        with pytest.raises(DALServiceError) as exc_info:
+            query.raise_if_error()
+        assert 'No intersection between cutout and image' in str(exc_info.value)
 
     def test_query_exception(self):
         service = DALService('http://example.com/query/errorstatus')


### PR DESCRIPTION
## Description

DALServiceError raised by `raise_if_error` was showing an empty message
Example:
  `DALServiceError:  for https://.../sync`

when the caller used the pattern:
```
data = sq.execute_stream().read()
sq.raise_if_error() 
```

The root cause seemed to be that `execute_stream` returns the raw response stream without reading the body. 
If a caller consumed that stream before calling `raise_if_error` the  `response_text` that `DALServiceError.from_except` reads was empty because presumably the underlying buffer was already exhausted.

## Fix

The fix reads and caches the response body in  the exception handler, before the raw stream is returned to the caller. This ensures response.text remains available when `raise_if_error` is called later regardless of whether the caller has already read the stream.