### PR TITLE
FIX: Auth methods registered for base URLs being dropped for capability-declared sub-paths

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@
 
 Enhancements and Fixes
 ----------------------
+
+- Fix auth methods registered for base URLs being dropped for capability-declared sub-paths [#758]
   
 - Change get_tables in regtap.py to use 2 calls instead of N + 1 [#750]
 

--- a/pyvo/auth/authurls.py
+++ b/pyvo/auth/authurls.py
@@ -11,11 +11,36 @@ class AuthURLs():
     AuthURLs helps determine which security method should be used
     with a given URL.  It learns the security methods through the
     VOSI capabilities, which are passed in via update_from_capabilities.
+
+    Three collections are used internally:
+
+    ``full_urls``
+        Exact-match entries, populated when a capability declares
+        ``use="full"``. An exact match takes priority and is
+        returned without consulting any other collection.
+
+    ``_explicit_urls``
+        Prefix-match entries registered by callers via
+        ``add_security_method_for_url``. All matching entries are
+        combined, so a registration for a base URL propagates
+        to every sub-path beneath it.
+
+    ``_capability_urls``
+        Prefix-match entries loaded from VOSI capabilities
+        (``use="base"``).  Only the most-specific (longest) matching
+        entry is used.
+
+    For a given URL ``allowed_auth_methods`` returns the union of:
+
+    1. The ``full_urls`` exact match, if one exists (short-circuits).
+    2. All matching ``_explicit_urls`` entries.
+    3. The single most-specific matching ``_capability_urls`` entry.
     """
 
     def __init__(self):
         self.full_urls = collections.defaultdict(set)
-        self.base_urls = collections.defaultdict(set)
+        self._explicit_urls = collections.defaultdict(set)
+        self._capability_urls = collections.defaultdict(set)
 
     def update_from_capabilities(self, capabilities):
         """
@@ -34,11 +59,11 @@ class AuthURLs():
                     exact = u.use == 'full'
 
                     if not i.securitymethods:
-                        self.add_security_method_for_url(url, securitymethods.ANONYMOUS, exact)
+                        self._add_capability_method(url, securitymethods.ANONYMOUS, exact)
 
                     for sm in i.securitymethods:
                         method = sm.standardid or securitymethods.ANONYMOUS
-                        self.add_security_method_for_url(url, method, exact)
+                        self._add_capability_method(url, method, exact)
 
     def add_security_method_for_url(self, url, security_method, exact=False):
         """
@@ -54,13 +79,20 @@ class AuthURLs():
         security_method : str
             URI of the security method to set
         exact : bool
-            If True, match only this URL.  If false, match all URLs that
-            match this as a base URL.
+            If True, match only this URL.  If False, match all URLs that
+            start with this URL as a base.
         """
         if exact:
             self.full_urls[url].add(security_method)
         else:
-            self.base_urls[url].add(security_method)
+            self._explicit_urls[url].add(security_method)
+
+    def _add_capability_method(self, url, security_method, exact=False):
+        """Store a security method discovered from VOSI capabilities."""
+        if exact:
+            self.full_urls[url].add(security_method)
+        else:
+            self._capability_urls[url].add(security_method)
 
     def allowed_auth_methods(self, url):
         """
@@ -74,42 +106,47 @@ class AuthURLs():
         """
         logging.debug('Determining auth method for %s', url)
 
+        # Exact-match entries take unconditional priority.
         if url in self.full_urls:
             methods = self.full_urls[url]
             logging.debug('Matching full url %s, methods %s', url, methods)
             return methods
 
-        for base_url, methods in self._iterate_base_urls():
-            if url.startswith(base_url):
-                logging.debug('Matching base url %s, methods %s', base_url, methods)
-                return methods
+        methods = set()
+
+        # Union every matching caller-registered prefix.
+        for prefix, prefix_methods in self._sorted(self._explicit_urls):
+            if url.startswith(prefix):
+                logging.debug(
+                    'Matching explicit url %s, methods %s', prefix, prefix_methods
+                )
+                methods.update(prefix_methods)
+
+        # Most-specific capability entry wins, stop at first match.
+        for cap_url, cap_methods in self._sorted(self._capability_urls):
+            if url.startswith(cap_url):
+                logging.debug(
+                    'Matching capability url %s, methods %s', cap_url, cap_methods
+                )
+                methods.update(cap_methods)
+                break
+
+        if methods:
+            return methods
 
         logging.debug('No match, using anonymous auth')
         return {securitymethods.ANONYMOUS}
 
-    def _iterate_base_urls(self):
-        """
-        A generator to sort the base URLs in the correct way
-        to determine the most specific base_url.  This is done
-        by returning them longest to shortest.
-        """
-        def sort_by_len(x):
-            return len(x[0])
-
-        # Sort the base path matching URLs, so that
-        # the longest URLs (the most specific ones, if
-        # there is a tie) are used to determine the
-        # auth method.
-        yield from sorted(self.base_urls.items(),
-                                  key=sort_by_len,
-                                  reverse=True)
+    def _sorted(self, url_dict):
+        """Yield (url, methods) pairs from ``url_dict``, longest URL first."""
+        yield from sorted(url_dict.items(), key=lambda x: len(x[0]), reverse=True)
 
     def __repr__(self):
         urls = []
-
         for url, methods in self.full_urls.items():
             urls.append('Full match:' + url + ':' + str(methods))
-        for url, methods in self._iterate_base_urls():
-            urls.append('Base match:' + url + ':' + str(methods))
-
+        for url, methods in self._sorted(self._explicit_urls):
+            urls.append('Explicit match:' + url + ':' + str(methods))
+        for url, methods in self._sorted(self._capability_urls):
+            urls.append('Capability match:' + url + ':' + str(methods))
         return '\n'.join(urls)

--- a/pyvo/auth/tests/data/tap/tables.xml
+++ b/pyvo/auth/tests/data/tap/tables.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<?xml-stylesheet href='/static/xsl/vosi.xsl' type='text/xsl'?>
+<vtm:tableset xmlns:vs="http://www.ivoa.net/xml/VODataService/v1.1" xmlns:vtm="http://www.ivoa.net/xml/VOSITables/v1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.ivoa.net/xml/VODataService/v1.1 http://vo.ari.uni-heidelberg.de/docs/schemata/VODataService-v1.1.xsd http://www.ivoa.net/xml/VOSITables/v1.0 http://vo.ari.uni-heidelberg.de/docs/schemata/VOSITables-v1.0.xsd">
+  <schema>
+    <name>test</name>
+    <description>This is a unittest schema</description>
+    <table>
+      <name>test.table1</name>
+    </table>
+    <table>
+      <name>test.table2</name>
+    </table>
+  </schema>
+</vtm:tableset>

--- a/pyvo/auth/tests/test_auth.py
+++ b/pyvo/auth/tests/test_auth.py
@@ -13,8 +13,11 @@ from astropy.utils.data import get_pkg_data_contents
 
 import pyvo.dal
 from pyvo.auth.authsession import AuthSession
+from pyvo.auth.authurls import AuthURLs
+from pyvo.auth import securitymethods
 
 from pyvo.dal.tests.test_tap import MockAsyncTAPServer
+from pyvo.utils.http import create_session
 
 
 @pytest.fixture(name='security_methods')
@@ -96,6 +99,18 @@ def basic_auth_service(mocker):
     yield from MockBasicAuthTAPServer().use(mocker)
 
 
+@pytest.fixture()
+def bearer_token_tables(mocker):
+    def callback(request, context):
+        assert request.headers.get('Authorization', None) == 'Bearer mytoken'
+        return get_pkg_data_contents('data/tap/tables.xml').encode('utf-8')
+
+    with mocker.register_uri(
+        'GET', 'http://example.com/tap/tables', content=callback
+    ):
+        yield
+
+
 @pytest.mark.usefixtures('cookie_auth_service', 'auth_capabilities')
 @pytest.mark.parametrize('security_methods', [[None, 'ivo://ivoa.net/sso#cookie']])
 @pytest.mark.filterwarnings("ignore::astropy.io.votable.exceptions.W27")
@@ -158,6 +173,90 @@ def test_negotiation():
     session.credentials.set_cookie('TEST_COOKIE', 'BADCOOKIE')
     service = pyvo.dal.TAPService('http://example.com/tap', session=session)
     service.run_async("SELECT * FROM ivoa.obscore")
+
+
+class TestAuthURLs:
+    """Unit tests for AuthURLs prefix/capability matching semantics."""
+
+    def test_capability_does_not_override_prefix_registration(self):
+        auth = AuthURLs()
+        auth.add_security_method_for_url('http://example.com/tap', 'custom-token')
+        auth._add_capability_method(
+            'http://example.com/tap/tables', 'ivo://ivoa.net/sso#cookie'
+        )
+
+        methods = auth.allowed_auth_methods('http://example.com/tap/tables')
+        assert 'custom-token' in methods
+        assert 'ivo://ivoa.net/sso#cookie' in methods
+
+    def test_prefix_registration_propagates_to_all_subpaths(self):
+        auth = AuthURLs()
+        auth.add_security_method_for_url('http://example.com/tap', 'custom-token')
+
+        for sub in ('/sync', '/async', '/tables', '/tables/schema'):
+            methods = auth.allowed_auth_methods(
+                'http://example.com/tap' + sub
+            )
+            assert 'custom-token' in methods, f"missing for {sub}"
+
+    def test_multiple_prefix_registrations_are_unioned(self):
+        auth = AuthURLs()
+        auth.add_security_method_for_url('http://example.com/tap', 'token-a')
+        auth.add_security_method_for_url('http://example.com/tap/v2', 'token-b')
+
+        methods = auth.allowed_auth_methods('http://example.com/tap/v2/sync')
+        assert 'token-a' in methods
+        assert 'token-b' in methods
+
+    def test_most_specific_capability_wins_over_less_specific(self):
+        auth = AuthURLs()
+        auth._add_capability_method(
+            'http://example.com/tap', 'ivo://ivoa.net/sso#cookie'
+        )
+        auth._add_capability_method(
+            'http://example.com/tap/tables', 'ivo://ivoa.net/sso#BasicAA'
+        )
+
+        methods = auth.allowed_auth_methods('http://example.com/tap/tables')
+        assert 'ivo://ivoa.net/sso#BasicAA' in methods
+        assert 'ivo://ivoa.net/sso#cookie' not in methods
+
+    def test_exact_match_overrides_all(self):
+        auth = AuthURLs()
+        auth.add_security_method_for_url('http://example.com/tap', 'custom-token')
+        auth._add_capability_method(
+            'http://example.com/tap/tables', 'ivo://ivoa.net/sso#cookie'
+        )
+        auth.add_security_method_for_url(
+            'http://example.com/tap/tables', securitymethods.ANONYMOUS, exact=True
+        )
+
+        methods = auth.allowed_auth_methods('http://example.com/tap/tables')
+        assert methods == {securitymethods.ANONYMOUS}
+
+    def test_no_match_returns_anonymous(self):
+        auth = AuthURLs()
+        methods = auth.allowed_auth_methods('http://example.com/unknown')
+        assert methods == {securitymethods.ANONYMOUS}
+
+
+@pytest.mark.usefixtures('bearer_token_tables', 'auth_capabilities')
+@pytest.mark.parametrize('security_methods', [
+    ['ivo://ivoa.net/sso#BasicAA',
+     'ivo://ivoa.net/sso#cookie',
+     'ivo://ivoa.net/sso#OAuth']
+])
+@pytest.mark.filterwarnings("ignore::astropy.io.votable.exceptions.W27")
+@pytest.mark.filterwarnings("ignore::astropy.io.votable.exceptions.W48")
+@pytest.mark.filterwarnings("ignore::astropy.io.votable.exceptions.W06")
+def test_bearer_token_auth():
+    session = AuthSession()
+    credentials = create_session()
+    credentials.headers["Authorization"] = "Bearer mytoken"
+    session.credentials.set("my-token", credentials)
+    session.add_security_method_for_url("http://example.com/tap", "my-token")
+    service = pyvo.dal.TAPService('http://example.com/tap', session=session)
+    _ = service.tables
 
 
 @pytest.mark.usefixtures('anon_auth_service', 'auth_capabilities')


### PR DESCRIPTION
## Description

This PR is my attempt to address issue #749 where non-IVOA recognized authentication methods added by the users via `add_security_method_for_url` (e.g. bearer tokens) are replaced by auth methods declared in the VOSI capabilities for more specific sub-paths (/tap/tables). Auth fails in this case as the client's custom credentials are no longer in the list of available methods.

## Cause

`AuthURLs` stored both caller registrations and capability-discovered methods in the same `base_urls` dict, then used longest-match to pick one entry. 
A capability entry for `/tap/tables` would win over the caller's /tap registration, discarding it entirely.

## Fix

The fix proposed here is to split the `base_urls` into two collections:
- `_explicit_urls` : Caller registrations via `add_security_method_for_url`. Methods registered for a base URL apply to all URLs beneath it.
-  `_capability_urls`: Populated from VOSI capabilities, only the most-specific (longest) matching entry is used

## Tests
Added a few tests covering the various related use-cases

Fixes: https://github.com/astropy/pyvo/issues/749