### PR TITLE
FIX: clear stale _ex before each execute_stream call

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 Enhancements and Fixes
 ----------------------
 
+- Clear stale _ex before each execute_stream call [#751]
+
 - Support VOTableFile in accessible_table and broadcast_samp [#745]
 
 - Declaratively define new-style standard IDs in Servicetype constraint [#744]

--- a/pyvo/dal/query.py
+++ b/pyvo/dal/query.py
@@ -206,6 +206,7 @@ class DALQuery(dict):
         No exceptions are raised here because non-2xx responses might still
         contain payload. They can be raised later by calling ``raise_if_error``
         """
+        self._ex = None
         response = self.submit(post=post)
 
         try:

--- a/pyvo/dal/tests/test_query.py
+++ b/pyvo/dal/tests/test_query.py
@@ -302,6 +302,31 @@ class TestDALQuery:
         assert raw.startswith(b'<?xml')
         assert raw.strip().endswith(b'</VOTABLE>')
 
+    def test_execute_stream_clears_stale_ex_on_success(self, mocker):
+        query = DALQuery('http://example.com/query/basic')
+        with mocker.register_uri('GET', '//example.com/query/basic',
+                                 text='Server Error', status_code=500):
+            query.execute_stream()
+        assert query._ex is not None
+
+        with mocker.register_uri('GET', '//example.com/query/basic',
+                                 content=get_pkg_data_contents('data/query/basic.xml')):
+            query.execute_stream()
+        assert query._ex is None
+
+    def test_execute_votable_raises_parse_error_not_stale_http_error(self, mocker):
+        query = DALQuery('http://example.com/query/basic')
+        with mocker.register_uri('GET', '//example.com/query/basic',
+                                 text='Server Error', status_code=500):
+            query.execute_stream()
+        assert query._ex is not None
+
+        with mocker.register_uri('GET', '//example.com/query/basic',
+                                 content=b'not valid votable xml',
+                                 status_code=200):
+            with pytest.raises(DALFormatError):
+                query.execute_votable()
+
 
 @pytest.mark.filterwarnings('ignore::astropy.io.votable.exceptions.W03')
 @pytest.mark.filterwarnings('ignore::astropy.io.votable.exceptions.W06')


### PR DESCRIPTION
## Description

`_ex` was never cleared between `execute_stream` calls, so there was the potential that a stale HTTP error from a previous failed request could mask VOTable parse errors on a later successful one.

## Fix

Reset `self._ex = None` at the start of `execute_stream`