### PR TITLE
CI: temporarily upper pin for pytest

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -76,6 +76,7 @@ all =
     pillow
     defusedxml
 test =
+    pytest<9.1
     pytest-doctestplus>=0.13
     pytest-astropy>=0.6
     requests-mock


### PR DESCRIPTION
This should do a temporarily fix for failing CI jobs (see #768), I'll deal with it properly when I'm back from holidays.