### PR TITLE
FIX: Corrections to the TAPResults documentation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 Enhancements and Fixes
 ----------------------
 
+- Corrections to the TAPResults documentation [#760]
+
 - Fix auth methods registered for base URLs being dropped for capability-declared sub-paths [#758]
 
 - Fix W19 when deep-copying ``TAPService`` (and other objects using

--- a/pyvo/dal/tap.py
+++ b/pyvo/dal/tap.py
@@ -1237,15 +1237,15 @@ class TAPQuery(DALQuery):
 
 class TAPResults(DatalinkResultsMixin, DALResults):
     """
-    The list of matching images resulting from an image (SIA) query.
+    The list of records resulting from a TAP query.
     Each record contains a set of metadata that describes an available
-    image matching the query constraints.  The number of records in
+    result matching the query constraints.  The number of records in
     the results is available by passing it to the Python built-in ``len()`` function.
 
     This class supports iterable semantics; thus,
     individual records (in the form of
     :py:class:`~pyvo.dal.Record` instances) are typically
-    accessed by iterating over an ``TAPResults`` instance.
+    accessed by iterating over a ``TAPResults`` instance.
 
     Alternatively, records can be accessed randomly via
     :py:meth:`getrecord` or through a Python Database API (v2)
@@ -1256,7 +1256,7 @@ class TAPResults(DatalinkResultsMixin, DALResults):
     ``TAPResults`` is essentially a wrapper around an Astropy
     :py:mod:`~astropy.io.votable`
     :py:class:`~astropy.io.votable.tree.TableElement` instance where the
-    columns contain the various metadata describing the images.
+    columns contain the various metadata describing the query results.
     One can access that VOTable directly via the
     :py:attr:`pyvo.dal.DALResults.votable` attribute.  Thus,
     when one retrieves a whole column via
@@ -1267,7 +1267,7 @@ class TAPResults(DatalinkResultsMixin, DALResults):
 
     ``table = results.to_table``
 
-    ``SIAResults`` supports the array item operator ``[...]`` in a
+    ``TAPResults`` supports the array item operator ``[...]`` in a
     read-only context.  When the argument is numerical, the result
     is an
     :py:class:`~pyvo.dal.Record` instance, representing the
@@ -1296,7 +1296,7 @@ class TAPResults(DatalinkResultsMixin, DALResults):
         return a representation of a tap result record that follows
         dictionary semantics. The keys of the dictionary are those returned by
         this instance's fieldnames attribute. The returned record has
-        additional image-specific properties
+        additional TAP-specific properties
 
         Parameters
         ----------
@@ -1306,7 +1306,7 @@ class TAPResults(DatalinkResultsMixin, DALResults):
 
         Returns
         -------
-        REc
+        TAPRecord
            a dictionary-like wrapper containing the result record metadata.
 
         Raises


### PR DESCRIPTION
I think the doc string for the `TAPResults` method was copied over so it still refers to SIA query information.
PR updates the documentation accordingly. 