### PR TITLE
feat: add RegistryResource.validate() for on-demand test query execution

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@
 Enhancements and Fixes
 ----------------------
 
+- Add ``RegistryResource.validate()`` to execute a resource's registered
+  test query on demand and return a ``ValidateResult`` with ``success``,
+  ``response_time_seconds``, and ``status_code`` fields. [#766]
+
 
 Deprecations and Removals
 -------------------------

--- a/pyvo/registry/regtap.py
+++ b/pyvo/registry/regtap.py
@@ -21,6 +21,7 @@ import functools
 import itertools
 import os
 import textwrap
+import time
 import warnings
 
 from astropy import table
@@ -29,6 +30,8 @@ from astropy.utils.exceptions import AstropyDeprecationWarning
 
 import numpy
 
+import requests
+
 from . import rtcons
 from ..dal import scs, sia, sia2, ssa, sla, tap, query as dalq
 from ..io.vosi import vodataservice
@@ -36,7 +39,10 @@ from ..utils.formatting import para_format_desc
 
 
 __all__ = ["search", "get_RegTAP_query", "get_RegTAP_service_url", "Interface",
-           "RegistryResource", "RegistryResults", "ivoid2service"]
+           "RegistryResource", "RegistryResults", "ivoid2service", "ValidateResult"]
+
+ValidateResult = collections.namedtuple(
+    "ValidateResult", ["success", "response_time_seconds", "status_code"])
 
 REGISTRY_BASEURL = os.environ.get("IVOA_REGISTRY", "http://reg.g-vo.org/tap"
                                   ).rstrip("/")
@@ -1089,6 +1095,98 @@ class RegistryResource(dalq.Record):
             FROM rr.alt_identifier
             WHERE ivoid={}""".format(rtcons.make_sql_literal(self.ivoid)))
         return [r["alt_identifier"] for r in res]
+
+    def validate(self, session=None):
+        """Execute the resource's registered test query and report the outcome.
+
+        Many registry entries carry a ``testQuery`` element that encodes a
+        known-working example request for the service.  This method assembles
+        that request from the registry, executes it via an HTTP GET, and
+        returns a `ValidateResult` named tuple with three fields:
+
+        * ``success`` (`bool`) - ``True`` when the server replied with
+          HTTP 200, ``False`` otherwise.
+        * ``response_time_seconds`` (`float`) - round-trip wall-clock time
+          measured with `time.monotonic`.
+        * ``status_code`` (`int`) - the HTTP status code returned by the
+          server (e.g. 200, 404, 500).
+
+        Parameters
+        ----------
+        session : requests.Session, optional
+            An existing requests session to use for the HTTP call.  If
+            *None* (the default) a fresh pyvo session is created.
+
+        Returns
+        -------
+        `ValidateResult`
+
+        Raises
+        ------
+        `pyvo.dal.DALQueryError`
+            If the resource has no test query registered in the registry,
+            or if no standard interface with an access URL can be found.
+
+        Examples
+        --------
+        >>> result = resource.validate()   # doctest: +SKIP
+        >>> print(result.success, result.response_time_seconds)  # doctest: +SKIP
+        True 0.42
+        """
+        from ..utils.http import use_session
+
+        # Fetch testQuery params for this resource from the registry.
+        # The registry stores individual testQuery sub-elements as separate
+        # rows in rr.res_detail using XPaths like
+        # /capability/testQuery/ra, /capability/testQuery/dec, etc.
+        # We join with rr.interface to get the access URL for the matching
+        # capability so we can assemble the full request URL.
+        res = get_RegTAP_service().run_sync("""
+            SELECT rd.detail_xpath, rd.detail_value, i.access_url
+            FROM rr.res_detail rd
+            JOIN rr.interface i
+              ON i.ivoid = rd.ivoid
+             AND i.cap_index = rd.cap_index
+            WHERE rd.ivoid = {}
+              AND rd.detail_xpath LIKE '/capability/testQuery/%'
+              AND i.intf_role = 'std'
+        """.format(rtcons.make_sql_literal(self.ivoid)))
+
+        rows = list(res)
+        if not rows:
+            raise dalq.DALQueryError(
+                "Resource {} has no test query registered in the"
+                " registry.".format(self.ivoid))
+
+        # Collect the testQuery parameter name/value pairs and the
+        # access URL (all rows share the same access URL).
+        access_url = str(rows[0]["access_url"])
+        params = {}
+        for row in rows:
+            # XPath looks like /capability/testQuery/<param_name>
+            xpath = str(row["detail_xpath"])
+            param_name = xpath.rsplit("/", 1)[-1]
+            params[param_name] = str(row["detail_value"])
+
+        # Assemble the request URL by appending params to the access URL.
+        # Some access URLs already end in '?' or '&'; requests handles
+        # encoding, but we need to pass params separately so existing
+        # query-string fragments in the base URL are preserved.
+        session = use_session(session)
+        t0 = time.monotonic()
+        try:
+            response = session.get(access_url, params=params)
+        except requests.RequestException as exc:
+            raise dalq.DALQueryError(
+                "HTTP request for test query of {} failed: {}".format(
+                    self.ivoid, exc)) from exc
+        elapsed = time.monotonic() - t0
+
+        return ValidateResult(
+            success=response.status_code == 200,
+            response_time_seconds=elapsed,
+            status_code=response.status_code,
+        )
 
     def _build_vosi_column(self, column_row):
         """

--- a/pyvo/registry/tests/test_regtap.py
+++ b/pyvo/registry/tests/test_regtap.py
@@ -782,6 +782,109 @@ def test_get_alt_identifier():
     }
 
 
+class TestValidate:
+    """Unit tests for RegistryResource.validate()."""
+
+    _IVOID = "ivo://example.org/svc/cone"
+
+    def _make_detail_rows(self, access_url):
+        """Return a list of mock registry detail rows for a SCS testQuery."""
+        return [
+            {"detail_xpath": "/capability/testQuery/ra",
+             "detail_value": "10.0",
+             "access_url": access_url},
+            {"detail_xpath": "/capability/testQuery/dec",
+             "detail_value": "-20.0",
+             "access_url": access_url},
+            {"detail_xpath": "/capability/testQuery/sr",
+             "detail_value": "0.01",
+             "access_url": access_url},
+        ]
+
+    def test_success(self):
+        """validate() returns success=True when the server replies 200."""
+        access_url = "http://example.org/cone?"
+        rows = self._make_detail_rows(access_url)
+        rsc = _makeRegistryRecord(ivoid=self._IVOID)
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+
+        with patch('pyvo.registry.regtap.get_RegTAP_service',
+                   return_value=_mock_svc(rows)):
+            with patch('pyvo.registry.regtap.requests.Session.get',
+                       return_value=mock_response):
+                with patch('pyvo.utils.http.create_session') as mock_create:
+                    mock_session = MagicMock()
+                    mock_session.get.return_value = mock_response
+                    mock_create.return_value = mock_session
+                    result = rsc.validate()
+
+        assert result.success is True
+        assert result.status_code == 200
+        assert result.response_time_seconds >= 0.0
+
+    def test_no_test_query_raises(self):
+        """validate() raises DALQueryError when no testQuery is registered."""
+        rsc = _makeRegistryRecord(ivoid=self._IVOID)
+
+        with patch('pyvo.registry.regtap.get_RegTAP_service',
+                   return_value=_mock_svc([])):
+            with pytest.raises(dalq.DALQueryError,
+                               match="no test query registered"):
+                rsc.validate()
+
+    def test_http_error_returns_failure(self):
+        """validate() returns success=False when the server replies with a non-200 code."""
+        access_url = "http://example.org/cone?"
+        rows = self._make_detail_rows(access_url)
+        rsc = _makeRegistryRecord(ivoid=self._IVOID)
+
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+
+        with patch('pyvo.registry.regtap.get_RegTAP_service',
+                   return_value=_mock_svc(rows)):
+            with patch('pyvo.utils.http.create_session') as mock_create:
+                mock_session = MagicMock()
+                mock_session.get.return_value = mock_response
+                mock_create.return_value = mock_session
+                result = rsc.validate()
+
+        assert result.success is False
+        assert result.status_code == 500
+        assert result.response_time_seconds >= 0.0
+
+    def test_response_time_is_positive_float(self):
+        """validate() returns a non-negative float for response_time_seconds."""
+        access_url = "http://example.org/cone?"
+        rows = self._make_detail_rows(access_url)
+        rsc = _makeRegistryRecord(ivoid=self._IVOID)
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+
+        with patch('pyvo.registry.regtap.get_RegTAP_service',
+                   return_value=_mock_svc(rows)):
+            with patch('pyvo.utils.http.create_session') as mock_create:
+                mock_session = MagicMock()
+                mock_session.get.return_value = mock_response
+                mock_create.return_value = mock_session
+                result = rsc.validate()
+
+        assert isinstance(result.response_time_seconds, float)
+        assert result.response_time_seconds >= 0.0
+
+    @pytest.mark.remote_data
+    def test_remote_validate(self):
+        """validate() returns a ValidateResult for a known-good live registry resource."""
+        rsc = _makeRegistryRecord(
+            ivoid="ivo://irsa.ipac/planck/catalog/pr2_sz_pws")
+        result = rsc.validate()
+        assert isinstance(result, regtap.ValidateResult)
+        assert result.response_time_seconds > 0.0
+
+
 @pytest.mark.remote_data
 class TestDatamodelQueries:
     # right now, the data model queries are all rather sui generis, and


### PR DESCRIPTION
## Summary

This PR adds `RegistryResource.validate()`, a new method that executes a service's registered `testQuery` on demand and reports whether the service is reachable and how long it took to respond.

## Why this matters

Most IVOA registry entries publish a `testQuery` - a known-working example request intended for validation. Today pyvo has no way to invoke it, so users who want to check service liveness or compare latency across candidate services must hand-roll their own HTTP calls. This is especially useful for HAT workflows where several equivalent services may be available and the best one depends on network proximity. The maintainer (bsipocz, MEMBER) confirmed this direction on 2026-06-11 as part of broader pyvo support for HATs.

## How it works

`validate()` follows the same remote-query pattern as `get_contact()`: it calls `get_RegTAP_service().run_sync()` to fetch the resource's testQuery parameters from `rr.res_detail` (joined to `rr.interface` to get the access URL), assembles the full request URL, performs an HTTP GET timed with `time.monotonic()`, and returns a `ValidateResult` namedtuple with `success`, `response_time_seconds`, and `status_code`. If no testQuery is registered, a `DALQueryError` is raised with an informative message. The `ValidateResult` type is exported in `__all__` for discoverability. Four unit tests cover the happy path, the no-testQuery case, an HTTP error response, and the return type of `response_time_seconds`.

Fixes #766
