### PR TITLE
FIX: Change tap to better handle timeout default based on context

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 Enhancements and Fixes
 ----------------------
 
+- Improve handling of timeouts in tap wait and _update [#740]
+
 - Preserve text/plain error body in raise_if_error() after stream is consumed. [#736]
 
 - Provide an API for SoftId-compliant management of the 'User-Agent'

--- a/pyvo/dal/tap.py
+++ b/pyvo/dal/tap.py
@@ -718,7 +718,10 @@ class AsyncTAPJob:
         updates local job infos with remote values
         """
         if timeout is None:
-            timeout = DEFAULT_JOB_POLL_TIMEOUT
+            timeout = (
+                DEFAULT_JOB_WAIT_TIMEOUT if wait_for_statechange
+                else DEFAULT_JOB_POLL_TIMEOUT
+            )
         try:
             if wait_for_statechange:
                 response = self._session.get(
@@ -983,8 +986,9 @@ class AsyncTAPJob:
         ----------
         phases : list
             phases to wait for
-        timeout : float
-            maximum time to wait in seconds
+        timeout : float or None
+            maximum time to wait in seconds. If None, defaults to
+            ``DEFAULT_JOB_WAIT_TIMEOUT``.
 
         Raises
         ------


### PR DESCRIPTION
## Description

So currently and based on recent changes to the tap module, `_update()` resolves a `None` timeout to  `DEFAULT_JOB_POLL_TIMEOUT` (10s) regardless of context.

This may be slightly problematic when a None timeout is passed in to `wait()`, it currently falls through to the 10s poll timeout in `_update()`. This then leads to the timeout exception propagating to wait() which then aborts the job. So any job taking more than 10s would be killed.

We encountered this in our testing workflows where we currently have to add a conditional `if self.query_timeout is not None` to determine whether the timeout param should be passed in which is a bit of extra code it would be nice to avoid having to add.

## Fix

The fix proposed here is to pick the right timeout default when a None is encountered based on the context:
- `wait_for_statechange=True` (long-poll from wait()) -> `DEFAULT_JOB_WAIT_TIMEOUT` (600s)
- `wait_for_statechange=False` (regular status check) -> `DEFAULT_JOB_POLL_TIMEOUT` (10s)

This way passing in a `timeout=None` to `wait()` is safe.


