### PR TITLE
Fix pytest 9.1 compatibility

### DIFF
--- a/pyvo/registry/tests/test_rtcons.py
+++ b/pyvo/registry/tests/test_rtcons.py
@@ -48,7 +48,8 @@ class TestAbstractConstraint:
 
 class TestSQLLiterals:
     @pytest.fixture(scope="class", autouse=True)
-    def literals(self):
+    @classmethod
+    def literals(cls):
         class _WithFillers(rtcons.Constraint):
             _fillers = {
                 "aString": "some harmless stuff",

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,7 +76,7 @@ all =
     pillow
     defusedxml
 test =
-    pytest<9.1
+    pytest
     pytest-doctestplus>=0.13
     pytest-astropy>=0.6
     requests-mock


### PR DESCRIPTION
Use @classmethod for class-scoped fixture in TestSQLLiterals to fix PytestRemovedIn10Warning promoted to error by filterwarnings = error.