### PR TITLE
Pass session when creating `VOSITables` objects

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,13 @@ Deprecations and Removals
 1.9.2 (unreleased)
 ==================
 
-- no changes yet
+Enhancements and Fixes
+----------------------
+
+- Fix a bug where a custom session (including authentication configuration) was
+  not propagated when retrieving tables with the ``TAPService.tables``
+  property. [#772]
+
 
 1.9.1 (2026-06-11)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,11 @@ Enhancements and Fixes
   not propagated when retrieving tables with the ``TAPService.tables``
   property. [#772]
 
+Deprecations and Removals
+-------------------------
+
+  - Remove ``dal.vosi.TablesMixin``. It is no longer used anywhere. It creates a ``VOSITables`` object without propagating the existing session, and there is no clear way to fix it. It was added in https://github.com/astropy/pyvo/commit/72005872b8148fd3fee8571b357d0cbcf089d1de and all usages of it were removed in https://github.com/astropy/pyvo/commit/e71a8e3f08ef0300cd68316023bc09b186ac4ea0 on Jan 9, 2018.
+
 
 1.9.1 (2026-06-11)
 ==================

--- a/pyvo/dal/tap.py
+++ b/pyvo/dal/tap.py
@@ -177,7 +177,7 @@ class TAPService(DALService, AvailabilityMixin, CapabilityMixin):
             response.raw.read = partial(response.raw.read, decode_content=True)
 
             self._tables = VOSITables(
-                vosi.parse_tables(response.raw.read), tables_url)
+                vosi.parse_tables(response.raw.read), tables_url, session=self._session)
         return self._tables
 
     def _parse_examples(self, examples_uri, *, depth=0):

--- a/pyvo/dal/tests/test_tap.py
+++ b/pyvo/dal/tests/test_tap.py
@@ -395,33 +395,53 @@ def async_fixture_with_timeout(mocker):
     yield from mock_server.use(mocker)
 
 
-@pytest.fixture()
-def tables(mocker):
-    def callback_tables(request, context):
-        return get_pkg_data_contents('data/tap/tables.xml')
+def make_tables_fixture(custom_auth=False):
+    """
+    Returns and registers a pytest fixture to expect tables HTTP calls.
 
-    def callback_table1(request, context):
-        return get_pkg_data_contents('data/tap/lazy-table1.xml')
+    If custom_auth is true, then an auth header will be expected in all calls.
+    """
+    kwargs = {}
+    if custom_auth:
+        kwargs['request_headers'] = {'Authorization': 'Bearer some-token'}
 
-    def callback_table2(request, context):
-        return get_pkg_data_contents('data/tap/lazy-table2.xml')
+    def fixture(mocker, request):
+        def callback_tables(request, context):
+            return get_pkg_data_contents('data/tap/tables.xml')
 
-    with ExitStack() as stack:
-        matchers = {
-            'tables': stack.enter_context(mocker.register_uri(
-                'GET', 'http://example.com/tap/tables', content=callback_tables
-            )),
-            'table1': stack.enter_context(mocker.register_uri(
-                'GET', 'http://example.com/tap/tables/test.table1',
-                content=callback_table1
-            )),
-            'table2': stack.enter_context(mocker.register_uri(
-                'GET', 'http://example.com/tap/tables/test.table2',
-                content=callback_table2
-            )),
-        }
+        def callback_table1(request, context):
+            return get_pkg_data_contents('data/tap/lazy-table1.xml')
 
-        yield matchers
+        def callback_table2(request, context):
+            return get_pkg_data_contents('data/tap/lazy-table2.xml')
+
+        with ExitStack() as stack:
+            matchers = {
+                'tables': stack.enter_context(mocker.register_uri(
+                    'GET', 'http://example.com/tap/tables', content=callback_tables,
+                    **kwargs
+                )),
+                'table1': stack.enter_context(mocker.register_uri(
+                    'GET', 'http://example.com/tap/tables/test.table1',
+                    content=callback_table1, **kwargs
+                )),
+                'table2': stack.enter_context(mocker.register_uri(
+                    'GET', 'http://example.com/tap/tables/test.table2',
+                    content=callback_table2, **kwargs
+                )),
+            }
+
+            yield matchers
+
+    return pytest.fixture(fixture)
+
+
+tables = make_tables_fixture()
+"""A fixture to expect tables HTTP requests with no auth."""
+
+
+tables_custom_auth = make_tables_fixture(custom_auth=True)
+"""A fixture to expect tables HTTP requests with auth."""
 
 
 @pytest.fixture()
@@ -517,7 +537,13 @@ class TestTAPService:
         assert service.capability_description == description
         assert str(service) == f"""TAPService(baseurl : '{url}', description : '{description}')"""
 
-    def _test_tables(self, table1, table2):
+    def _test_tables(self, vositables):
+        assert list(vositables.keys()) == ['test.table1', 'test.table2']
+
+        assert "test.table1" in vositables
+        assert "any.random.stuff" not in vositables
+
+        table1, table2 = list(vositables)
         assert table1.description == 'Lazy Test Table 1'
         assert table1.title == 'Test table 1'
 
@@ -527,15 +553,14 @@ class TestTAPService:
     @pytest.mark.usefixtures('tables')
     def test_tables(self):
         service = TAPService('http://example.com/tap')
-        vositables = service.tables
+        self._test_tables(service.tables)
 
-        assert list(vositables.keys()) == ['test.table1', 'test.table2']
-
-        assert "test.table1" in vositables
-        assert "any.random.stuff" not in vositables
-
-        table1, table2 = list(vositables)
-        self._test_tables(table1, table2)
+    @pytest.mark.usefixtures('tables_custom_auth')
+    def test_tables_custom_auth(self):
+        session = requests.Session()
+        session.headers = {'Authorization': 'Bearer some-token'}
+        service = TAPService('http://example.com/tap', session=session)
+        self._test_tables(service.tables)
 
     def _test_examples(self, parsed_examples):
         assert len(parsed_examples) == 6

--- a/pyvo/dal/vosi.py
+++ b/pyvo/dal/vosi.py
@@ -2,7 +2,6 @@
 """
 VOSI classes and mixins
 """
-from itertools import chain
 import requests
 from urllib.parse import urlparse
 
@@ -173,47 +172,6 @@ class CapabilityMixin(EndpointMixin):
     @lazyproperty
     def capabilities(self):
         return vosi.parse_capabilities(self._capabilities().read)
-
-
-class TablesMixin(CapabilityMixin):
-    """
-    Mixin for VOSI tables
-    """
-    @stream_decode_content
-    def _tables(self):
-        try:
-            interfaces = next(
-                _ for _ in self.capabilities if _.standardid.startswith(
-                    'ivo://ivoa.net/std/VOSI#tables')
-            ).interfaces
-            accessurls = chain.from_iterable(_.accessurls for _ in interfaces)
-            tables_urls = (_.value for _ in accessurls)
-        except StopIteration:
-            tables_urls = [
-                f'{self.baseurl}/tables',
-                url_sibling(self.baseurl, 'tables')
-            ]
-
-        for tables_url in tables_urls:
-            try:
-                response = self._session.get(tables_url, stream=True)
-                response.raise_for_status()
-                break
-            except requests.HTTPError as ex:
-                if ex.response.status_code == 429:
-                    raise DALRateLimitError.from_response(ex.response, ex,
-                                                          tables_url)
-                continue
-            except requests.RequestException:
-                continue
-        else:
-            raise DALServiceError("No working tables endpoint provided")
-
-        return response.raw
-
-    @lazyproperty
-    def tables(self):
-        return VOSITables(vosi.parse_tables(self._tables().read))
 
 
 class VOSITables:


### PR DESCRIPTION
Session info is not propagated to `VOSITables` HTTP calls, causing auth errors with some configurations. Here's an example of this with bearer token auth. This is running against a
[youcat](https://github.com/opencadc/tap/tree/main/youcat) server instance, but the particular TAP server doesn't matter.

```python
def get_pyvo_auth(token: str, url: str) -> pyvo.auth.authsession.AuthSession | None:
    """Create a PyVO-compatible auth object."""
    s = requests.Session()
    s.headers["Authorization"] = f"Bearer {token}"

    auth = pyvo.auth.authsession.AuthSession()
    auth.credentials.set("lsst-token", s)

    for subpath in (
        "/sync",
        "/async",
        "/tables",
    ):
        auth.add_security_method_for_url(url + subpath, "lsst-token")

    return auth

auth = get_pyvo_auth(token=TOKEN, url=URL)
tap_service = pyvo.dal.TAPService(URL, session=auth)
tables = list(tap_service.tables)

# pyvo.dal.exceptions.DALServiceError: 401 Client Error: Unauthorized for url: https://my-tap-server/tables/dfuchs_test_schema.some_table
```

When accessing the `tables` property on a `TAPService` object, the existing session is not passed to to the `VOSITables` object constructor. Any auth properties of that session are not used in any HTTP requests that the `VOSITables` object makes.