### PR TITLE
FIX: raise_if_error() to use cached job phase instead of re-polling

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 Enhancements and Fixes
 ----------------------
 
+- Fix raise_if_error() to use cached job phase instead of re-polling [#743]
+
 - Add ``pyvo.registry.get_RegTAP_service_url()`` to allow users to inspect the
   currently configured registry endpoint. Expose other user-facing constants at their package level. [#742]
 

--- a/pyvo/dal/tap.py
+++ b/pyvo/dal/tap.py
@@ -1045,7 +1045,7 @@ class AsyncTAPJob:
         DALQueryError
             if theres an error
         """
-        if self.phase in {"ERROR", "ABORTED"}:
+        if self._job.phase in {"ERROR", "ABORTED"}:
             msg = ""
             if self._job and self._job.errorsummary:
                 msg = self._job.errorsummary.message.content

--- a/pyvo/dal/tap.py
+++ b/pyvo/dal/tap.py
@@ -1047,7 +1047,7 @@ class AsyncTAPJob:
         """
         if self._job.phase in {"ERROR", "ABORTED"}:
             msg = ""
-            if self._job and self._job.errorsummary:
+            if self._job.errorsummary:
                 msg = self._job.errorsummary.message.content
             msg = msg or "<No useful error from server>"
             raise DALQueryError("Query Error: " + msg, self.url)

--- a/pyvo/dal/tests/test_tap.py
+++ b/pyvo/dal/tests/test_tap.py
@@ -617,6 +617,16 @@ class TestTAPService:
             job.raise_if_error()
         assert 'test_erroneus_submit.non_existent not found' in str(e)
 
+    def test_raise_if_error_uses_cached_phase(self, async_fixture):
+        matchers = async_fixture
+        service = TAPService('http://example.com/tap')
+        job = service.submit_job(
+            "SELECT * FROM test_erroneus_submit.non_existent")
+        call_count_before = matchers["job"].call_count
+        with pytest.raises(DALQueryError):
+            job.raise_if_error()
+        assert call_count_before == matchers["job"].call_count
+
     @pytest.mark.usefixtures('async_fixture')
     def test_submit_job_case(self):
         """Test using mixed case in the QUERY parameter to a job.


### PR DESCRIPTION
## Description
`raise_if_error`() currently calls `self.phase`, which triggers `_update()` which causes an extra HTTP request to the job endpoint. However `raise_if_error` is called `wait()` or `run_async()` where the job has already been updated, so it makes sense to use the cached terminal job state from `self._job`

### Tests
Added `test_raise_if_error_uses_cached_phase` which verifies that calling `raise_if_error()` on an errored job does not increase the HTTP request count.