### PR TITLE
FIX: Support VOTableFile in accessible_table and broadcast_samp

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 Enhancements and Fixes
 ----------------------
 
+- Support VOTableFile in accessible_table and broadcast_samp [#745]
+
 - Fix raise_if_error() to use cached job phase instead of re-polling [#743]
 
 - Add ``pyvo.registry.get_RegTAP_service_url()`` to allow users to inspect the

--- a/pyvo/dal/query.py
+++ b/pyvo/dal/query.py
@@ -697,7 +697,7 @@ class DALResults:
         """
         with samp.connection() as conn:
             samp.send_table_to(
-                conn, self.to_table(),
+                conn, self.votable,
                 client_name=client_name, name=self.queryurl)
 
     def cursor(self):

--- a/pyvo/samp/tests/test_vo_helpers.py
+++ b/pyvo/samp/tests/test_vo_helpers.py
@@ -1,0 +1,33 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from astropy.io.votable import parse
+from astropy.io.votable.tree import Info, Param, VOTableFile
+from astropy.table import Table
+from pyvo.samp.vo_helpers import accessible_table
+
+
+def make_votable_with_metadata():
+    """Return a VOTableFile with a PARAM and INFO to verify metadata survives."""
+    vot = VOTableFile()
+    vot.params.append(Param(vot, name="TestParam", value="42", datatype="int"))
+    vot.infos.append(Info(name="TestInfo", value="hello"))
+    return vot
+
+
+def test_accessible_table_with_votable():
+    vot = make_votable_with_metadata()
+    with accessible_table(vot) as url:
+        assert url.startswith("file://")
+        roundtripped = parse(url[len("file://"):])
+
+    assert roundtripped.params[0].name == "TestParam"
+    assert roundtripped.infos[0].name == "TestInfo"
+
+
+def test_accessible_table_with_astropy_table():
+    t = Table({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+    with accessible_table(t) as url:
+        assert url.startswith("file://")
+        roundtripped = parse(url[len("file://"):])
+
+    assert len(roundtripped.get_first_table().array) == 3

--- a/pyvo/samp/vo_helpers.py
+++ b/pyvo/samp/vo_helpers.py
@@ -6,6 +6,8 @@ import contextlib
 import os
 import tempfile
 
+from astropy.io.votable.tree import VOTableFile
+
 from .integrated_client import SAMPIntegratedClient
 
 
@@ -96,7 +98,12 @@ def accessible_table(table):
     """
     handle, f_name = tempfile.mkstemp(suffix=".xml")
     with open(handle, "w") as f:
-        table.write(output=f, format="votable")
+        # This can be removed once the minimum supported version of astropy
+        # is 8.0, as this will have a write method for VOTableFile
+        if isinstance(table, VOTableFile):
+            table.to_xml(f)
+        else:
+            table.write(output=f, format="votable")
     try:
         yield "file://" + f_name
     finally:


### PR DESCRIPTION
This PR is motivated by https://github.com/astropy/pyvo/issues/734 where metadata was lossed in the process of broadcasting TAP results via SAMP as both `broadcast_samp` and  `send_table_to` which both used `to_table()`.

The fix here is to pass the votable directly instead and update accessible_table to handle VOTableFile objects.
There is an associated astropy change here: https://github.com/astropy/astropy/pull/19499 which would add a write method to `VOTableFile` via the unified I/O framework allowing the `isinstance` fallback in `accessible_table` to be removed once that lands.


