### PR TITLE
MivotInstance update

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@
 Enhancements and Fixes
 ----------------------
 
+- Improve ``pyvo.mivot.viewer.%ivotInstance`` (API to allow users to access the mapped data
+  attributes directly as properties of the instance); [#747]
+  - Access to not exiting attribute, e.g. not mappped, returns ``None``
+  - Support DOTS in unit string, e.g. "mas.year_1"
+  
 - Support VOTableFile in accessible_table and broadcast_samp [#745]
 
 - Declaratively define new-style standard IDs in Servicetype constraint [#744]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,7 @@ Enhancements and Fixes
 - Improve ``pyvo.mivot.viewer.%ivotInstance`` (API to allow users to access the mapped data
   attributes directly as properties of the instance); [#747]
   - Access to not exiting attribute, e.g. not mappped, returns ``None``
-  - Support DOTS in unit string, e.g. "mas.year_1"
+  - Support DOTS in unit string, e.g. "mas.year-1"
   
 - Support VOTableFile in accessible_table and broadcast_samp [#745]
 

--- a/pyvo/mivot/tests/test_mivot_instance.py
+++ b/pyvo/mivot/tests/test_mivot_instance.py
@@ -5,6 +5,7 @@ Created on 19 févr. 2024
 @author: michel
 '''
 import pytest
+from copy import deepcopy
 from astropy.table import Table
 from pyvo.mivot.viewer.mivot_instance import MivotInstance
 
@@ -119,6 +120,23 @@ def test_mivot_instance_update():
     mivot_object.update(t[0])
     assert mivot_object.longitude.value == 67.87
     assert mivot_object.latitude.value == -89.87
+
+
+def test_mivot_instance_missing_filed():
+    """Test that the generated class returns None
+    for missing fields instead of raising an error.
+    """
+    mivot_object = MivotInstance(**fake_hk_dict)
+    assert mivot_object.missing_field is None
+
+
+def test_mivot_instance_unit_filtering():
+    """Test that the @@@@@@@@
+    """
+    mydict = deepcopy(fake_hk_dict)
+    mydict["longitude"]["unit"] = "mas.year-1"
+    mivot_object = MivotInstance(**mydict)
+    assert mivot_object.longitude.unit == "mas.year-1"
 
 
 def test_mivot_instance_update_wrong_columns():

--- a/pyvo/mivot/tests/test_mivot_instance.py
+++ b/pyvo/mivot/tests/test_mivot_instance.py
@@ -131,12 +131,25 @@ def test_mivot_instance_missing_filed():
 
 
 def test_mivot_instance_unit_filtering():
-    """Test that the @@@@@@@@
+    """Test that unit are properly read and stored in the class instance.
     """
     mydict = deepcopy(fake_hk_dict)
     mydict["longitude"]["unit"] = "mas.year-1"
     mivot_object = MivotInstance(**mydict)
     assert mivot_object.longitude.unit == "mas.year-1"
+    mydict["dmid"] = "a.b.c"
+    mivot_object = MivotInstance(**mydict)
+
+
+def test_mivot_instance_ref_id():
+    """Test that dmid/ref are properly read and stored in the class instance.
+    """
+    mydict = deepcopy(fake_hk_dict)
+    mydict["longitude"]["ref"] = "ref.b.c"
+    mydict["dmid"] = "id.b.c"
+    mivot_object = MivotInstance(**mydict)
+    assert mivot_object.dmid == "id.b.c"
+    assert mivot_object.longitude.ref == "ref.b.c"
 
 
 def test_mivot_instance_update_wrong_columns():

--- a/pyvo/mivot/tests/test_mivot_instance.py
+++ b/pyvo/mivot/tests/test_mivot_instance.py
@@ -138,6 +138,7 @@ def test_mivot_instance_unit_filtering():
     mivot_object = MivotInstance(**mydict)
     assert mivot_object.longitude.unit == "mas.year-1"
     mydict["dmid"] = "a.b.c"
+    # make sure that no exception are thrown.
     mivot_object = MivotInstance(**mydict)
 
 

--- a/pyvo/mivot/viewer/mivot_instance.py
+++ b/pyvo/mivot/viewer/mivot_instance.py
@@ -41,6 +41,17 @@ class MivotInstance:
         """
         self._create_class(**instance_dict)
 
+    def __getattr__(self, item):
+        """
+        Return None for any attribute that does not exist in the class,
+        except for the attributes that start with "_" which correspond to
+        internal class attributes.
+        This allows to avoid AttributeError when accessing non existing attributes.
+        """
+        if item.startswith("_"):
+            super().__getattr__(item)
+        return None
+
     def __str__(self):
         """
         return  a human readable representation of object
@@ -93,7 +104,7 @@ class MivotInstance:
                 if key == 'value':  # We cast the value read in the row
                     setattr(self, self._remove_model_name(key),
                             MivotUtils.cast_type_value(value, getattr(self, 'dmtype')))
-                elif key not in ["dmtype", "dmrole"]:
+                elif key not in ["dmtype", "dmrole", "unit"]:
                     setattr(self, self._remove_model_name(key), self._remove_model_name(value))
                 else:
                     setattr(self, self._remove_model_name(key), value)

--- a/pyvo/mivot/viewer/mivot_instance.py
+++ b/pyvo/mivot/viewer/mivot_instance.py
@@ -104,14 +104,8 @@ class MivotInstance:
                 if key == 'value':  # We cast the value read in the row
                     setattr(self, self._remove_model_name(key),
                             MivotUtils.cast_type_value(value, getattr(self, 'dmtype')))
-                elif key not in ["dmtype", "dmrole", "unit"]:
-                    setattr(self, self._remove_model_name(key), self._remove_model_name(value))
                 else:
                     setattr(self, self._remove_model_name(key), value)
-
-                if key == 'unit':  # We convert the unit to astropy unit or to astropy time format if possible
-                    # The first Vizier implementation used mas/year for the mapped pm unit: let's correct it
-                    value = value.replace("year", "yr") if value else None
 
     def update(self, row, ref=None):
         """


### PR DESCRIPTION
- FEATURE: Return None when accessing missing attributes, e.g. not mapped model field
- BUG FIX: Support unit strings with a DOT, e.g. ms.year-1