### PR TITLE
Use consistent column names in user table load docs

### DIFF
--- a/docs/dal/index.rst
+++ b/docs/dal/index.rst
@@ -442,7 +442,7 @@ tab-separated values (tsv), comma-separated values (cvs) or VOTable (VOTable):
 .. doctest-skip::
 
     >>> tap_service.load_table(name='test_schema.test_table',
-    ...                        source=StringIO('article,count\narticle1,10\narticle2,20\n'), format='csv')
+    ...                        source=StringIO('article,count_of\narticle1,10\narticle2,20\n'), format='csv')
 
 Users can also create indexes on single columns:
 .. doctest-skip::


### PR DESCRIPTION
The `create_table` docs create a table with a `count_of` column (because `count` is a Postgres reserved word). The `load_table` docs specify a `count` column though.

This chances `count` -> `count_of` in the data in the `load_table` docs.