### PR TITLE
ENH: Change tapregext code to handle proposed use of forMode to allow specifying limits per mode

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,9 @@ Deprecations and Removals
 Enhancements and Fixes
 ----------------------
 
+- Add support for the forMode attribute in TAPRegExt, which allows TAP services 
+  to advertise different limits for different modes [#757]
+  
 - Fix auth methods registered for base URLs being dropped for capability-declared
   sub-paths [#758]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,9 +27,14 @@ Deprecations and Removals
 Enhancements and Fixes
 ----------------------
 
-- Add support for the forMode attribute in TAPRegExt, which allows TAP services 
+- Add support for the forMode attribute in TAPRegExt, which allows TAP services
   to advertise different limits for different modes [#757]
-  
+
+- Change the default ``timeout`` behavior of ``TAPService.run_async``. When
+  ``timeout`` is not specified, it now uses the advertised async
+  ``executionDuration`` default instead of falling back to
+  ``DEFAULT_JOB_WAIT_TIMEOUT``. [#757]
+
 - Fix auth methods registered for base URLs being dropped for capability-declared
   sub-paths [#758]
 

--- a/pyvo/dal/tap.py
+++ b/pyvo/dal/tap.py
@@ -255,6 +255,47 @@ class TAPService(DALService, AvailabilityMixin, CapabilityMixin):
             pass
         raise DALServiceError("Hard limit not exposed by the service")
 
+    def get_maxrec(self, mode=None):
+        """
+        The default output limit for the given mode.
+
+        Parameters
+        ----------
+        mode : str or None
+            The access mode ('sync', 'async', or None for the default limit).
+
+        Raises
+        ------
+        DALServiceError
+            if the property is not exposed by the service
+        """
+        try:
+            return self.get_tap_capability().get_outputlimit(
+                mode).default.content
+        except AttributeError:
+            pass
+        raise DALServiceError("Default limit not exposed by the service")
+
+    def get_hardlimit(self, mode=None):
+        """
+        The hard output limit for the given mode.
+
+        Parameters
+        ----------
+        mode : str or None
+            The access mode ('sync', 'async', or None for the default limit).
+
+        Raises
+        ------
+        DALServiceError
+            if the property is not exposed by the service
+        """
+        try:
+            return self.get_tap_capability().get_outputlimit(mode).hard.content
+        except AttributeError:
+            pass
+        raise DALServiceError("Hard limit not exposed by the service")
+
     @property
     def upload_methods(self):
         """
@@ -299,7 +340,7 @@ class TAPService(DALService, AvailabilityMixin, CapabilityMixin):
 
     def run_async(
             self, query, *, language="ADQL", maxrec=None, uploads=None,
-            delete=True, timeout=DEFAULT_JOB_WAIT_TIMEOUT, **keywords):
+            delete=True, timeout=None, **keywords):
         """
         runs async query and returns its result
 
@@ -316,8 +357,10 @@ class TAPService(DALService, AvailabilityMixin, CapabilityMixin):
             a mapping from table names to objects containing a votable
         delete : bool
             delete the job after fetching the results
-        timeout : float
-            maximum time to wait for job completion in seconds. Default is 600.
+        timeout : float or None
+            maximum time to wait for job completion in seconds. If None,
+            uses the service's advertised async executionDuration,
+            (if available) otherwise use ``DEFAULT_JOB_WAIT_TIMEOUT``.
 
         Returns
         -------
@@ -338,6 +381,13 @@ class TAPService(DALService, AvailabilityMixin, CapabilityMixin):
         --------
         AsyncTAPJob
         """
+        if timeout is None:
+            try:
+                limit = self.get_tap_capability().get_executionduration('async')
+                timeout = float(limit.default) if limit and limit.default else DEFAULT_JOB_WAIT_TIMEOUT
+            except DALServiceError:
+                timeout = DEFAULT_JOB_WAIT_TIMEOUT
+
         job = AsyncTAPJob.create(
             self.baseurl, query, language=language, maxrec=maxrec, uploads=uploads,
             session=self._session, **keywords)

--- a/pyvo/dal/tests/test_tap.py
+++ b/pyvo/dal/tests/test_tap.py
@@ -25,6 +25,7 @@ from pyvo.io.uws.tree import Parameter, Result, ErrorSummary, Message
 from pyvo.auth.authsession import AuthSession
 from pyvo.io.vosi.exceptions import VOSIError
 from pyvo.utils import prototype
+from pyvo.io.vosi.tapregext import TimeLimits, TableAccess
 
 from astropy.time import Time, TimeDelta
 
@@ -564,6 +565,16 @@ class TestTAPService:
         assert service.hardlimit == 10000000
 
     @pytest.mark.usefixtures('capabilities')
+    def test_get_maxrec_no_mode(self):
+        service = TAPService('http://example.com/tap')
+        assert service.get_maxrec() == 20000
+
+    @pytest.mark.usefixtures('capabilities')
+    def test_get_hardlimit_no_mode(self):
+        service = TAPService('http://example.com/tap')
+        assert service.get_hardlimit() == 10000000
+
+    @pytest.mark.usefixtures('capabilities')
     def test_upload_methods(self):
         service = TAPService('http://example.com/tap')
         upload_methods = service.upload_methods
@@ -607,6 +618,28 @@ class TestTAPService:
         _test_image_results(results)
         # make sure that delete was not called
         mock_delete.assert_not_called()
+
+    @pytest.mark.usefixtures('async_fixture')
+    @pytest.mark.filterwarnings("ignore::astropy.io.votable.exceptions.W27")
+    @pytest.mark.filterwarnings("ignore::astropy.io.votable.exceptions.W48")
+    @pytest.mark.filterwarnings("ignore::astropy.io.votable.exceptions.W06")
+    def test_run_async_uses_timeout_from_capabilities(self, monkeypatch):
+
+        service = TAPService('http://example.com/tap')
+        mock_wait = Mock(return_value=Mock(
+            phase='COMPLETED', raise_if_error=Mock(), result=Mock()))
+        monkeypatch.setattr(AsyncTAPJob, "wait", mock_wait)
+
+        async_limit = TimeLimits()
+        async_limit.for_mode = 'async'
+        async_limit._default = 7200
+
+        mock_cap = Mock(spec=TableAccess)
+        mock_cap.get_executionduration = Mock(return_value=async_limit)
+        monkeypatch.setattr(service, "get_tap_capability", Mock(return_value=mock_cap))
+
+        service.run_async("SELECT * FROM ivoa.obscore", delete=False)
+        mock_wait.assert_called_once_with(timeout=7200.0)
 
     @pytest.mark.usefixtures('async_fixture')
     @pytest.mark.filterwarnings("ignore::astropy.io.votable.exceptions.W27")

--- a/pyvo/io/vosi/exceptions.py
+++ b/pyvo/io/vosi/exceptions.py
@@ -362,6 +362,38 @@ class W37(VOSIWarning, XMLWarning):
     message_template = "The dataType element must not occur more than once"
 
 
+class W38(VOSIWarning, XMLWarning):
+    """
+    The `retentionPeriod` element has a duplicate forMode value.
+    """
+    message_template = (
+        "The retentionPeriod element has duplicate forMode: {}")
+
+
+class W39(VOSIWarning, XMLWarning):
+    """
+    The `executionDuration` element has a duplicate forMode value.
+    """
+    message_template = (
+        "The executionDuration element has duplicate forMode: {}")
+
+
+class W40(VOSIWarning, XMLWarning):
+    """
+    The `outputLimit` element has a duplicate forMode value.
+    """
+    message_template = (
+        "The outputLimit element has duplicate forMode: {}")
+
+
+class W41(VOSIWarning, XMLWarning):
+    """
+    The `uploadLimit` element has a duplicate forMode value.
+    """
+    message_template = (
+        "The uploadLimit element has duplicate forMode: {}")
+
+
 class E01(VOSIWarning, XMLWarning, ValueError):
     r"""
     The attribute must be a valid arraysize according to the VOTable standard.

--- a/pyvo/io/vosi/tapregext.py
+++ b/pyvo/io/vosi/tapregext.py
@@ -8,7 +8,7 @@ from ...utils.xml.elements import (
     Element, ContentMixin, xmlelement, xmlattribute)
 from . import voresource as vr
 from .exceptions import (
-    W05, W06, W19, W20, W21, W22, W23, W24, W25, W26, W27, W28, W29, W30, W31,
+    W05, W06, W19, W20, W21, W26, W27, W28, W29, W30, W31, W38, W39, W40, W41,
     E06, E08, E09, VOSIError)
 
 __all__ = [
@@ -126,10 +126,12 @@ class TimeLimits(Element):
 
         self._default = None
         self._hard = None
+        self.for_mode = kwargs.get('forMode', None)
 
     def __repr__(self):
-        return '<TimeLimits default={} hard={}/>'.format(
-            self.default, self.hard)
+        mode = f' forMode={self.for_mode}' if self.for_mode else ''
+        return '<TimeLimits{} default={} hard={}/>'.format(
+            mode, self.default, self.hard)
 
     @xmlelement(plain=True, multiple_exc=W29)
     def default(self):
@@ -146,6 +148,14 @@ class TimeLimits(Element):
     @hard.setter
     def hard(self, hard):
         self._hard = int(hard)
+
+    @xmlattribute(name='forMode')
+    def for_mode(self):
+        return self._for_mode
+
+    @for_mode.setter
+    def for_mode(self, for_mode):
+        self._for_mode = for_mode
 
 
 class LanguageFeature(Element):
@@ -401,13 +411,16 @@ class DataLimits(Element):
 
         self.default = None
         self.hard = None
+        self.for_mode = kwargs.get('forMode', None)
 
     def __repr__(self):
         parts = []
+        if self.for_mode is not None:
+            parts.append(f"forMode={self.for_mode}")
         if self.default is not None:
-            parts.append("default={self.default}")
+            parts.append(f"default={self.default}")
         if self.hard is not None:
-            parts.append("hard={self.hard}")
+            parts.append(f"hard={self.hard}")
         return '<DataLimits {}/>'.format(" ".join(parts))
 
     @xmlelement(cls=DataLimit, multiple_exc=W29)
@@ -425,6 +438,14 @@ class DataLimits(Element):
     @hard.setter
     def hard(self, hard):
         self._hard = hard
+
+    @xmlattribute(name='forMode')
+    def for_mode(self):
+        return self._for_mode
+
+    @for_mode.setter
+    def for_mode(self, for_mode):
+        self._for_mode = for_mode
 
 
 class TAPCapRestriction(vr.Capability):
@@ -448,10 +469,44 @@ class TableAccess(TAPCapRestriction):
         self._languages = HomogeneousList(Language)
         self._outputformats = HomogeneousList(OutputFormat)
         self._uploadmethods = HomogeneousList(UploadMethod)
-        self.retentionperiod = None
-        self.executionduration = None
-        self.outputlimit = None
-        self.uploadlimit = None
+        self._retentionperiods = HomogeneousList(TimeLimits)
+        self._executiondurations = HomogeneousList(TimeLimits)
+        self._outputlimits = HomogeneousList(DataLimits)
+        self._uploadlimits = HomogeneousList(DataLimits)
+
+    @staticmethod
+    def _get_limit_for_mode(limits, mode=None):
+        """
+        Returns the limit for the given mode, or the default if no
+        mode-specific limit is found.  If there is no default, returns None.
+
+        Parameters
+        ----------
+        limits : list of `~pyvo.io.vosi.tapregext.TimeLimits` or
+            list of `~pyvo.io.vosi.tapregext.DataLimits`
+            The limits to search through
+        mode : str or None
+            The mode to search for.  If None, return the default limit.
+        """
+        default = None
+        mode_specific = None
+
+        for limit in limits:
+            if limit.for_mode is None:
+                default = limit
+            elif mode is not None and limit.for_mode.lower() == mode.lower():
+                mode_specific = limit
+        return mode_specific if mode_specific is not None else default
+
+    @staticmethod
+    def _check_duplicate_modes(limits, exc_class, config):
+        seen = set()
+        for limit in limits:
+            key = limit.for_mode
+            if key in seen:
+                warn_or_raise(exc_class, args=(key,), config=config,
+                              pos=limit._pos)
+            seen.add(key)
 
     def describe(self):
         """
@@ -471,37 +526,36 @@ class TableAccess(TAPCapRestriction):
         for uploadmethod in self.uploadmethods:
             uploadmethod.describe()
 
-        if self.retentionperiod:
-            print("Time a job is kept (in seconds)")
-            print(indent(f"Default {self.retentionperiod.default}", INDENT))
-            if self.retentionperiod.hard:
-                print(indent(f"Maximum {self.retentionperiod.hard}", INDENT))
+        for limit in self._retentionperiods:
+            mode = f" ({limit.for_mode})" if limit.for_mode else ""
+            print(f"Time a job is kept (in seconds){mode}")
+            print(indent(f"Default {limit.default}", INDENT))
+            if limit.hard:
+                print(indent(f"Maximum {limit.hard}", INDENT))
             print()
 
-        if self.executionduration:
-            print("Maximal run time of a job")
-            print(indent(f"Default {self.executionduration.default}", INDENT))
-            if self.executionduration.hard:
-                print(indent(f"Maximum {self.executionduration.hard}", INDENT))
+        for limit in self._executiondurations:
+            mode = f" ({limit.for_mode})" if limit.for_mode else ""
+            print(f"Maximal run time of a job{mode}")
+            print(indent(f"Default {limit.default}", INDENT))
+            if limit.hard:
+                print(indent(f"Maximum {limit.hard}", INDENT))
             print()
 
-        if self.outputlimit:
-            print("Maximum size of resultsets")
-            print(indent("Default {} {}".format(
-                self.outputlimit.default.content,
-                self.outputlimit.default.unit), INDENT)
-            )
-            if self.outputlimit.hard:
-                print(indent("Maximum {} {}".format(
-                    self.outputlimit.hard.content, self.outputlimit.hard.unit), INDENT)
-                )
+        for limit in self._outputlimits:
+            mode = f" ({limit.for_mode})" if limit.for_mode else ""
+            print(f"Maximum size of resultsets{mode}")
+            print(indent(f"Default {limit.default.content} {limit.default.unit}", INDENT))
+            if limit.hard:
+                print(indent(f"Maximum {limit.hard.content} {limit.hard.unit}", INDENT))
             print()
 
-        if self.uploadlimit and self.uploadlimit.hard:
-            print("Maximal size of uploads")
-            print(indent("Maximum {} {}".format(
-                self.uploadlimit.hard.content, self.uploadlimit.hard.unit), INDENT))
-            print()
+        for limit in self._uploadlimits:
+            if limit.hard:
+                mode = f" ({limit.for_mode})" if limit.for_mode else ""
+                print(f"Maximal size of uploads{mode}")
+                print(indent(f"Maximum {limit.hard.content} {limit.hard.unit}", INDENT))
+                print()
 
     def get_adql(self):
         """
@@ -541,40 +595,68 @@ class TableAccess(TAPCapRestriction):
         """
         return self._uploadmethods
 
-    @xmlelement(name='retentionPeriod', cls=TimeLimits, multiple_exc=W22)
-    def retentionperiod(self):
+    @xmlelement(name='retentionPeriod', cls=TimeLimits)
+    def retentionperiods(self):
         """Limits on the time between job creation and destruction time."""
-        return self._retentionperiod
+        return self._retentionperiods
 
-    @retentionperiod.setter
-    def retentionperiod(self, retentionperiod):
-        self._retentionperiod = retentionperiod
-
-    @xmlelement(name='executionDuration', cls=TimeLimits, multiple_exc=W23)
-    def executionduration(self):
+    @xmlelement(name='executionDuration', cls=TimeLimits)
+    def executiondurations(self):
         """Limits on executionDuration."""
-        return self._executionduration
+        return self._executiondurations
 
-    @executionduration.setter
-    def executionduration(self, executionduration):
-        self._executionduration = executionduration
-
-    @xmlelement(name='outputLimit', cls=DataLimits, multiple_exc=W24)
-    def outputlimit(self):
+    @xmlelement(name='outputLimit', cls=DataLimits)
+    def outputlimits(self):
         """Limits on the size of data returned."""
-        return self._outputlimit
+        return self._outputlimits
 
-    @outputlimit.setter
-    def outputlimit(self, outputlimit):
-        self._outputlimit = outputlimit
+    @xmlelement(name='uploadLimit', cls=DataLimits)
+    def uploadlimits(self):
+        return self._uploadlimits
 
-    @xmlelement(name='uploadLimit', cls=DataLimits, multiple_exc=W25)
+    def _get_limit_compat(self, limits):
+        """Return the default limit, falling back to the first entry if no
+        default exists."""
+        result = self._get_limit_for_mode(limits)
+        if result is None and limits:
+            return limits[0]
+        return result
+
+    @property
+    def retentionperiod(self):
+        """The default retentionPeriod limit."""
+        return self._get_limit_compat(self._retentionperiods)
+
+    @property
+    def executionduration(self):
+        """The default executionDuration limit."""
+        return self._get_limit_compat(self._executiondurations)
+
+    @property
+    def outputlimit(self):
+        """The default outputLimit."""
+        return self._get_limit_compat(self._outputlimits)
+
+    @property
     def uploadlimit(self):
-        return self._uploadlimit
+        """The default uploadLimit."""
+        return self._get_limit_compat(self._uploadlimits)
 
-    @uploadlimit.setter
-    def uploadlimit(self, uploadlimit, cls=DataLimits):
-        self._uploadlimit = uploadlimit
+    def get_retentionperiod(self, mode=None):
+        """Get retentionPeriod limit for a specific mode."""
+        return self._get_limit_for_mode(self._retentionperiods, mode)
+
+    def get_executionduration(self, mode=None):
+        """Get executionDuration limit for a specific mode."""
+        return self._get_limit_for_mode(self._executiondurations, mode)
+
+    def get_outputlimit(self, mode=None):
+        """Get outputLimit for a specific mode."""
+        return self._get_limit_for_mode(self._outputlimits, mode)
+
+    def get_uploadlimit(self, mode=None):
+        """Get uploadLimit for a specific mode."""
+        return self._get_limit_for_mode(self._uploadlimits, mode)
 
     def parse(self, iterator, config):
         super().parse(iterator, config)
@@ -584,3 +666,8 @@ class TableAccess(TAPCapRestriction):
 
         if not self.outputformats:
             warn_or_raise(W21, W21, config=config, pos=self._pos)
+
+        self._check_duplicate_modes(self.retentionperiods, W38, config)
+        self._check_duplicate_modes(self.executiondurations, W39, config)
+        self._check_duplicate_modes(self.outputlimits, W40, config)
+        self._check_duplicate_modes(self.uploadlimits, W41, config)

--- a/pyvo/io/vosi/tests/data/capabilities/formode-tapregext-template.xml
+++ b/pyvo/io/vosi/tests/data/capabilities/formode-tapregext-template.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<cap:capabilities xmlns:cap="http://www.ivoa.net/xml/VOSICapabilities/v1.0" xmlns:tr="http://www.ivoa.net/xml/TAPRegExt/v1.0" xmlns:vs="http://www.ivoa.net/xml/VODataService/v1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <capability standardID="ivo://ivoa.net/std/VOSI#capabilities">
+    <interface xsi:type="vs:ParamHTTP">
+      <accessURL use="full">http://example.org/tap/capabilities</accessURL>
+    </interface>
+  </capability>
+  <capability standardID="ivo://ivoa.net/std/VOSI#tables">
+    <interface xsi:type="vs:ParamHTTP">
+      <accessURL use="full">http://example.org/tap/tables</accessURL>
+    </interface>
+  </capability>
+  <capability standardID="ivo://ivoa.net/std/TAP" xsi:type="tr:TableAccess">
+    <interface role="std" xsi:type="vs:ParamHTTP">
+      <accessURL use="base">http://example.org/tap</accessURL>
+    </interface>
+    <language>
+      <name>ADQL</name>
+      <version ivo-id="ivo://ivoa.net/std/ADQL#v2.0">2.0</version>
+      <description>ADQL 2.0</description>
+    </language>
+    <outputFormat ivo-id="ivo://ivoa.net/std/TAPRegExt#output-votable-binary">
+      <mime>text/xml</mime>
+    </outputFormat>
+{extra_elements}
+  </capability>
+</cap:capabilities>

--- a/pyvo/io/vosi/tests/test_capabilities.py
+++ b/pyvo/io/vosi/tests/test_capabilities.py
@@ -13,7 +13,7 @@ import pytest
 import pyvo.io.vosi as vosi
 import pyvo.io.vosi.vodataservice as vs
 import pyvo.io.vosi.tapregext as tr
-from pyvo.io.vosi.exceptions import W06
+from pyvo.io.vosi.exceptions import W06, W39
 
 from astropy.utils.data import get_pkg_data_filename
 
@@ -28,6 +28,43 @@ def _parsed_caps():
 def _minimal_tapregext():
     return vosi.parse_capabilities(get_pkg_data_filename(
         "data/capabilities/minimal-tapregext.xml"))
+
+
+def _read_formode_template(extra_elements):
+    with open(get_pkg_data_filename(
+            "data/capabilities/formode-tapregext-template.xml")) as f:
+        return io.BytesIO(
+            f.read().format(extra_elements=extra_elements).encode())
+
+
+@pytest.fixture(name='parsed_formode_tapregext')
+def _formode_tapregext():
+    return vosi.parse_capabilities(_read_formode_template("""\
+    <executionDuration>
+      <default>600</default>
+    </executionDuration>
+    <executionDuration forMode="sync">
+      <default>60</default>
+    </executionDuration>
+    <executionDuration forMode="async">
+      <default>7200</default>
+    </executionDuration>
+    <outputLimit>
+      <default unit="row">10000</default>
+      <hard unit="row">10000</hard>
+    </outputLimit>
+    <outputLimit forMode="async">
+      <default unit="row">1000000</default>
+      <hard unit="row">1000000</hard>
+    </outputLimit>"""))
+
+
+@pytest.fixture(name='parsed_formode_no_default_tapregext')
+def _formode_no_default_tapregext():
+    return vosi.parse_capabilities(_read_formode_template("""\
+    <executionDuration forMode="sync">
+      <default>60</default>
+    </executionDuration>"""))
 
 
 @pytest.mark.usefixtures("parsed_caps")
@@ -165,8 +202,8 @@ class TestMinimalTAPRegExt:
         assert isinstance(parsed_minimal_tapregext[2], tr.TableAccess)
 
     def test_limits(self, parsed_minimal_tapregext):
-        assert parsed_minimal_tapregext[2]._uploadlimit is None
-        assert parsed_minimal_tapregext[2]._outputlimit is None
+        assert parsed_minimal_tapregext[2]._uploadlimits == []
+        assert parsed_minimal_tapregext[2]._outputlimits == []
 
     def test_adql(self, parsed_minimal_tapregext):
         assert parsed_minimal_tapregext[2].get_adql().name == "ADQL"
@@ -245,3 +282,71 @@ class TestFreePrefixes:
     def test_parses_as_tapregext(self, cap_with_free_prefix):
         _, cap = cap_with_free_prefix
         assert isinstance(cap[0], tr.TableAccess)
+
+
+@pytest.mark.usefixtures("parsed_formode_tapregext")
+class TestForModeTAPRegExt:
+    def test_three_execution_durations(self, parsed_formode_tapregext):
+        assert len(parsed_formode_tapregext[2].executiondurations) == 3
+
+    def test_default_execution_duration(self, parsed_formode_tapregext):
+        assert parsed_formode_tapregext[2].executionduration.default == 600
+
+    def test_sync_execution_duration(self, parsed_formode_tapregext):
+        assert parsed_formode_tapregext[2].get_executionduration('sync').default == 60
+
+    def test_async_execution_duration(self, parsed_formode_tapregext):
+        assert parsed_formode_tapregext[2].get_executionduration('async').default == 7200
+
+    def test_for_mode_sync_parsed(self, parsed_formode_tapregext):
+        assert parsed_formode_tapregext[2].get_executionduration('sync').for_mode == 'sync'
+
+    def test_default_no_for_mode(self, parsed_formode_tapregext):
+        assert parsed_formode_tapregext[2].executionduration.for_mode is None
+
+    def test_case_insensitive_lookup(self, parsed_formode_tapregext):
+        assert parsed_formode_tapregext[2].get_executionduration('SYNC').default == 60
+
+    def test_output_limit_default(self, parsed_formode_tapregext):
+        assert parsed_formode_tapregext[2].outputlimit.default.content == 10000
+
+    def test_output_limit_async(self, parsed_formode_tapregext):
+        assert parsed_formode_tapregext[2].get_outputlimit('async').default.content == 1000000
+
+    def test_output_limit_sync_falls_back_to_default(self, parsed_formode_tapregext):
+        assert parsed_formode_tapregext[2].get_outputlimit('sync').default.content == 10000
+
+
+@pytest.mark.usefixtures("parsed_formode_no_default_tapregext")
+class TestForModeNoDefault:
+    def test_compat_property_returns_mode_entry_when_no_default(
+            self, parsed_formode_no_default_tapregext):
+        assert parsed_formode_no_default_tapregext[2].executionduration.default == 60
+
+    def test_explicit_mode_lookup(self, parsed_formode_no_default_tapregext):
+        assert parsed_formode_no_default_tapregext[2].get_executionduration('sync').default == 60
+
+    def test_missing_mode_returns_none(self, parsed_formode_no_default_tapregext):
+        assert parsed_formode_no_default_tapregext[2].get_executionduration('async') is None
+
+
+class TestForModeDuplicate:
+    def test_duplicate_formode_warns(self):
+        with pytest.warns(W39):
+            vosi.parse_capabilities(_read_formode_template("""\
+    <executionDuration forMode="sync">
+      <default>60</default>
+    </executionDuration>
+    <executionDuration forMode="sync">
+      <default>120</default>
+    </executionDuration>"""))
+
+    def test_duplicate_default_warns(self):
+        with pytest.warns(W39):
+            vosi.parse_capabilities(_read_formode_template("""\
+    <executionDuration>
+      <default>600</default>
+    </executionDuration>
+    <executionDuration>
+      <default>1200</default>
+    </executionDuration>"""))

--- a/pyvo/registry/tests/test_rtcons.py
+++ b/pyvo/registry/tests/test_rtcons.py
@@ -47,7 +47,7 @@ class TestAbstractConstraint:
 
 
 class TestSQLLiterals:
-    @pytest.fixture(scope="class", autouse=True)
+    @pytest.fixture(scope="class")
     @classmethod
     def literals(cls):
         class _WithFillers(rtcons.Constraint):


### PR DESCRIPTION
## Description

This is my attempt to provide client support for the proposal to add a `forMode` attribute to capabilities to allow specifying mode-specific (`sync` vs `async`) limits (`executionDuration`, `retentionPeriod`, `outputLimit`, and `uploadLimit`) as written in https://github.com/ivoa-std/TAPRegExt/pull/10.

The current behaviour is that PyvVO will warn if more than 1 of these elements appears, which makes sense for the existing TAPRegExt spec.

Since this is still a PR in `TAPRegExt` I'll leave this as a Draft PR mainly for visibility and discussion. If we don't want this cluttering the PR list I could also move this into an issue and add a comment to refer to the branch with the changes.

## Changes

Limit elements (`executionDuration`, `outputLimit` etc.) are now parsed into lists with new `get_x(mode)` methods for mode-aware getters. 

One place I noticed that can take advantage of these mode-specific limits is the `run_async` timeout, so I've changed that to default to the service's advertised async execution duration as its wait timeout.

## Compatibility

With the approach I've gone with existing code that depends on the singular limit properties (maxrec, and hardlimit) should be fine.