### PR TITLE
Add the two missing asserts in test_columnaliases

### DIFF
--- a/pyvo/dal/tests/test_query.py
+++ b/pyvo/dal/tests/test_query.py
@@ -583,8 +583,8 @@ class TestRecord:
         truth = 'Illuminatus'
         assert record.getbyutype('foobar') == truth
 
-        record.getbyucd('baz') is None
-        record.getbyutype('foobaz') is None
+        assert record.getbyucd('baz') is None
+        assert record.getbyutype('foobaz') is None
 
     def test_datasets(self):
         records = DALResults.from_result_url(


### PR DESCRIPTION
Split out of #778 as you suggested.

`dal/tests/test_query.py:586` has two statements with `assert` missing:

```python
record.getbyucd('baz') is None
record.getbyutype('foobaz') is None
```

Both are evaluated and thrown away, so `test_columnaliases` does not check the last two of the four aliases it is named for.

The behaviour is already correct, so nothing changes for users. This is only about the test guarding what it claims.

### Checks

```
$ python -m pytest pyvo/dal/tests/test_query.py -k columnaliases
2 passed
```

And the other direction, to show the asserts are really comparing something: flipping the first one to `is not None` gives `1 failed, 1 passed` with `AssertionError` at line 586.