### PR TITLE
Change regtap to only make 2 calls instead of N+1 for get_tables

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 Enhancements and Fixes
 ----------------------
 
+- Change get_tables in regtap.py to use 2 calls instead of N + 1 [#750]
+
 - Clear stale _ex before each execute_stream call [#751]
 
 - Support VOTableFile in accessible_table and broadcast_samp [#745]

--- a/pyvo/registry/regtap.py
+++ b/pyvo/registry/regtap.py
@@ -16,6 +16,7 @@ This module provides basic, low-level access to the RegTAP Registries using
 standardized TAP-based services.
 """
 
+import collections
 import functools
 import itertools
 import os
@@ -1150,26 +1151,31 @@ class RegistryResource(dalq.Record):
             FROM rr.res_table
             WHERE ivoid={}""".format(
                 rtcons.make_sql_literal(self.ivoid)))
+
         if len(tables) > table_limit:
             raise dalq.DALQueryError(f"Resource {self.ivoid} reports"
                                      f" {len(tables)} tables.  Pass a higher table_limit"
                                      " to see them all.")
 
-        res = {}
-        for table_row in tables:
-            columns = svc.run_sync(
-                """
-                SELECT name, ucd, unit, utype, datatype, arraysize,
-                    extended_type, column_description
-                FROM rr.table_column
-                WHERE ivoid={}
-                    AND table_index={}""".format(
-                    rtcons.make_sql_literal(self.ivoid),
-                    rtcons.make_sql_literal(table_row["table_index"])))
-            res[table_row["table_name"]] = self._build_vosi_table(
-                table_row, columns)
+        if len(tables) == 0:
+            return {}
 
-        return res
+        all_columns = svc.run_sync(
+            """SELECT name, ucd, unit, utype, datatype, arraysize,
+                    extended_type, column_description, table_index
+            FROM rr.table_column
+            WHERE ivoid={}""".format(
+                rtcons.make_sql_literal(self.ivoid)))
+
+        columns_by_table = collections.defaultdict(list)
+        for col_row in all_columns:
+            columns_by_table[int(col_row["table_index"])].append(col_row)
+
+        return {
+            table_row["table_name"]: self._build_vosi_table(
+                table_row, columns_by_table[int(table_row["table_index"])])
+            for table_row in tables
+        }
 
 
 @deprecated("1.5", "ivoid2service does not work in the presence of"

--- a/pyvo/registry/regtap.py
+++ b/pyvo/registry/regtap.py
@@ -1165,7 +1165,8 @@ class RegistryResource(dalq.Record):
                     extended_type, column_description, table_index
             FROM rr.table_column
             WHERE ivoid={}""".format(
-                rtcons.make_sql_literal(self.ivoid)))
+                rtcons.make_sql_literal(self.ivoid)),
+            maxrec=1000000)
 
         columns_by_table = collections.defaultdict(list)
         for col_row in all_columns:

--- a/pyvo/registry/regtap.py
+++ b/pyvo/registry/regtap.py
@@ -1127,7 +1127,7 @@ class RegistryResource(dalq.Record):
 
         return res
 
-    def get_tables(self, *, table_limit=20):
+    def get_tables(self, *, table_limit=500):
         """
         return the structure of the tables underlying the service.
 

--- a/pyvo/registry/tests/test_regtap.py
+++ b/pyvo/registry/tests/test_regtap.py
@@ -7,6 +7,7 @@ Tests for pyvo.registry.regtap
 import io
 import re
 from functools import partial
+from unittest.mock import MagicMock, patch
 from urllib.parse import parse_qsl
 
 import pytest
@@ -649,6 +650,55 @@ def _makeRegistryRecord(**overrides):
     }
     defaults.update(overrides)
     return regtap.RegistryResource(_FakeResult(defaults), 0)
+
+
+def _mock_svc(*run_sync_results):
+    svc = MagicMock()
+    svc.run_sync.side_effect = list(run_sync_results)
+    return svc
+
+
+class TestGetTablesUnit:
+    """Unit tests for get_tables."""
+
+    def test_no_tables_returns_empty_dict(self):
+        rsc = _makeRegistryRecord()
+        with patch('pyvo.registry.regtap.get_RegTAP_service',
+                   return_value=_mock_svc([])):
+            assert rsc.get_tables() == {}
+
+    def test_limit_exceeded_raises(self):
+        table_rows = [{"table_name": f"t{i}", "table_description": "",
+                       "table_index": i, "table_title": "", "table_utype": ""}
+                      for i in range(5)]
+        rsc = _makeRegistryRecord()
+        with patch('pyvo.registry.regtap.get_RegTAP_service',
+                   return_value=_mock_svc(table_rows)):
+            with pytest.raises(dalq.DALQueryError, match=r"reports 5 tables"):
+                rsc.get_tables(table_limit=4)
+
+    def test_multiple_tables_columns_grouped_correctly(self):
+        table_rows = [
+            {"table_name": "t1", "table_description": "", "table_index": 1,
+             "table_title": "", "table_utype": ""},
+            {"table_name": "t2", "table_description": "", "table_index": 2,
+             "table_title": "", "table_utype": ""},
+        ]
+        column_rows = [
+            {"name": "c1", "ucd": "", "unit": "", "utype": "", "datatype": "char",
+             "arraysize": "*", "extended_type": "", "column_description": "",
+             "table_index": 1},
+            {"name": "c2", "ucd": "", "unit": "", "utype": "", "datatype": "char",
+             "arraysize": "*", "extended_type": "", "column_description": "",
+             "table_index": 2},
+        ]
+        rsc = _makeRegistryRecord()
+        with patch('pyvo.registry.regtap.get_RegTAP_service',
+                   return_value=_mock_svc(table_rows, column_rows)):
+            result = rsc.get_tables()
+        assert set(result.keys()) == {"t1", "t2"}
+        assert len(result["t1"].columns) == 1
+        assert len(result["t2"].columns) == 1
 
 
 class TestInterfaceRejection:


### PR DESCRIPTION
## Description

`get_tables` issues one TAP query to list a resource's tables, then a separate query *per table* to fetch its columns which leads to O(N) round-trips for a resource with N tables.

This PR replaces that with two queries:
- one for table metadata
- one for all columns of the resource at once
We then group in Python by `table_index`.

## Approach

It would also be possible to do this in a single query with an `LEFT OUTER JOIN` across the two queries,  but I wasn't sure if that is guaranteed to be supported across all RegTAP service implementations.

## Tests

- I haven't added any tests, but I think the existing suite should validate / test this correctly as far as I can see

Any thoughts on whether this approach seems reasonable?