### PR TITLE
Fix four docstring parameter names that do not match the signature

### DIFF
--- a/pyvo/dal/sia2.py
+++ b/pyvo/dal/sia2.py
@@ -163,7 +163,7 @@ class SIA2Service(DALService, AvailabilityMixin, CapabilityMixin):
 
         Parameters
         ----------
-        url : str
+        baseurl : str
            url - URL of the SIA2service (base or query endpoint)
         session : object
            optional session to use for network requests

--- a/pyvo/dal/sia2.py
+++ b/pyvo/dal/sia2.py
@@ -165,6 +165,8 @@ class SIA2Service(DALService, AvailabilityMixin, CapabilityMixin):
         ----------
         baseurl : str
            url - URL of the SIA2service (base or query endpoint)
+        capability_description : str
+           Optional description of the service.
         session : object
            optional session to use for network requests
         check_baseurl : bool

--- a/pyvo/mivot/utils/mivot_utils.py
+++ b/pyvo/mivot/utils/mivot_utils.py
@@ -293,7 +293,7 @@ class MivotUtils:
             Table (from parsed VOTable) of the mapped data
         dmtype : string
             common dmtype of object attributes
-        as_literal : boolean, optional (default isTrue)
+        as_literals : boolean, optional (default is True)
             If True, all attribute are set with literal values (@value="...")
         package : str, optional (default as None)
             Package name possibly prefixing dmroles

--- a/pyvo/registry/rtcons.py
+++ b/pyvo/registry/rtcons.py
@@ -1041,7 +1041,7 @@ class Temporal(SubqueriedConstraint):
 
         Parameters
         ----------
-        spec : astropy.Time or a 2-tuple of astropy.Time-s
+        times : astropy.Time or a 2-tuple of astropy.Time-s
             A point in time or time interval to cover.  Plain numbers
             are interpreted as MJD.  All resources *overlapping* the
             interval are returned.

--- a/pyvo/utils/xml/elements.py
+++ b/pyvo/utils/xml/elements.py
@@ -27,7 +27,7 @@ def parse_for_object(
     ----------
     source : str or readable file-like object
         Path or file object containing a tableset xml file.
-    object : object type to return (subtype `~pyvo.utils.xml.elements.Element`)
+    object_type : object type to return (subtype `~pyvo.utils.xml.elements.Element`)
     pedantic : bool, optional
         When `True`, raise an error when the file violates the spec,
         otherwise issue a warning.  Warnings may be controlled using


### PR DESCRIPTION
### Problem

Four docstrings name a parameter the function does not take, so the parameter that is really there goes undocumented and the one in the docs cannot be passed.

| File | Documented | Actual signature |
|---|---|---|
| `registry/rtcons.py:1044` | `spec` | `def __init__(self, times, *, inclusive=False)` |
| `dal/sia2.py:166` | `url` | `def __init__(self, baseurl, *, capability_description=None, ...)` |
| `utils/xml/elements.py:30` | `object` | `def parse_for_object(source, object_type, ...)` |
| `mivot/utils/mivot_utils.py:296` | `as_literal` | `def populate_instance(..., as_literals=True, ...)` |

The `mivot_utils.py` one is a dropped `s`, and the same line reads `(default isTrue)` with the space missing.

`sia2.py` needed care: the module level `search()` at line 119 genuinely takes `url`, so that docstring is correct and untouched. Only the `SIA2Service` constructor at 166 was wrong.

### Change

Renamed the four in the docstrings to match the signatures. Docstrings only, no code touched.

### Checks

```
$ python -m pytest pyvo -q
519 passed, 107 skipped, 1 xfailed
```

Found by a script that pulls every numpydoc `Parameters` name out of a docstring and compares it against the identifiers in the signature below it. It reported these four before the change and none after. All four were read by hand before touching.

### Two more things I noticed, not included here

**`dal/tests/test_query.py:586`** has two statements with the `assert` missing, so `test_columnaliases` does not actually check them:

```python
record.getbyucd('baz') is None
record.getbyutype('foobaz') is None
```

I checked that the behaviour is already correct, the test passes either way once the asserts are added, so this is about the test guarding what it claims rather than about a bug. Happy to send it separately, or fold it in here if you would rather have one PR.

**`dal/sia2.py:166`**, the same block, documents `session` and `check_baseurl` but not `capability_description`. I left that alone rather than write a description for a parameter whose intent I would be guessing at.
