### PR TITLE
Don't use ADQL reserved words as column names in table load docs

### DIFF
--- a/docs/dal/index.rst
+++ b/docs/dal/index.rst
@@ -429,7 +429,7 @@ functionality is only available to authenticated (and authorized) users.
     ...         <dataType xsi:type="vod:VOTableType" arraysize="30*">char</dataType>
     ...     </column>
     ...     <column>
-    ...         <name>count</name>
+    ...         <name>count_of</name>
     ...         <description>how many</description>
     ...         <dataType xsi:type="vod:VOTableType">long</dataType>
     ...     </column>
@@ -442,7 +442,7 @@ tab-separated values (tsv), comma-separated values (cvs) or VOTable (VOTable):
 .. doctest-skip::
 
     >>> tap_service.load_table(name='test_schema.test_table',
-    ...                        source=StringIO('article,count\narticle1,10\narticle2,20\n'), format='csv')
+    ...                        source=StringIO('article,count_of\narticle1,10\narticle2,20\n'), format='csv')
 
 Users can also create indexes on single columns:
 .. doctest-skip::


### PR DESCRIPTION
The [`create_table` docs](https://github.com/astropy/pyvo/blob/6c5311c06cd04cf0c56f648ccdae50338cc351a2/docs/dal/index.rst?plain=1#L412) currently create a table with a `count` column. This will cause an error when run against
a [youcat](https://github.com/opencadc/tap/tree/main/youcat) TAP server (which the docs imply is the target TAP server) because `count` is an ADQL reserved word. This will cause a similar error when run against any any tap service that uses the [cadc-tap-schema](https://github.com/opencadc/tap/tree/main/cadc-tap-schema) and
[cadc-tap-server](https://github.com/opencadc/tap/tree/main/cadc-tap-server) libraries, like the CADC's `argus` service and some of the Rubin TAP services.

This changes the docs to use `count_of` for that column name instead of `count`. See [this cadc/tap issue](https://github.com/opencadc/tap/issues/263) for more details.

This is related to https://github.com/astropy/pyvo/pull/774, but with the real reason for the error, confirmation from the CADC folks, and no local branch confusion on my part :)