### PR TITLE
docs(README): drop dead VAO website link, point at Wayback snapshot (#748)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,8 +21,10 @@ PyVO is a package providing access to remote data and services of the
 Virtual observatory (VO) using Python.
 
 Its development was launched by the NSF/NASA-funded Virtual Astronomical
-Observatory (VAO, www.usvao.org) project (formerly under the name
-VAOpy) as part of its initiative to bring VO capabilities to desktop.
+Observatory (VAO) project (formerly under the name VAOpy) as part of its
+initiative to bring VO capabilities to desktop. The VAO website has since
+gone offline; an archived snapshot is available at
+https://web.archive.org/web/20190106160759/http://usvao.org/.
 Its goal is to allow astronomers and tool developers to access data and
 services from remote archives and other web resources.  It takes
 advantage of VO standards to give access to thousands of catalogs,


### PR DESCRIPTION
Closes #748.

`www.usvao.org` was the original VAO project website that funded the early development of PyVO. The domain has since lapsed and now resolves to a parking page that fingerprints visitors and offers the domain for sale, which is what the issue reports.

Drop the inline URL from the parenthetical and add a one-line note pointing at the 2019-01-06 Wayback snapshot so the historical project page stays reachable for anyone tracing the package's origins. The surrounding context is preserved as-is.

### Change Type

- [x] Documentation