### PR TITLE
MAINT: be explicit about pytest-astropy minimum required version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -77,7 +77,7 @@ all =
     defusedxml
 test =
     pytest-doctestplus>=0.13
-    pytest-astropy
+    pytest-astropy>=0.6
     requests-mock
     pytest-timeout
 docs =


### PR DESCRIPTION
For some unknown reason CI is throwing a hissy fit and picks up an ancient v0.5 version of pytest-astropy. So this PR fixes the minimum version requirement -- we use astropy-header which was added there as a dependency in 0.6

I'll backport this to 1.9.1 as it in fact fixes a packaging bug.